### PR TITLE
use domain instead of port

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -439,10 +439,10 @@ both authentication and getting the underlying Django session (which is what
 Django authentication relies on).
 
 Channels can use Django sessions either from cookies (if you're running your
-websocket server on the same port as your main site, using something like Daphne),
+websocket server on the same domain as your main site, using something like Daphne),
 or from a ``session_key`` GET parameter, which works if you want to keep
 running your HTTP requests through a WSGI server and offload WebSockets to a
-second server process on another port.
+second server process on another domain.
 
 You get access to a user's normal Django session using the ``http_session``
 decorator - that gives you a ``message.http_session`` attribute that behaves


### PR DESCRIPTION
i think this is a typo, as cookies aren't restricted by port, so even if you offload on the same domain, daphne will still work without having to specify a ``session_key`` GET parameter since it can read the django session cookie which it defaults to.