### PR TITLE
Sort imports and make Travis run isort

### DIFF
--- a/channels/binding/base.py
+++ b/channels/binding/base.py
@@ -1,13 +1,11 @@
 from __future__ import unicode_literals
 
 import six
-
 from django.apps import apps
-from django.db.models.signals import post_save, post_delete, pre_save, pre_delete
+from django.db.models.signals import post_delete, post_save, pre_delete, pre_save
 
-from ..channel import Group
 from ..auth import channel_session, channel_session_user
-
+from ..channel import Group
 
 CREATE = 'create'
 UPDATE = 'update'

--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -3,9 +3,9 @@ import json
 from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
 
-from .base import Binding
 from ..generic.websockets import WebsocketDemultiplexer
 from ..sessions import enforce_ordering
+from .base import Binding
 
 
 class WebsocketBinding(Binding):

--- a/channels/generic/base.py
+++ b/channels/generic/base.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals
+
+from ..auth import channel_session_user
 from ..routing import route_class
 from ..sessions import channel_session
-from ..auth import channel_session_user
 
 
 class BaseConsumer(object):

--- a/channels/generic/websockets.py
+++ b/channels/generic/websockets.py
@@ -1,7 +1,7 @@
-from django.core.serializers.json import json, DjangoJSONEncoder
+from django.core.serializers.json import DjangoJSONEncoder, json
 
-from ..channel import Group, Channel
 from ..auth import channel_session_user_from_http
+from ..channel import Channel, Group
 from ..sessions import enforce_ordering
 from .base import BaseConsumer
 

--- a/channels/handler.py
+++ b/channels/handler.py
@@ -17,7 +17,7 @@ from django.http import FileResponse, HttpResponse, HttpResponseServerError
 from django.utils import six
 from django.utils.functional import cached_property
 
-from channels.exceptions import ResponseLater as ResponseLaterOuter, RequestTimeout, RequestAborted
+from channels.exceptions import RequestAborted, RequestTimeout, ResponseLater as ResponseLaterOuter
 
 logger = logging.getLogger('django.request')
 

--- a/channels/management/commands/runserver.py
+++ b/channels/management/commands/runserver.py
@@ -4,8 +4,7 @@ import threading
 
 from daphne.server import Server
 from django.conf import settings
-from django.core.management.commands.runserver import \
-    Command as RunserverCommand
+from django.core.management.commands.runserver import Command as RunserverCommand
 from django.utils import six
 from django.utils.encoding import get_system_encoding
 

--- a/channels/management/commands/runworker.py
+++ b/channels/management/commands/runworker.py
@@ -5,9 +5,9 @@ from django.core.management import BaseCommand, CommandError
 
 from channels import DEFAULT_CHANNEL_LAYER, channel_layers
 from channels.log import setup_logger
+from channels.signals import worker_process_ready
 from channels.staticfiles import StaticFilesConsumer
 from channels.worker import Worker, WorkerGroup
-from channels.signals import worker_process_ready
 
 
 class Command(BaseCommand):

--- a/channels/message.py
+++ b/channels/message.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 import copy
 import threading
 

--- a/channels/routing.py
+++ b/channels/routing.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
-import re
 import importlib
+import re
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import six

--- a/channels/signals.py
+++ b/channels/signals.py
@@ -1,7 +1,6 @@
 from django.db import close_old_connections
 from django.dispatch import Signal
 
-
 consumer_started = Signal(providing_args=["environ"])
 consumer_finished = Signal()
 worker_ready = Signal()

--- a/channels/tests/base.py
+++ b/channels/tests/base.py
@@ -5,14 +5,15 @@ import random
 import string
 from functools import wraps
 
-from django.test.testcases import TestCase, TransactionTestCase
-from .. import DEFAULT_CHANNEL_LAYER
-from ..channel import Group
-from ..routing import Router, include
-from ..asgi import channel_layers, ChannelLayerWrapper
-from ..message import Message
-from ..signals import consumer_finished, consumer_started
 from asgiref.inmemory import ChannelLayer as InMemoryChannelLayer
+from django.test.testcases import TestCase, TransactionTestCase
+
+from .. import DEFAULT_CHANNEL_LAYER
+from ..asgi import ChannelLayerWrapper, channel_layers
+from ..channel import Group
+from ..message import Message
+from ..routing import Router, include
+from ..signals import consumer_finished, consumer_started
 
 
 class ChannelTestCaseMixin(object):

--- a/channels/tests/http.py
+++ b/channels/tests/http.py
@@ -1,8 +1,7 @@
-import json
 import copy
+import json
 
 import six
-
 from django.apps import apps
 from django.conf import settings
 

--- a/channels/tests/test_binding.py
+++ b/channels/tests/test_binding.py
@@ -1,13 +1,15 @@
 from __future__ import unicode_literals
+
 import json
 
 from django.contrib.auth import get_user_model
-from channels.binding.base import CREATE, UPDATE, DELETE
+
+from channels import Group, route
+from channels.binding.base import CREATE, DELETE, UPDATE
 from channels.binding.websockets import WebsocketBinding
 from channels.generic.websockets import WebsocketDemultiplexer
-from channels.tests import ChannelTestCase, apply_routes, HttpClient
 from channels.signals import consumer_finished
-from channels import route, Group
+from channels.tests import ChannelTestCase, HttpClient, apply_routes
 
 User = get_user_model()
 

