### PR TITLE
Docs: JS code should be executed all together

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -130,7 +130,9 @@ back to the client using its ``send()`` method.
 
 Let's test it! Run ``runserver``, open a browser and put the following into the
 JavaScript console to open a WebSocket and send some data down it (you might
-need to change the socket address if you're using a development VM or similar)::
+need to change the socket address if you're using a development VM or similar).
+Note, the code needs to be executed all-at-once, so copy-paste it in;
+entering it line-by-line will open the socket before the handler is bound::
 
     // Note that the path doesn't matter for routing; any WebSocket
     // connection gets bumped over to WebSocket consumers


### PR DESCRIPTION
The JS code for websockets needs to be executed together so the handler is bound before the socket is opened.
Pretty minor, but would have saved me 15 min as I retyped it line-by-line and it didn't work.

For example, try entering
`socket = new WebSocket("ws://" + window.location.host + "/chat/");` (enter)
`socket.onopen = function() { console.log("You'll never see me"); }` (enter)
This will not produce any output because the socket is opened before the handler is bound.  

Instead, try this:
`socket = new WebSocket("ws://" + window.location.host + "/chat/"); socket.onopen = function() { console.log("This works"); }` (enter)
This will produce output since the handler will be bound before the socket is opened.

Tested with Chrome 52.0.2743.116