### PR TITLE
Valid cookie serialization for the test HTTPClient

### DIFF
--- a/channels/tests/http.py
+++ b/channels/tests/http.py
@@ -6,6 +6,7 @@ from django.apps import apps
 from django.conf import settings
 
 from django.utils.six.moves import http_cookies
+from django.http.cookie import SimpleCookie
 
 from ..sessions import session_for_reply_channel
 from .base import Client
@@ -127,5 +128,10 @@ class HttpClient(Client):
 
 def _encoded_cookies(cookies):
     """Encode dict of cookies to ascii string"""
-    return ('; '.join('{0}={1}'.format(k, http_cookies._quote(v))
-                      for k, v in cookies.items())).encode("ascii")
+
+    cookie_encoder = SimpleCookie()
+
+    for k, v in cookies.items():
+        cookie_encoder[k] = v
+
+    return cookie_encoder.output(header='', sep=';').encode("ascii")

--- a/channels/tests/http.py
+++ b/channels/tests/http.py
@@ -5,6 +5,8 @@ import six
 from django.apps import apps
 from django.conf import settings
 
+from six.moves.urllib.parse import quote
+
 from ..sessions import session_for_reply_channel
 from .base import Client
 
@@ -125,4 +127,5 @@ class HttpClient(Client):
 
 def _encoded_cookies(cookies):
     """Encode dict of cookies to ascii string"""
-    return ('; '.join('{0}={1}'.format(k, v) for k, v in cookies.items())).encode("ascii")
+    return ('; '.join('{0}={1}'.format(k, quote(v))
+                      for k, v in cookies.items())).encode("ascii")

--- a/channels/tests/http.py
+++ b/channels/tests/http.py
@@ -125,4 +125,4 @@ class HttpClient(Client):
 
 def _encoded_cookies(cookies):
     """Encode dict of cookies to ascii string"""
-    return ('&'.join('{0}={1}'.format(k, v) for k, v in cookies.items())).encode("ascii")
+    return ('; '.join('{0}={1}'.format(k, v) for k, v in cookies.items())).encode("ascii")

--- a/channels/tests/http.py
+++ b/channels/tests/http.py
@@ -5,7 +5,6 @@ import six
 from django.apps import apps
 from django.conf import settings
 
-from django.utils.six.moves import http_cookies
 from django.http.cookie import SimpleCookie
 
 from ..sessions import session_for_reply_channel

--- a/channels/tests/http.py
+++ b/channels/tests/http.py
@@ -5,7 +5,7 @@ import six
 from django.apps import apps
 from django.conf import settings
 
-from six.moves.urllib.parse import quote
+from django.utils.six.moves import http_cookies
 
 from ..sessions import session_for_reply_channel
 from .base import Client
@@ -127,5 +127,5 @@ class HttpClient(Client):
 
 def _encoded_cookies(cookies):
     """Encode dict of cookies to ascii string"""
