### PR TITLE
Update channel_session decorator to rehydrate http_session

### DIFF
--- a/channels/sessions.py
+++ b/channels/sessions.py
@@ -37,10 +37,6 @@ def channel_session(func):
     the same incoming "reply_channel" value.
 
     Use this to persist data across the lifetime of a connection.
-
-    The channel_session will also rehydrate an existing http_session
-    if the http session key has been stored. To store the http session key
-    use the persist=True option with the http_session decorator
     """
     @functools.wraps(func)
     def inner(message, *args, **kwargs):
@@ -63,13 +59,6 @@ def channel_session(func):
                 # Session wasn't unique, so another consumer is doing the same thing
                 raise ConsumeLater()
         message.channel_session = session
-
-        # Refresh http_session if we've stored the session key
-        if settings.SESSION_COOKIE_NAME in message.channel_session:
-            session_engine = import_module(settings.SESSION_ENGINE)
-            session = session_engine.SessionStore(session_key=message.channel_session[settings.SESSION_COOKIE_NAME])
-            message.http_session = session
-
         # Run the consumer
         try:
             return func(message, *args, **kwargs)
@@ -144,7 +133,7 @@ def enforce_ordering(func=None, slight=False):
         return decorator
 
 
-def http_session(func=None, persist=False):
+def http_session(func):
     """
     Wraps a HTTP or WebSocket connect consumer (or any consumer of messages
     that provides a "cookies" or "get" attribute) to provide a "http_session"
@@ -161,52 +150,60 @@ def http_session(func=None, persist=False):
 
     Does not allow a new session to be set; that must be done via a view. This
     is only an accessor for any existing session.
-
-    To access the http_session in other consumers (like receive consumers) use the
-    persist=True option. This will store the http session key in the channel_session
-    or throw an error if its not available.
     """
-    def decorator(func):
-        @functools.wraps(func)
-        def inner(message, *args, **kwargs):
-            # Make sure there's NOT a http_session already
-            if hasattr(message, "http_session"):
-                return func(message, *args, **kwargs)
-            try:
-                # We want to parse the WebSocket (or similar HTTP-lite) message
-                # to get cookies and GET, but we need to add in a few things that
-                # might not have been there.
-                if "method" not in message.content:
-                    message.content['method'] = "FAKE"
-                request = AsgiRequest(message)
-            except Exception as e:
-                raise ValueError("Cannot parse HTTP message - are you sure this is a HTTP consumer? %s" % e)
-            # Make sure there's a session key
-            session_key = request.GET.get("session_key", None)
-            if session_key is None:
-                session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME, None)
-            # Make a session storage
-            if session_key:
-                session_engine = import_module(settings.SESSION_ENGINE)
-                session = session_engine.SessionStore(session_key=session_key)
-            else:
-                session = None
+    @functools.wraps(func)
+    def inner(message, *args, **kwargs):
+        # Make sure there's NOT a http_session already
+        if hasattr(message, "http_session"):
+            return func(message, *args, **kwargs)
+        try:
+            # We want to parse the WebSocket (or similar HTTP-lite) message
+            # to get cookies and GET, but we need to add in a few things that
+            # might not have been there.
+            if "method" not in message.content:
+                message.content['method'] = "FAKE"
+            request = AsgiRequest(message)
+        except Exception as e:
+            raise ValueError("Cannot parse HTTP message - are you sure this is a HTTP consumer? %s" % e)
+        # Make sure there's a session key
+        session_key = request.GET.get("session_key", None)
+        if session_key is None:
+            session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME, None)
+        # Make a session storage
+        if session_key:
+            session_engine = import_module(settings.SESSION_ENGINE)
+            session = session_engine.SessionStore(session_key=session_key)
+        else:
+            session = None
+        message.http_session = session
+        # Run the consumer
+        result = func(message, *args, **kwargs)
+        # Persist session if needed (won't be saved if error happens)
+        if session is not None and session.modified:
+            session.save()
+        return result
+    return inner
+
+
+def channel_and_http_session(func):
+    """
+    Enables both the channel_session and http_session.
+
+    Stores the http session key in the channel_session on websocket.connect messages.
+    It will then hydrate the http_session from that same key on subsequent messages.
+    """
+    @http_session
+    @channel_session
+    @functools.wraps(func)
+    def inner(message, *args, **kwargs):
+        # Store the session key in channel_session
+        if message.http_session is not None and settings.SESSION_COOKIE_NAME not in message.channel_session:
+            message.channel_session[settings.SESSION_COOKIE_NAME] = message.http_session.session_key
+        # Hydrate the http_session from session_key
+        elif message.http_session is None and settings.SESSION_COOKIE_NAME in message.channel_session:
+            session_engine = import_module(settings.SESSION_ENGINE)
+            session = session_engine.SessionStore(session_key=message.channel_session[settings.SESSION_COOKIE_NAME])
             message.http_session = session
-
-            # Store the session key in channel_session for 'websocket.receive' consumers.
-            if hasattr(message, "channel_session") and session_key:
-                message.channel_session[settings.SESSION_COOKIE_NAME] = session_key
-            elif persist:
-                raise ValueError("Cannot persist http_session_key. No channel_session available.")
-
-            # Run the consumer
-            result = func(message, *args, **kwargs)
-            # Persist session if needed (won't be saved if error happens)
-            if session is not None and session.modified:
-                session.save()
-            return result
-        return inner
-    if func is not None:
-        return decorator(func)
-    else:
-        return decorator
+        # Run the consumer
+        return func(message, *args, **kwargs)
+    return inner

--- a/channels/tests/test_sessions.py
+++ b/channels/tests/test_sessions.py
@@ -3,7 +3,8 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.test import override_settings
 from channels.message import Message
-from channels.sessions import channel_session, http_session, enforce_ordering, session_for_reply_channel
+from channels.sessions import channel_session, channel_and_http_session, http_session, enforce_ordering, \
+    session_for_reply_channel
 from channels.tests import ChannelTestCase
 from channels import DEFAULT_CHANNEL_LAYER, channel_layers
 
@@ -76,27 +77,6 @@ class SessionTests(ChannelTestCase):
         with self.assertRaises(ValueError):
             inner(message)
 
-    def test_channel_session_http_session_key(self):
-        """
-        Tests that channel_session decorator rehydrates http_session from a stored session_key
-        """
-        message = Message({"reply_channel": "test-reply"}, None, None)
-
-        # Create a session with an http_session key
-        session = session_for_reply_channel("test-reply")
-        session[settings.SESSION_COOKIE_NAME] = session.session_key
-        session.save()
-
-        @channel_session
-        @channel_session
-        def inner(message):
-            message.http_session["num_ponies"] = -1
-
-        inner(message)
-
-        self.assertEqual(message.http_session.session_key, session.session_key)
-        self.assertEqual(message.http_session["num_ponies"], -1)
-
     def test_http_session(self):
         """
         Tests that http_session correctly extracts a session cookie.
