### PR TITLE
Accept Connection at WebsocketConsumer

### DIFF
--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -87,18 +87,17 @@ class WebsocketBinding(Binding):
         # Only allow received packets through further.
         if message.channel.name != "websocket.receive":
             return
-        # Call superclass, unpacking the payload in the process
-        payload = json.loads(message['text'])
-        super(WebsocketBinding, cls).trigger_inbound(payload, **kwargs)
+        super(WebsocketBinding, cls).trigger_inbound(message, **kwargs)
 
     def deserialize(self, message):
         """
         You must hook this up behind a Deserializer, so we expect the JSON
         already dealt with.
         """
-        action = message['action']
-        pk = message.get('pk', None)
-        data = message.get('data', None)
+        body = json.loads(message['text'])
+        action = body['action']
+        pk = body.get('pk', None)
+        data = body.get('data', None)
         return action, pk, data
 
     def _hydrate(self, pk, data):

--- a/channels/generic/websockets.py
+++ b/channels/generic/websockets.py
@@ -72,7 +72,7 @@ class WebsocketConsumer(BaseConsumer):
         """
         Called when a WebSocket connection is opened.
         """
-        pass
+        self.message.reply_channel.send({"accept": True})
 
     def raw_receive(self, message, **kwargs):
         """
@@ -220,6 +220,7 @@ class WebsocketDemultiplexer(JsonWebsocketConsumer):
 
     def connect(self, message, **kwargs):
         """Forward connection to all consumers."""
+        self.message.reply_channel.send({"accept": True})
         for stream, consumer in self.consumers.items():
             kwargs['multiplexer'] = WebsocketMultiplexer(stream, self.message.reply_channel)
             consumer(message, **kwargs)

--- a/channels/message.py
+++ b/channels/message.py
@@ -81,5 +81,6 @@ class PendingMessageStore(object):
             sender.send(message, immediately=True)
         self.threadlocal.messages = []
 
+
 pending_message_store = PendingMessageStore()
 consumer_finished.connect(pending_message_store.send_and_flush)

--- a/channels/tests/test_generic.py
+++ b/channels/tests/test_generic.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-import json
-
 from django.test import override_settings
 
 from channels import route_class
@@ -191,19 +189,13 @@ class GenericTests(ChannelTestCase):
                 "mystream": MyWebsocketConsumer
             }
 
-        with apply_routes([
-            route_class(Demultiplexer, path='/path/(?P<id>\d+)'),
-            route_class(MyWebsocketConsumer),
-        ]):
-            client = Client()
+        with apply_routes([route_class(Demultiplexer, path='/path/(?P<id>\d+)')]):
+            client = HttpClient()
 
             with self.assertRaises(SendNotAvailableOnDemultiplexer):
-                client.send_and_consume('websocket.receive', {
-                    'path': '/path/1',
-                    'text': json.dumps({
-                        "stream": "mystream",
-                        "payload": {"text_field": "mytext"}
-                    })
+                client.send_and_consume('websocket.receive', path='/path/1', text={
+                    "stream": "mystream",
+                    "payload": {"text_field": "mytext"},
                 })
 
                 client.receive()

--- a/channels/tests/test_generic.py
+++ b/channels/tests/test_generic.py
@@ -7,7 +7,7 @@ from django.test import override_settings
 from channels import route_class
 from channels.exceptions import SendNotAvailableOnDemultiplexer
 from channels.generic import BaseConsumer, websockets
-from channels.tests import ChannelTestCase, Client, apply_routes
+from channels.tests import ChannelTestCase, Client, apply_routes, HttpClient
 
 
 @override_settings(SESSION_ENGINE="django.contrib.sessions.backends.cache")
@@ -92,6 +92,7 @@ class GenericTests(ChannelTestCase):
         class WebsocketConsumer(websockets.WebsocketConsumer):
 
             def connect(self, message, **kwargs):
+                self.message.reply_channel.send({'accept': True})
                 self.send(text=message.get('order'))
 
         routes = [
@@ -103,18 +104,18 @@ class GenericTests(ChannelTestCase):
         self.assertIs(routes[1].consumer, WebsocketConsumer)
 
         with apply_routes(routes):
-            client = Client()
+            client = HttpClient()
 
             client.send('websocket.connect', {'path': '/path', 'order': 1})
             client.send('websocket.connect', {'path': '/path', 'order': 0})
+            client.consume('websocket.connect', check_accept=False)
             client.consume('websocket.connect')
+            self.assertEqual(client.receive(json=False), 0)
             client.consume('websocket.connect')
-            client.consume('websocket.connect')
-            self.assertEqual(client.receive(), {'text': 0})
-            self.assertEqual(client.receive(), {'text': 1})
+            self.assertEqual(client.receive(json=False), 1)
 
             client.send_and_consume('websocket.connect', {'path': '/path/2', 'order': 'next'})
-            self.assertEqual(client.receive(), {'text': 'next'})
+            self.assertEqual(client.receive(json=False), 'next')
 
     def test_as_route_method(self):
         class WebsocketConsumer(BaseConsumer):
@@ -154,40 +155,28 @@ class GenericTests(ChannelTestCase):
                 "mystream": MyWebsocketConsumer
             }
 
-        with apply_routes([
-            route_class(Demultiplexer, path='/path/(?P<id>\d+)'),
-            route_class(MyWebsocketConsumer),
-        ]):
-            client = Client()
+        with apply_routes([route_class(Demultiplexer, path='/path/(?P<id>\d+)')]):
+            client = HttpClient()
 
-            client.send_and_consume('websocket.connect', {'path': '/path/1'})
+            client.send_and_consume('websocket.connect', path='/path/1')
             self.assertEqual(client.receive(), {
-                "text": json.dumps({
-                    "stream": "mystream",
-                    "payload": {"id": "1"},
-                })
+                "stream": "mystream",
+                "payload": {"id": "1"},
             })
 
-            client.send_and_consume('websocket.receive', {
-                'path': '/path/1',
-                'text': json.dumps({
-                    "stream": "mystream",
-                    "payload": {"text_field": "mytext"}
-                })
-            })
-            self.assertEqual(client.receive(), {
-                "text": json.dumps({
+            client.send_and_consume('websocket.receive', text={
                     "stream": "mystream",
                     "payload": {"text_field": "mytext"},
-                })
+            }, path='/path/1')
+            self.assertEqual(client.receive(), {
+                "stream": "mystream",
+                "payload": {"text_field": "mytext"},
             })
 
-            client.send_and_consume('websocket.disconnect', {'path': '/path/1'})
+            client.send_and_consume('websocket.disconnect', path='/path/1')
             self.assertEqual(client.receive(), {
-                "text": json.dumps({
-                    "stream": "mystream",
-                    "payload": {"id": "1"},
-                })
+                "stream": "mystream",
+                "payload": {"id": "1"},
             })
 
     def test_websocket_demultiplexer_send(self):

--- a/channels/tests/test_generic.py
+++ b/channels/tests/test_generic.py
@@ -5,7 +5,7 @@ from django.test import override_settings
 from channels import route_class
 from channels.exceptions import SendNotAvailableOnDemultiplexer
 from channels.generic import BaseConsumer, websockets
-from channels.tests import ChannelTestCase, Client, apply_routes, HttpClient
+from channels.tests import ChannelTestCase, Client, HttpClient, apply_routes
 
 
 @override_settings(SESSION_ENGINE="django.contrib.sessions.backends.cache")

--- a/channels/tests/test_generic.py
+++ b/channels/tests/test_generic.py
@@ -165,8 +165,8 @@ class GenericTests(ChannelTestCase):
             })
 
             client.send_and_consume('websocket.receive', text={
-                    "stream": "mystream",
-                    "payload": {"text_field": "mytext"},
+                "stream": "mystream",
+                "payload": {"text_field": "mytext"},
             }, path='/path/1')
             self.assertEqual(client.receive(), {
                 "stream": "mystream",


### PR DESCRIPTION
Added  sending "accept" message at `WebsocketConsumer` as default behavior for `connect` method. I wanted to add it at `raw_connect` but it had break `Demultiplexer` logic.

Also I think that we must pass `message` itself to the `trigger_inbound`, because we need to have access to the `user` or to the `reply_channel`  