### PR TITLE
more consistent metrics

### DIFF
--- a/docs/asgi.rst
+++ b/docs/asgi.rst
@@ -367,17 +367,20 @@ A channel layer implementing the ``groups`` extension must also provide:
 
 A channel layer implementing the ``statistics`` extension must also provide:
 
-* ``global_statistics()``, a callable that returns a dict with zero
-  or more of (unicode string keys):
+* ``global_statistics()``, a callable that returns statistics across all channels
+* ``channel_statistics(channel)``, a callable that returns statistics for specified channel
 
-  * ``count``, the current number of messages waiting in all channels
+* in both cases statistics are a dict with zero or more of (unicode string keys):
 
-* ``channel_statistics(channel)``, a callable that returns a dict with zero
-  or more of (unicode string keys):
+  * ``messages_count``, the number of messages processed since server start
+  * ``messages_count_per_second``, the number of messages processed in the last second
+  * ``queue_depth``, the current number of messages waiting
+  * ``message_max_age``, how long the oldest message has been waiting, in seconds
+  * ``channel_full_count``, the number of times `ChannelFull` exception has been risen since server start
+  * ``channel_full_count_per_second``, the number of times `ChannelFull` exception has been risen in the last second
+  
+* Implementation may provide total counts, counts per seconds or both. 
 
-  * ``length``, the current number of messages waiting on the channel
-  * ``age``, how long the oldest message has been waiting, in seconds
-  * ``per_second``, the number of messages processed in the last second
 
 A channel layer implementing the ``flush`` extension must also provide:
 

--- a/docs/asgi.rst
+++ b/docs/asgi.rst
@@ -374,12 +374,12 @@ A channel layer implementing the ``statistics`` extension must also provide:
 
   * ``messages_count``, the number of messages processed since server start
   * ``messages_count_per_second``, the number of messages processed in the last second
-  * ``queue_depth``, the current number of messages waiting
-  * ``message_max_age``, how long the oldest message has been waiting, in seconds
+  * ``messages_pending``, the current number of messages waiting
+  * ``messages_max_age``, how long the oldest message has been waiting, in seconds
   * ``channel_full_count``, the number of times `ChannelFull` exception has been risen since server start
   * ``channel_full_count_per_second``, the number of times `ChannelFull` exception has been risen in the last second
-  
-* Implementation may provide total counts, counts per seconds or both. 
+
+* Implementation may provide total counts, counts per seconds or both.
 
 
 A channel layer implementing the ``flush`` extension must also provide:


### PR DESCRIPTION
More consistent metrics, in particular for consumers such as Graphite, CloudWatch etc. you don't want aggregated numbers per second, you want number since previous call. Since we don't want to track all the clients, total since start is the next best thing, because it can be easily calculated by the metrics consumer `count_since_last = pervious_count - current_count`