### PR TITLE
runserver should respect FORCE_SCRIPT_NAME setting

### DIFF
--- a/channels/handler.py
+++ b/channels/handler.py
@@ -44,7 +44,7 @@ class AsgiRequest(http.HttpRequest):
         # Path info
         self.path = self.message['path']
         self.script_name = self.message.get('root_path', '')
-        if self.script_name:
+        if self.script_name and self.path.startswith(self.script_name):
             # TODO: Better is-prefix checking, slash handling?
             self.path_info = self.path[len(self.script_name):]
         else:

--- a/channels/management/commands/runserver.py
+++ b/channels/management/commands/runserver.py
@@ -84,6 +84,7 @@ class Command(RunserverCommand):
                 action_logger=self.log_action,
                 http_timeout=self.http_timeout,
                 ws_protocols=getattr(settings, 'CHANNELS_WS_PROTOCOLS', None),
+                root_path=getattr(settings, 'FORCE_SCRIPT_NAME', ''),
             ).run()
             self.logger.debug("Daphne exited")
         except KeyboardInterrupt:

--- a/channels/tests/test_management.py
+++ b/channels/tests/test_management.py
@@ -87,7 +87,7 @@ class RunServerTests(TestCase):
         call_command('runserver', '--noreload')
         mocked_server.assert_called_with(port=8000, signal_handlers=True, http_timeout=60,
                                          host='127.0.0.1', action_logger=mock.ANY, channel_layer=mock.ANY,
-                                         ws_protocols=None)
+                                         ws_protocols=None, root_path=None)
 
     @mock.patch('channels.management.commands.runserver.sys.stdout', new_callable=StringIO)
     @mock.patch('channels.management.commands.runserver.Server')
@@ -101,12 +101,12 @@ class RunServerTests(TestCase):
             call_command('runserver', '--noreload')
             mocked_server.assert_called_with(port=8000, signal_handlers=True, http_timeout=60,
                                              host='127.0.0.1', action_logger=mock.ANY, channel_layer=mock.ANY,
-                                             ws_protocols=None)
+                                             ws_protocols=None, root_path=None)
 
             call_command('runserver', '--noreload', 'localhost:8001')
             mocked_server.assert_called_with(port=8001, signal_handlers=True, http_timeout=60,
                                              host='localhost', action_logger=mock.ANY, channel_layer=mock.ANY,
-                                             ws_protocols=None)
+                                             ws_protocols=None, root_path=None)
 
         self.assertFalse(mocked_worker.called,
                          "The worker should not be called with '--noworker'")
@@ -121,7 +121,7 @@ class RunServerTests(TestCase):
         call_command('runserver', '--noreload', '--noworker')
         mocked_server.assert_called_with(port=8000, signal_handlers=True, http_timeout=60,
                                          host='127.0.0.1', action_logger=mock.ANY, channel_layer=mock.ANY,
-                                         ws_protocols=None)
+                                         ws_protocols=None, root_path=None)
         self.assertFalse(mocked_worker.called,
                          "The worker should not be called with '--noworker'")
 


### PR DESCRIPTION
I am currently playing around with channels 0.17.3 in an old Django 1.8 ( I know its old but have to stick with i for now due to MSSQL ).

I have nginx running in the frontend as a proxy to path based seperate different projects from each other on the same hostname, which works without any problem with runserver or WSGI without channels activated. But as soon I enable channels the build-in runserver does not respect the FORCE_SCRIPT_NAME setting so the paths in rendered templates are wrong as the prefix set via FORCE_SCRIPT_NAME is missing.

As daphne already seem to have support for root_path I just pass FORCE_SCRIPT_NAME as root_path which fixes the issue.
I don't know if a new settings value would be more appropriate though.
In addition I stumbled over an issue that resulted in wrong path setting as the the PATH does not contain the root_path, so I changed so it only gets stripped when present.
