### PR TITLE
Update Binding to support models with UUIDField as primary key

### DIFF
--- a/channels/binding/base.py
+++ b/channels/binding/base.py
@@ -120,7 +120,8 @@ class Binding(object):
 
     @classmethod
     def pre_save_receiver(cls, instance, **kwargs):
-        cls.pre_change_receiver(instance, CREATE if instance.pk is None else UPDATE)
+        creating = instance._state.adding
+        cls.pre_change_receiver(instance, CREATE if creating else UPDATE)
 
     @classmethod
     def post_save_receiver(cls, instance, created, **kwargs):

--- a/channels/tests/models.py
+++ b/channels/tests/models.py
@@ -1,0 +1,12 @@
+from uuid import uuid4
+
+from django.db import models
+
+
+class TestUUIDModel(models.Model):
+    """
+    Simple model with UUIDField as primary key for tests.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid4)
+    name = models.CharField(max_length=255)

--- a/channels/tests/settings.py
+++ b/channels/tests/settings.py
@@ -6,7 +6,8 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.admin',
     'channels',
-    'channels.delay'
+    'channels.delay',
+    'channels.tests'
 )
 
 DATABASES = {


### PR DESCRIPTION
'update' message was sent when creating a new model instance because `instance.pk` is set for non auto pk.

The `instance.pk is None` check to detect creating instances only works for auto PKs. 