### PR TITLE
Bugfix for data binding code sample in documentation

### DIFF
--- a/docs/binding.rst
+++ b/docs/binding.rst
@@ -69,7 +69,8 @@ Start off like this::
         stream = "intval"
         fields = ["name", "value"]
 
-        def group_names(self, instance, action):
+        @classmethod
+        def group_names(cls, instance, action):
             return ["intval-updates"]
 
         def has_permission(self, user, action, pk):


### PR DESCRIPTION
Child classes of WebsocketBinding must overwrite WebsocketBinding.group_names() as a classmethod, not as an instance method.