-    return ('; '.join('{0}={1}'.format(k, quote(v))
+    return ('; '.join('{0}={1}'.format(k, http_cookies._quote(v))
                       for k, v in cookies.items())).encode("ascii")

--- a/channels/tests/test_http.py
+++ b/channels/tests/test_http.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from django.http.cookie import parse_cookie
-from six.moves.urllib.parse import unquote
 
 from channels.tests.http import HttpClient
 from channels.tests import ChannelTestCase

--- a/channels/tests/test_http.py
+++ b/channels/tests/test_http.py
@@ -17,10 +17,9 @@ class HttpClientTests(ChannelTestCase):
         cookie_dict = parse_cookie(client.headers['cookie'].decode('ascii'))
 
         self.assertEqual(client.get_cookies(),
-                         {k: unquote(v)
-                          for k, v in cookie_dict.items()})
+                         cookie_dict)
 
         self.assertEqual({'foo': 'bar',
-                          'qux': 'qu%3Bx',
+                          'qux': 'qu;x',
                           'sessionid': client.get_cookies()['sessionid']},
                          cookie_dict)

--- a/channels/tests/test_http.py
+++ b/channels/tests/test_http.py
@@ -5,6 +5,7 @@ from django.http.cookie import parse_cookie
 from channels.tests.http import HttpClient
 from channels.tests import ChannelTestCase
 
+
 class HttpClientTests(ChannelTestCase):
     def test_cookies(self):
         client = HttpClient()

--- a/channels/tests/test_http.py
+++ b/channels/tests/test_http.py
@@ -1,0 +1,21 @@
+from __future__ import unicode_literals
+
+from django.http.cookie import parse_cookie
+
+from channels.tests.http import HttpClient
+from channels.tests import ChannelTestCase
+
+class HttpClientTests(ChannelTestCase):
+    def test_cookies(self):
+        client = HttpClient()
+        client.set_cookie('foo', 'bar')
+
+        # Django's interpretation of the serialized cookie.
+        cookie_dict = parse_cookie(client.headers['cookie'].decode('ascii'))
+
+        self.assertEqual(client.get_cookies(),
+                         cookie_dict)
+
+        self.assertEqual({'foo': 'bar',
+                          'sessionid': client.get_cookies()['sessionid']},
+                         cookie_dict)

--- a/channels/tests/test_http.py
+++ b/channels/tests/test_http.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from django.http.cookie import parse_cookie
+from six.moves.urllib.parse import unquote
 
 from channels.tests.http import HttpClient
 from channels.tests import ChannelTestCase
@@ -8,14 +9,15 @@ from channels.tests import ChannelTestCase
 class HttpClientTests(ChannelTestCase):
     def test_cookies(self):
         client = HttpClient()
-        client.set_cookie('foo', 'bar')
+        client.set_cookie('foo', 'b;ar')
 
         # Django's interpretation of the serialized cookie.
         cookie_dict = parse_cookie(client.headers['cookie'].decode('ascii'))
 
         self.assertEqual(client.get_cookies(),
-                         cookie_dict)
+                         {k: unquote(v)
+                          for k, v in cookie_dict.items()})
 
-        self.assertEqual({'foo': 'bar',
+        self.assertEqual({'foo': 'b%3Bar',
                           'sessionid': client.get_cookies()['sessionid']},
                          cookie_dict)

--- a/channels/tests/test_http.py
+++ b/channels/tests/test_http.py
@@ -2,8 +2,8 @@ from __future__ import unicode_literals
 
 from django.http.cookie import parse_cookie
 
-from channels.tests.http import HttpClient
 from channels.tests import ChannelTestCase
+from channels.tests.http import HttpClient
 
 
 class HttpClientTests(ChannelTestCase):

--- a/channels/tests/test_http.py
+++ b/channels/tests/test_http.py
@@ -9,7 +9,9 @@ from channels.tests import ChannelTestCase
 class HttpClientTests(ChannelTestCase):
     def test_cookies(self):
         client = HttpClient()
-        client.set_cookie('foo', 'b;ar')
+        client.set_cookie('foo', 'not-bar')
+        client.set_cookie('foo', 'bar')
+        client.set_cookie('qux', 'qu;x')
 
         # Django's interpretation of the serialized cookie.
         cookie_dict = parse_cookie(client.headers['cookie'].decode('ascii'))
@@ -18,6 +20,7 @@ class HttpClientTests(ChannelTestCase):
                          {k: unquote(v)
                           for k, v in cookie_dict.items()})
 
-        self.assertEqual({'foo': 'b%3Bar',
+        self.assertEqual({'foo': 'bar',
+                          'qux': 'qu%3Bx',
                           'sessionid': client.get_cookies()['sessionid']},
                          cookie_dict)


### PR DESCRIPTION
https://github.com/django/channels/issues/452

This PR attempts to fix the `HTTPClient.set_cookie` method, which was serializing cookies into an invalid format. 

It may be worthwhile to re-implement the function using the stdlib:
https://docs.python.org/3/library/http.cookies.html

Any suggestions on where to put tests for test utilities?  