### PR TITLE
Call socket.send instead of in the onopen handler.

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -138,9 +138,7 @@ need to change the socket address if you're using a development VM or similar)::
     socket.onmessage = function(e) {
         alert(e.data);
     }
-    socket.onopen = function() {
-        socket.send("hello world");
-    }
+    socket.send("hello world");
 
 You should see an alert come back immediately saying "hello world" - your
 message has round-tripped through the server and come back to trigger the alert.
@@ -232,9 +230,7 @@ code in the developer console as before::
     socket.onmessage = function(e) {
         alert(e.data);
     }
-    socket.onopen = function() {
-        socket.send("hello world");
-    }
+    socket.send("hello world");
 
 You should see an alert come back immediately saying "hello world" - but this
 time, you can open another tab and do the same there, and both tabs will


### PR DESCRIPTION
The websocket is already open by the time the onopen handler was getting
defined.  Instead, just call socket.send() directly.  That causes the alert
message to show up immediately, as intended.