### PR TITLE
Add appveyor support to add windows tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ python:
   - "3.4"
   - "3.5"
 install: pip install tox-travis
-script: tox
+script:
+  - tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,4 @@ install:
 
 # command to run tests
 test_script:
-  - cmd: python ci/toxmatch.py > tox.env.txt && set /p TOXENV=<tox.env.txt
-  - cmd: python ci/toxmatch.py
-  - cmd: tox -e %TOXENV%
+  - cmd: tox --skip-missing-interpreters

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+#
+# Some help for Python on AppVeyor:
+# * https://packaging.python.org/appveyor/
+# * https://ci.appveyor.com/tools/validate-yaml
+
+build: false
+
+environment:
+  matrix:
+      - PYTHON_HOME: "C:/Python35"
+      - PYTHON_HOME: "C:/Python34"
+      - PYTHON_HOME: "C:/Python27"
+
+install:
+  - choco install redis-64
+  - redis-server --service-install
+  - redis-server --service-start
+  - cmd: |
+        set PATH=%PYTHON_HOME%;%PYTHON_HOME%\Scripts;%PATH%
+        python -m pip install --upgrade pip
+        pip install tox
+
+# command to run tests
+test_script:
+  - cmd: python ci/toxmatch.py > tox.env.txt && set /p TOXENV=<tox.env.txt
+  - cmd: python ci/toxmatch.py
+  - cmd: tox -e %TOXENV%

--- a/channels/worker.py
+++ b/channels/worker.py
@@ -158,7 +158,13 @@ class WorkerGroup(Worker):
     """
 
     def __init__(self, *args, **kwargs):
-        n_threads = kwargs.pop('n_threads', multiprocessing.cpu_count()) - 1
+        try:
+            default_cpu_count = multiprocessing.cpu_count()
+        except NotImplementedError:
+            # Set a sensible default
+            # 1 isn't sensible, as n_threads would be 0
+            default_cpu_count = 2
+        n_threads = kwargs.pop('n_threads', default_cpu_count) - 1
         super(WorkerGroup, self).__init__(*args, **kwargs)
         kwargs['signal_handlers'] = False
         self.workers = [Worker(*args, **kwargs) for ii in range(n_threads)]

--- a/ci/toxmatch.py
+++ b/ci/toxmatch.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+"""
+Quick script that returns list of TOX envs, after applying pattern expansion.
+Usage example:
+$ toxmatch {foo,bar}-py{2,3}
+foo-py2,foo-py3,bar-py2,bar-py3
+
+Needed because of: https://github.com/tox-dev/tox/issues/318
+Taken from: https://gist.github.com/eli-collins/ef91add2bc635ccaf61738cd805cb18b
+"""
+from __future__ import print_function
+import sys
+from tox.config import parseconfig, _expand_envstr
+
+
+def main(pattern):
+    reqs = set(frozenset(elem.split("-")) for elem in _expand_envstr(pattern))
+
+    def match(env):
+        factors = set(env.split("-"))
+        return any(factors.issuperset(req) for req in reqs)
+    print(",".join(env for env in parseconfig().envlist if match(env)))
+
+
+if __name__ == "__main__":
+    sys.exit(main('py%s%s' % sys.version_info[:2]))

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist =
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}
 platform =
-    windows: windows
+    windows: win32
     linux: linux
 deps =
     autobahn

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,8 @@
 [tox]
 skipsdist = True
 envlist =
-    {py27}-django-{18,19,110}
-    {py34}-django-{18,19,110}
-    {py35}-django-{18,19,110}
-    {py27,py35}-flake8
+    {py27,py34,py35}-django-{18,19,110}-{windows,linux}
+    {py27,py34,py35}-flake8
     isort
 
 [tox:travis]
@@ -13,6 +11,9 @@ envlist =
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}
+platform =
+    windows: windows
+    linux: linux
 deps =
     autobahn
     coverage
@@ -26,8 +27,8 @@ deps =
     django-18: Django>=1.8,<1.9
     django-19: Django>=1.9,<1.10
     django-110: Django>=1.10,<1.11
+    windows: pypiwin32
 commands =
     flake8: flake8
     isort: isort -c -rc channels
     django: coverage run --parallel-mode {toxinidir}/runtests.py
-


### PR DESCRIPTION
As per issue #498 here is a PR to add appveyor support to test windows compatibility.

There is only one change in the channels code - switching multiprocessing for psutil when calculating the cpu_count , as it caused a NotImplementedError on Python 2.7 on windows. I'm happy to revert that if you only want windows testing on Python 3.
https://docs.python.org/2/library/multiprocessing.html#multiprocessing.cpu_count

I also added a small util library (`toxmatch.py`) that does the same as travis-tox for appveyor to get the list of allowable test environments that can be run from a tox.ini matrix 

I've also made some small tweaks to `tox.ini` to reduce the number of lines and allow explicit platform specific testing.

For this to work someone on the team will need to sign up at Appveyor to configure hooks and such. But you can confirm it works smoothly here - https://ci.appveyor.com/project/LegoStormtroopr/channels

Enjoy your verified Windows compatibility and [brand new badge!](https://www.appveyor.com/docs/status-badges/)

For details on starting redis see: http://stackoverflow.com/questions/28673763/start-redis-server-on-appveyor

Some of this was influenced by the appveyor.yml from the Twisted repository
https://github.com/twisted/twisted/blob/trunk/appveyor.yml
