### PR TITLE
Fix formatting for generics docs

### DIFF
--- a/docs/generics.rst
+++ b/docs/generics.rst
@@ -224,7 +224,7 @@ This will run the appropriate decorator around your handler methods, and provide
 the one passed in to your handler as an argument as well as ``self.message``,
 as they point to the same instance.
 
-And if you just want to use the user from the django session, add ``http_user``:
+And if you just want to use the user from the django session, add ``http_user``::
 
     class MyConsumer(WebsocketConsumer):
 


### PR DESCRIPTION
The paragraph was lacking the double colon to treat the http_user example code as a code block.

Previously:
![screenshot from 2016-10-18 11-42-17](https://cloud.githubusercontent.com/assets/509427/19472578/19d181e8-9528-11e6-899b-71ebbe7cf8d2.png)
