### PR TITLE
Save session before invoking consumers (#356)

### DIFF
--- a/channels/sessions.py
+++ b/channels/sessions.py
@@ -61,6 +61,7 @@ def channel_session(func):
         message.channel_session = session
         # Run the consumer
         try:
+            session.save()
             return func(message, *args, **kwargs)
         finally:
             # Persist session if needed


### PR DESCRIPTION
With demultiplexers, consumers could be invoked after the session has been created but not saved. These consumers wouldn't find the session in the database.

See also #356