### PR TITLE
Fix for issue 398

### DIFF
--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -55,7 +55,7 @@ class WebsocketBinding(Binding):
         """
         Serializes model data into JSON-compatible types.
         """
-        if self.fields == ['__all__']:
+        if list(self.fields) == ['__all__']:
             fields = None
         else:
             fields = self.fields


### PR DESCRIPTION
Fix for issue 398. Converts channels.binding.websockets.WebsocketBinding.fields to list before comparing to ['__all__'] to ensure most common data structures do not cause unexpected failures (i.e. ('__all__',), '__all__')