### PR TITLE
Remove unnecessary profane word in the documentation

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -153,8 +153,8 @@ For example::
 
         def test_rooms(self):
             client = HttpClient()
-            user = User.objects.create_user(username='test', email='test@test.com',
-                                            password='123456') # fuck you security
+            user = User.objects.create_user(
+                username='test', email='test@test.com', password='123456')
             client.login(username='test', password='123456')
 
             client.send_and_consume('websocket.connect', '/rooms/')


### PR DESCRIPTION
It certainly didn't add anything to the documentation, and being that it's a unit test it really shouldn't matter in this context.