### PR TITLE
string should be compared with string

### DIFF
--- a/channels/tests/test_request.py
+++ b/channels/tests/test_request.py
@@ -63,7 +63,7 @@ class RequestTests(ChannelTestCase):
         self.assertEqual(request.META["REMOTE_HOST"], "10.0.0.1")
         self.assertEqual(request.META["REMOTE_PORT"], 1234)
         self.assertEqual(request.META["SERVER_NAME"], "10.0.0.2")
-        self.assertEqual(request.META["SERVER_PORT"], 80)
+        self.assertEqual(request.META["SERVER_PORT"], "80")
         self.assertEqual(request.GET["x"], "1")
         self.assertEqual(request.GET["y"], "&foo bar+baz")
         self.assertEqual(request.COOKIES["test-time"], "1448995585123")


### PR DESCRIPTION
request.META["SERVER_PORT"] gives string, and hence should be compared with a string in assertEqual() method. Therefore, I have converted integer value 80 to string "80".