### PR TITLE
Fix type for request.META['SERVER_PORT']

### DIFF
--- a/channels/handler.py
+++ b/channels/handler.py
@@ -66,7 +66,7 @@ class AsgiRequest(http.HttpRequest):
             self.META['REMOTE_PORT'] = self.message['client'][1]
         if self.message.get('server', None):
             self.META['SERVER_NAME'] = self.message['server'][0]
-            self.META['SERVER_PORT'] = self.message['server'][1]
+            self.META['SERVER_PORT'] = six.text_type(self.message['server'][1])
         # Handle old style-headers for a transition period
         if "headers" in self.message and isinstance(self.message['headers'], dict):
             self.message['headers'] = [

--- a/channels/tests/test_request.py
+++ b/channels/tests/test_request.py
@@ -63,7 +63,7 @@ class RequestTests(ChannelTestCase):
         self.assertEqual(request.META["REMOTE_HOST"], "10.0.0.1")
         self.assertEqual(request.META["REMOTE_PORT"], 1234)
         self.assertEqual(request.META["SERVER_NAME"], "10.0.0.2")
-        self.assertEqual(request.META["SERVER_PORT"], 80)
+        self.assertEqual(request.META["SERVER_PORT"], "80")
         self.assertEqual(request.GET["x"], "1")
         self.assertEqual(request.GET["y"], "&foo bar+baz")
         self.assertEqual(request.COOKIES["test-time"], "1448995585123")


### PR DESCRIPTION
Django documentation states that it is a string
(https://docs.djangoproject.com/en/1.10/ref/request-response/#django.http.HttpRequest.META):

> SERVER_PORT – The port of the server (as a string).

Fixes #366 
Recreates incomplete #370 