@@ -126,9 +106,9 @@ class SessionTests(ChannelTestCase):
         session2 = session_for_reply_channel("test-reply")
         self.assertEqual(session2["species"], "horse")
 
-    def test_http_session_channel_session(self):
+    def test_channel_and_http_session(self):
         """
-        Tests that the http_session stores the session_key when the channel_session is available
+        Tests that channel_and_http_session decorator stores the http session key and hydrates it when expected
         """
         # Make a session to try against
         session = session_for_reply_channel("test-reply-session")
@@ -144,42 +124,22 @@ class SessionTests(ChannelTestCase):
             },
         }, None, None)
 
-        @channel_session
-        @channel_session
-        @http_session
-        @http_session
+        @channel_and_http_session
         def inner(message):
-            message.http_session["species"] = "horse"
+            pass
 
         inner(message)
 
+        # It should store the session key
         self.assertEqual(message.channel_session[settings.SESSION_COOKIE_NAME], session.session_key)
 
-    def test_http_session_persist_error(self):
-        """
-        Tests that the http_session store will thrown an error when it cannot save the session_key
-        """
-        # Make a session to try against
-        session = session_for_reply_channel("test-reply-session")
-        # Construct message to send
-        message = Message({
-            "reply_channel": "test-reply-session",
-            "http_version": "1.1",
-            "method": "GET",
-            "path": "/test2/",
-            "headers": {
-                "host": b"example.com",
-                "cookie": ("%s=%s" % (settings.SESSION_COOKIE_NAME, session.session_key)).encode("ascii"),
-            },
-        }, None, None)
+        # Construct a new message
+        message2 = Message({"reply_channel": "test-reply-session", "path": "/"}, None, None)
 
-        @http_session(persist=True)
-        @http_session(persist=True)
-        def inner(message):
-            message.http_session["species"] = "horse"
+        inner(message2)
 
-        with self.assertRaises(ValueError):
-            inner(message)
+        # It should hydrate the http_session
+        self.assertEqual(message2.http_session.session_key, session.session_key)
 
     def test_enforce_ordering_slight(self):
         """


### PR DESCRIPTION
This is my first take on a solution for #318 more feedback is welcomed.

I would like to add docs before this is merged because I think it might be a little tricky to understand. This is the use case as I understand it.

```python
@channel_session
@http_session
def ws_connect(message):
    pass

@channel_session
def ws_receive(message):
     print(message.http_session)
```
