### PR TITLE
Send all messages before ChannelTestCase.get_next_message looks for a message

### DIFF
--- a/channels/tests/base.py
+++ b/channels/tests/base.py
@@ -11,7 +11,7 @@ from django.test.testcases import TestCase, TransactionTestCase
 from .. import DEFAULT_CHANNEL_LAYER
 from ..asgi import ChannelLayerWrapper, channel_layers
 from ..channel import Group
-from ..message import Message
+from ..message import Message, pending_message_store
 from ..routing import Router, include
 from ..signals import consumer_finished, consumer_started
 
@@ -63,6 +63,7 @@ class ChannelTestCaseMixin(object):
 
         If require is true, will fail the test if no message is received.
         """
+        pending_message_store.send_and_flush()
         recv_channel, content = channel_layers[alias].receive_many([channel])
         if recv_channel is None:
             if require:

--- a/channels/tests/test_worker.py
+++ b/channels/tests/test_worker.py
@@ -97,6 +97,17 @@ class WorkerTests(ChannelTestCase):
         self.assertEqual(consumer.call_count, 1)
         self.assertEqual(channel_layer.send.call_count, 0)
 
+    def test_a_thing(self):
+        """
+        This test corresponds to the test example in the documentation.
+        make sure, that it works.
+        """
+        # Inject a message onto the channel to use in a consumer
+        Channel("input").send({"value": 33})
+        # Verify there's a result and that it's accurate
+        result = self.get_next_message("input", require=True)
+        self.assertEqual(result['value'], 33)
+
 
 class WorkerGroupTests(ChannelTestCase):
     """


### PR DESCRIPTION
In the documentation there is an test example, which does currently not work:
http://channels.readthedocs.io/en/latest/testing.html#channeltestcase
The problem is, that the messages are not send when you call ```Channel(...).send(...)```. You have to call ```Channel(...).send(..., immediately=True)``` which is possible in one test, but not, if you test a function which calls the send message.

The problem is, that all messages are cached until ```pending_message_store.send_and_flush()``` is called. So I think it is a good idea to call it first thing in ```get_next_message```.

I added a test to test the example test. I did not know where the right place for this test is. I can move it to another file if you like.