### PR TITLE
Add conventional request.META['PATH_INFO']

### DIFF
--- a/channels/handler.py
+++ b/channels/handler.py
@@ -55,6 +55,7 @@ class AsgiRequest(http.HttpRequest):
             "REQUEST_METHOD": self.method,
             "QUERY_STRING": self.message.get('query_string', ''),
             "SCRIPT_NAME": self.script_name,
+            "PATH_INFO": self.path_info,
             # Old code will need these for a while
             "wsgi.multithread": True,
             "wsgi.multiprocess": True,


### PR DESCRIPTION
As per discussion on #django-channels

We claim it's conventional because of this issue: benjaoming/django-nyt#27

Maybe it's also documented somewhere... that would only make it more justified :)