### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -10,7 +10,7 @@ Examples of contributions include:
 * Documentation improvements
 * Bug reports and patch reviews
 
-For more information, please see our `contribution guide <http://channels.readthedocs.io/en/latest/contributing.html>`_.
+For more information, please see our `contribution guide <https://channels.readthedocs.io/en/latest/contributing.html>`_.
 
 Quick Setup
 -----------

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Django Channels
     :target: https://travis-ci.org/django/channels
 
 .. image:: https://readthedocs.org/projects/channels/badge/?version=latest
-    :target: http://channels.readthedocs.org/en/latest/?badge=latest
+    :target: https://channels.readthedocs.io/en/latest/?badge=latest
 
 .. image:: https://img.shields.io/pypi/v/channels.svg
     :target: https://pypi.python.org/pypi/channels
@@ -23,21 +23,21 @@ a bit as things develop. Once we hit ``1.0``, it will be stablized and a
 deprecation policy will come in.
 
 Documentation, installation and getting started instructions are at
-http://channels.readthedocs.org
+https://channels.readthedocs.io
 
 Support can be obtained either here via issues, or in the ``#django-channels``
 channel on Freenode.
 
 You can install channels from PyPI as the ``channels`` package.
 You'll likely also want to ``asgi_redis`` to provide the Redis channel layer.
-See our `installation <http://channels.readthedocs.io/en/latest/installation.html>`_
-and `getting started <http://channels.readthedocs.io/en/latest/getting-started.html>`_ docs for more.
+See our `installation <https://channels.readthedocs.io/en/latest/installation.html>`_
+and `getting started <https://channels.readthedocs.io/en/latest/getting-started.html>`_ docs for more.
 
 
 Contributing
 ------------
 
-To learn more about contributing, please `read our contributing docs <http://channels.readthedocs.io/en/latest/contributing.html>`_.
+To learn more about contributing, please `read our contributing docs <https://channels.readthedocs.io/en/latest/contributing.html>`_.
 
 
 Maintenance and Security
@@ -60,7 +60,7 @@ Maintenance team:
 * Jeremy Spencer
 
 If you are interested in joining the maintenance team, please
-`read more about contributing <http://channels.readthedocs.io/en/latest/contributing.html>`_
+`read more about contributing <https://channels.readthedocs.io/en/latest/contributing.html>`_
 and get in touch!
 
 

--- a/patchinator.py
+++ b/patchinator.py
@@ -139,7 +139,7 @@ docs_transforms = global_transforms + [
     Replacement(r":doc:`getting-started`", r":doc:`/intro/channels`"),
     Replacement(r"<backends>`", r"</ref/channels/backends>`"),
     Replacement(r":doc:`backends`", r":doc:`/ref/channels/backends`"),
-    Replacement(r":doc:`([\w\d\s]+) <asgi>`", r"`\1 <http://channels.readthedocs.org/en/latest/asgi.html>`_"),
+    Replacement(r":doc:`([\w\d\s]+) <asgi>`", r"`\1 <https://channels.readthedocs.io/en/latest/asgi.html>`_"),
     Replacement(r"\n\(.*installation>`\)\n", r""),
     Replacement(r":doc:`installed Channels correctly <installation>`", r"added the channel layer setting"),
     Replacement(r"Channels", r"channels"),


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.