### PR TITLE
Remove 'onopen' for compatibility and usability

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -138,9 +138,8 @@ need to change the socket address if you're using a development VM or similar)::
     socket.onmessage = function(e) {
         alert(e.data);
     }
-    socket.onopen = function() {
-        socket.send("hello world");
-    }
+    
+    socket.send("hello world");
 
 You should see an alert come back immediately saying "hello world" - your
 message has round-tripped through the server and come back to trigger the alert.


### PR DESCRIPTION
socket.onopen doesn't work as expected for me on chromium based browsers (chrome and vivaldi). Instead, I recommend suggesting a straight send command in the tutorial. In addition to being more compatible, this also is more directly actionable (user can try .send over and over again, opening browsers of different types, etc.) A small change, but this is what I ended up doing, and I was stuck for a few with the .onopen attempts.