### PR TITLE
Set self.kwargs in Binding.trigger_inbound when setting self.message

### DIFF
--- a/channels/binding/base.py
+++ b/channels/binding/base.py
@@ -214,6 +214,7 @@ class Binding(object):
         from django.contrib.auth.models import AnonymousUser
         self = cls()
         self.message = message
+        self.kwargs = kwargs
         # Deserialize message
         self.action, self.pk, self.data = self.deserialize(self.message)
         self.user = getattr(self.message, "user", AnonymousUser())


### PR DESCRIPTION
- it is useful to generate dynamic group names based on the path
- it is consistent with BaseConsumer that saves both message and kwargs