### PR TITLE
Fix testing infrastructure.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    {py27,34,35}-django-{18,19,110}
-    {py27,py35}-flake8
+    py{27,34,35}-django-{18,19,110}
+    py{27,35}-flake8
     isort
 
 [testenv]


### PR DESCRIPTION
Changes:
1. Move requirements for tests in separate file. I think making extras tests is a bad idea, because extra have another sense to install additional functionality to current package, that not always need. For example in requests we can install `pip install requests[security]` or `pip install requests[socks]`. Tests requirements need for channels developers, not for programmers that using channels.
2. Fix tox envlist. Here is mistake in tox envlist.
3. Add python3.6 to travis. What about new Python 3.6? :)