--- a/channels/tests/test_generic.py
+++ b/channels/tests/test_generic.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals
 
 from django.test import override_settings
+
 from channels import route_class
 from channels.generic import BaseConsumer, websockets
-from channels.tests import ChannelTestCase
-from channels.tests import apply_routes, Client
+from channels.tests import ChannelTestCase, Client, apply_routes
 
 
 @override_settings(SESSION_ENGINE="django.contrib.sessions.backends.cache")

--- a/channels/tests/test_handler.py
+++ b/channels/tests/test_handler.py
@@ -4,16 +4,13 @@ import os
 from datetime import datetime
 from itertools import islice
 
-from django.http import (
-    FileResponse, HttpResponse, HttpResponseRedirect, JsonResponse,
-    StreamingHttpResponse,
-)
+from django.http import FileResponse, HttpResponse, HttpResponseRedirect, JsonResponse, StreamingHttpResponse
 from six import BytesIO
 
 from channels import Channel
 from channels.handler import AsgiHandler
-from channels.tests import ChannelTestCase
 from channels.signals import consumer_finished
+from channels.tests import ChannelTestCase
 
 
 class FakeAsgiHandler(AsgiHandler):

--- a/channels/tests/test_management.py
+++ b/channels/tests/test_management.py
@@ -4,11 +4,11 @@ import logging
 
 from asgiref.inmemory import ChannelLayer
 from django.core.management import CommandError, call_command
-from channels.staticfiles import StaticFilesConsumer
 from django.test import TestCase, mock
 from six import StringIO
 
 from channels.management.commands import runserver
+from channels.staticfiles import StaticFilesConsumer
 
 
 class FakeChannelLayer(ChannelLayer):

--- a/channels/tests/test_request.py
+++ b/channels/tests/test_request.py
@@ -1,10 +1,11 @@
 from __future__ import unicode_literals
+
 from django.utils import six
 
 from channels import Channel
-from channels.tests import ChannelTestCase
+from channels.exceptions import RequestAborted, RequestTimeout
 from channels.handler import AsgiRequest
-from channels.exceptions import RequestTimeout, RequestAborted
+from channels.tests import ChannelTestCase
 
 
 class RequestTests(ChannelTestCase):

--- a/channels/tests/test_routing.py
+++ b/channels/tests/test_routing.py
@@ -1,10 +1,11 @@
 from __future__ import unicode_literals
+
 from django.test import SimpleTestCase
 
-from channels.routing import Router, route, route_class, include
-from channels.message import Message
-from channels.utils import name_that_thing
 from channels.generic import BaseConsumer
+from channels.message import Message
+from channels.routing import Router, include, route, route_class
+from channels.utils import name_that_thing
 
 
 # Fake consumers and routing sets that can be imported by string

--- a/channels/tests/test_sessions.py
+++ b/channels/tests/test_sessions.py
@@ -2,11 +2,13 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.test import override_settings
-from channels.message import Message
-from channels.sessions import channel_session, channel_and_http_session, http_session, enforce_ordering, \
-    session_for_reply_channel
-from channels.tests import ChannelTestCase
+
 from channels import DEFAULT_CHANNEL_LAYER, channel_layers
+from channels.message import Message
+from channels.sessions import (
+    channel_and_http_session, channel_session, enforce_ordering, http_session, session_for_reply_channel,
+)
+from channels.tests import ChannelTestCase
 
 
 @override_settings(SESSION_ENGINE="django.contrib.sessions.backends.cache")

--- a/channels/tests/test_worker.py
+++ b/channels/tests/test_worker.py
@@ -1,17 +1,18 @@
 from __future__ import unicode_literals
 
+import threading
+
+from channels import DEFAULT_CHANNEL_LAYER, Channel, route
+from channels.asgi import channel_layers
+from channels.exceptions import ConsumeLater
+from channels.signals import worker_ready
+from channels.tests import ChannelTestCase
+from channels.worker import Worker, WorkerGroup
+
 try:
     from unittest import mock
 except ImportError:
     import mock
-import threading
-
-from channels import Channel, route, DEFAULT_CHANNEL_LAYER
-from channels.asgi import channel_layers
-from channels.tests import ChannelTestCase
-from channels.worker import Worker, WorkerGroup
-from channels.exceptions import ConsumeLater
-from channels.signals import worker_ready
 
 
 class PatchedWorker(Worker):

--- a/channels/worker.py
+++ b/channels/worker.py
@@ -2,17 +2,16 @@ from __future__ import unicode_literals
 
 import fnmatch
 import logging
+import multiprocessing
 import signal
 import sys
-import time
-import multiprocessing
 import threading
+import time
 
-from .signals import consumer_started, consumer_finished
 from .exceptions import ConsumeLater, DenyConnection
 from .message import Message
+from .signals import consumer_finished, consumer_started, worker_ready
 from .utils import name_that_thing
-from .signals import worker_ready
 
 logger = logging.getLogger('django.channels')
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ include_trailing_comma = true
 known_first_party = channels
 multi_line_output = 5
 not_skip = __init__.py
+line_length = 119
 
 [bdist_wheel]
 universal=1

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,9 @@ envlist =
     {py27,py35}-flake8
     isort
 
+[tox:travis]
+2.7 = py27, isort
+
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}


### PR DESCRIPTION
The changes in `tox.ini` make Travis run `isort` in the Python 2.7 build.