### PR TITLE
Fixed import to resolve RemovedInDjango20Warning

### DIFF
--- a/channels/handler.py
+++ b/channels/handler.py
@@ -13,17 +13,17 @@ from django.conf import settings
 from django.core import signals
 from django.core.handlers import base
 
-try:
-    from django.urls import set_script_prefix
-except ImportError:
-    # Django < 1.10
-    from django.core.urlresolvers import set_script_prefix
-
 from django.http import FileResponse, HttpResponse, HttpResponseServerError
 from django.utils import six
 from django.utils.functional import cached_property
 
 from channels.exceptions import RequestAborted, RequestTimeout, ResponseLater as ResponseLaterOuter
+
+try:
+    from django.urls import set_script_prefix
+except ImportError:
+    # Django < 1.10
+    from django.core.urlresolvers import set_script_prefix
 
 logger = logging.getLogger('django.request')
 

--- a/channels/handler.py
+++ b/channels/handler.py
@@ -19,7 +19,7 @@ except ImportError:
     # Django < 1.10
     from django.core.urlresolvers import set_script_prefix
 
-    from django.http import FileResponse, HttpResponse, HttpResponseServerError
+from django.http import FileResponse, HttpResponse, HttpResponseServerError
 from django.utils import six
 from django.utils.functional import cached_property
 

--- a/channels/handler.py
+++ b/channels/handler.py
@@ -12,8 +12,14 @@ from django import http
 from django.conf import settings
 from django.core import signals
 from django.core.handlers import base
-from django.core.urlresolvers import set_script_prefix
-from django.http import FileResponse, HttpResponse, HttpResponseServerError
+
+try:
+    from django.urls import set_script_prefix
+except ImportError:
+    # Django < 1.10
+    from django.core.urlresolvers import set_script_prefix
+
+    from django.http import FileResponse, HttpResponse, HttpResponseServerError
 from django.utils import six
 from django.utils.functional import cached_property
 


### PR DESCRIPTION
That resolves: "RemovedInDjango20Warning: Importing from django.core.urlresolvers is deprecated in favor of django.urls."