### PR TITLE
Iimprovements for test client 

### DIFF
--- a/channels/auth.py
+++ b/channels/auth.py
@@ -1,4 +1,4 @@
-import functools
+    import functools
 
 from django.contrib import auth
 
@@ -82,6 +82,7 @@ def channel_session_user_from_http(func):
     """
     @http_session_user
     @channel_session
+    @functools.wraps(func)
     def inner(message, *args, **kwargs):
         if message.http_session is not None:
             transfer_user(message.http_session, message.channel_session)

--- a/channels/auth.py
+++ b/channels/auth.py
@@ -1,4 +1,4 @@
-    import functools
+import functools
 
 from django.contrib import auth
 

--- a/channels/tests/base.py
+++ b/channels/tests/base.py
@@ -135,7 +135,7 @@ class Client(object):
         return self.consume(channel, fail_on_none=fail_on_none)
 
     def receive(self):
-        """self.get_next_message(self.reply_channel)
+        """
         Get content of next message for reply channel if message exists
         """
         message = self.get_next_message(self.reply_channel)

--- a/channels/tests/http.py
+++ b/channels/tests/http.py
@@ -9,6 +9,8 @@ from django.conf import settings
 from ..sessions import session_for_reply_channel
 from .base import Client
 
+json_module = json  # alias for using at functions with json kwarg
+
 
 class HttpClient(Client):
     """
@@ -58,13 +60,14 @@ class HttpClient(Client):
             self._session = session_for_reply_channel(self.reply_channel)
         return self._session
 
-    def receive(self):
+    def receive(self, json=True):
+        """
+        Return text content of a message for client channel and decoding it if json kwarg is set
+        """
         content = super(HttpClient, self).receive()
-        if content:
-            try:
-                return json.loads(content['text'])
-            except (KeyError, TypeError):
-                return content
+        if content and json:
+            return json_module.loads(content['text'])
+        return content['text'] if content else None
 
     def send(self, to, content={}, text=None, path='/'):
         """

--- a/channels/tests/http.py
+++ b/channels/tests/http.py
@@ -60,10 +60,11 @@ class HttpClient(Client):
 
     def receive(self):
         content = super(HttpClient, self).receive()
-        try:
-            return json.loads(content['text'])
-        except (KeyError, TypeError):
-            return content
+        if content:
+            try:
+                return json.loads(content['text'])
+            except (KeyError, TypeError):
+                return content
 
     def send(self, to, content={}, text=None, path='/'):
         """

--- a/channels/tests/http.py
+++ b/channels/tests/http.py
@@ -60,8 +60,10 @@ class HttpClient(Client):
 
     def receive(self):
         content = super(HttpClient, self).receive()
-        if content:
+        try:
             return json.loads(content['text'])
+        except (KeyError, TypeError):
+            return content
 
     def send(self, to, content={}, text=None, path='/'):
         """

--- a/channels/tests/http.py
+++ b/channels/tests/http.py
@@ -1,6 +1,8 @@
 import json
 import copy
 
+import six
+
 from django.apps import apps
 from django.conf import settings
 
@@ -71,8 +73,11 @@ class HttpClient(Client):
         content.setdefault('path', path)
         content.setdefault('headers', self.headers)
         text = text or content.get('text', None)
-        if text:
-            content['text'] = json.dumps(text)
+        if text is not None:
+            if not isinstance(text, six.string_types):
+                content['text'] = json.dumps(text)
+            else:
+                content['text'] = text
         self.channel_layer.send(to, content)
 
     def send_and_consume(self, channel, content={}, text=None, path='/', fail_on_none=True):


### PR DESCRIPTION
Sometimes websocket client send/receive non json-encoded/decoded messages. 
Plus it is helpfull for testing  nonwebsocket consumers by using the `HttpClient`.
Example:  we have group of related consumers (some of them for websocket channels and other are internal) and that is onerously to create a `Client` for a "single" call.