### PR TITLE
Fix for streaming responses being cached in memory.

### DIFF
--- a/channels/handler.py
+++ b/channels/handler.py
@@ -340,7 +340,9 @@ class ViewConsumer(object):
                 # a whole worker if the client just vanishes and leaves the response
                 # channel full.
                 try:
-                    message.reply_channel.send(reply_message)
+                    # Note: Use immediately to prevent streaming responses trying
+                    # cache all data.
+                    message.reply_channel.send(reply_message, immediately=True)
                 except message.channel_layer.ChannelFull:
                     time.sleep(0.05)
                 else:


### PR DESCRIPTION
Found a bug whereby streaming responses would try to be cached entirely in memory. Was causing views that stream a lot of data to timeout.