### PR TITLE
Typecasted server port from integer to string.

### DIFF
--- a/channels/handler.py
+++ b/channels/handler.py
@@ -65,7 +65,7 @@ class AsgiRequest(http.HttpRequest):
             self.META['REMOTE_PORT'] = self.message['client'][1]
         if self.message.get('server', None):
             self.META['SERVER_NAME'] = self.message['server'][0]
-            self.META['SERVER_PORT'] = self.message['server'][1]
+            self.META['SERVER_PORT'] = str(self.message['server'][1])
         # Handle old style-headers for a transition period
         if "headers" in self.message and isinstance(self.message['headers'], dict):
             self.message['headers'] = [


### PR DESCRIPTION
Converted self.message['server'][1] form integer to string using str() function so that SERVER_PORT can be received as a string in HttpRequest.META