### PR TITLE
Add demultiplexer for class-based consumers (#383)

### DIFF
--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -3,7 +3,7 @@ import json
 from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
 
-from ..generic.websockets import WebsocketDemultiplexer
+from ..generic.websockets import WebsocketMultiplexer
 from ..sessions import enforce_ordering
 from .base import Binding
 
@@ -40,7 +40,7 @@ class WebsocketBinding(Binding):
     # Outbound
     @classmethod
     def encode(cls, stream, payload):
-        return WebsocketDemultiplexer.encode(stream, payload)
+        return WebsocketMultiplexer.encode(stream, payload)
 
     def serialize(self, instance, action):
         payload = {

--- a/channels/exceptions.py
+++ b/channels/exceptions.py
@@ -33,7 +33,14 @@ class RequestAborted(Exception):
 
 class DenyConnection(Exception):
     """
-    Raise during a websocket.connect (or other supported connection) handler
+    Raised during a websocket.connect (or other supported connection) handler
     to deny the connection.
+    """
+    pass
+
+
+class SendNotAvailableOnDemultiplexer(Exception):
+    """
+    Raised when trying to send with a WebsocketDemultiplexer. Use the multiplexer instead.
     """
     pass

--- a/channels/tests/base.py
+++ b/channels/tests/base.py
@@ -105,6 +105,13 @@ class Client(object):
             return
         return Message(content, recv_channel, channel_layers[self.alias])
 
+    def get_consumer_by_channel(self, channel):
+        message = Message({'text': ''}, channel, self.channel_layer)
+        match = self.channel_layer.router.match(message)
+        if match:
+            consumer, kwargs = match
+            return consumer
+
     def send(self, to, content={}):
         """
         Send a message to a channel.

--- a/channels/tests/test_generic.py
+++ b/channels/tests/test_generic.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import json
+
 from django.test import override_settings
 
 from channels import route_class
@@ -129,3 +131,57 @@ class GenericTests(ChannelTestCase):
 
             client.send_and_consume('mychannel', {'name': 'filter'})
             self.assertEqual(client.receive(), {'trigger': 'from_as_route'})
+
+    def test_websockets_demultiplexer(self):
+
+        class MyWebsocketConsumer(websockets.JsonWebsocketConsumer):
+            def connect(self, message, multiplexer=None, **kwargs):
+                multiplexer.send(kwargs)
+
+            def disconnect(self, message, multiplexer=None, **kwargs):
+                multiplexer.send(kwargs)
+
+            def receive(self, content, multiplexer=None, **kwargs):
+                multiplexer.send(content)
+
+        class Demultiplexer(websockets.WebsocketConsumerDemultiplexer):
+
+            consumers = {
+                "mystream": MyWebsocketConsumer
+            }
+
+        with apply_routes([
+            route_class(Demultiplexer, path='/path/(?P<id>\d+)'),
+            route_class(MyWebsocketConsumer),
+        ]):
+            client = Client()
+
+            client.send_and_consume('websocket.connect', {'path': '/path/1'})
+            self.assertEqual(client.receive(), {
+                "text": json.dumps({
+                    "stream": "mystream",
+                    "payload": {"id": "1"},
+                })
+            })
+
+            client.send_and_consume('websocket.receive', {
+                'path': '/path/1',
+                'text': json.dumps({
+                    "stream": "mystream",
+                    "payload": {"text_field": "mytext"}
+                })
+            })
+            self.assertEqual(client.receive(), {
+                "text": json.dumps({
+                    "stream": "mystream",
+                    "payload": {"text_field": "mytext"},
+                })
+            })
+
+            client.send_and_consume('websocket.disconnect', {'path': '/path/1'})
+            self.assertEqual(client.receive(), {
+                "text": json.dumps({
+                    "stream": "mystream",
+                    "payload": {"id": "1"},
+                })
+            })

--- a/docs/generics.rst
+++ b/docs/generics.rst
@@ -198,11 +198,31 @@ channel name. It will then forward the message onto that channel while
 preserving ``reply_channel``, so you can hook consumers up to them directly
 in the ``routing.py`` file, and use authentication decorators as you wish.
 
-You cannot use class-based consumers this way as the messages are no
-longer in WebSocket format, though. If you need to do operations on
-``connect`` or ``disconnect``, override those methods on the ``Demultiplexer``
-itself (you can also provide a ``connection_groups`` method, as it's just
-based on the JSON WebSocket generic consumer).
+
+Example using class-based consumer::
+
+    from channels.generic.websockets import WebsocketConsumerDemultiplexer, JsonWebsocketConsumer
+
+    class MyWebsocketConsumer(JsonWebsocketConsumer):
+        def connect(self, message, multiplexer=None, **kwargs):
+            multiplexer.send({"status": "I just connected!"})
+
+        def disconnect(self, message, multiplexer=None, **kwargs):
+            print(multiplexer.stream)
+
+        def receive(self, content, multiplexer=None, **kwargs):
+            # simple echo
+            multiplexer.send(content)
+
+    class Demultiplexer(WebsocketConsumerDemultiplexer):
+
+        # Put your JSON consumers here: {stream_name : consumer}
+        consumers = {
+            "mystream": MyWebsocketConsumer
+        }
+
+The ``multiplexer`` allows the consumer class to be independant of the stream name.
+It holds the stream name and the demultiplexer on the attributes ``stream`` and ``demultiplexer``.
 
 The :doc:`data binding <binding>` code will also send out messages to clients
 in the same format, and you can encode things in this format yourself by


### PR DESCRIPTION
Avoid coupling between the demultiplexer and consumers.

Explanations are in https://github.com/django/channels/issues/383 .

In short, I chose to forward a multiplexer object to the consumer. This object can be used to send messages through the demultiplexer without depending on the stream used.