### PR TITLE
Make the channel_session decorator work on methods as well

### DIFF
--- a/channels/sessions.py
+++ b/channels/sessions.py
@@ -42,7 +42,7 @@ def channel_session(func):
     @functools.wraps(func)
     def inner(*args, **kwargs):
         message = None
-        for arg in args:
+        for arg in args[:2]:
             if isinstance(arg, Message):
                 message = arg
                 break

--- a/channels/sessions.py
+++ b/channels/sessions.py
@@ -8,6 +8,7 @@ from django.contrib.sessions.backends.base import CreateError
 
 from .exceptions import ConsumeLater
 from .handler import AsgiRequest
+from .message import Message
 
 
 def session_for_reply_channel(reply_channel):
@@ -39,11 +40,18 @@ def channel_session(func):
     Use this to persist data across the lifetime of a connection.
     """
     @functools.wraps(func)
-    def inner(message, *args, **kwargs):
+    def inner(*args, **kwargs):
+        message = None
+        for arg in args:
+            if isinstance(arg, Message):
+                message = arg
+                break
+        if message is None:
+            raise ValueError('channel_session called without Message instance')
         # Make sure there's NOT a channel_session already
         if hasattr(message, "channel_session"):
             try:
-                return func(message, *args, **kwargs)
+                return func(*args, **kwargs)
             finally:
                 # Persist session if needed
                 if message.channel_session.modified:
@@ -67,7 +75,7 @@ def channel_session(func):
         message.channel_session = session
         # Run the consumer
         try:
-            return func(message, *args, **kwargs)
+            return func(*args, **kwargs)
         finally:
             # Persist session if needed
             if session.modified and not session.is_empty():

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -67,6 +67,21 @@ class SessionTests(ChannelTestCase):
         session2 = session_for_reply_channel("test-reply")
         self.assertEqual(session2["num_ponies"], -1)
 
+    def test_channel_session_third_arg(self):
+        """
+        Tests the channel_session decorator with message as 3rd argument
+        """
+        # Construct message to send
+        message = Message({"reply_channel": "test-reply"}, None, None)
+
+        # Run through a simple fake consumer that assigns to it
+        @channel_session
+        def inner(a, b, message):
+            message.channel_session["num_ponies"] = -1
+
+        with self.assertRaisesMessage(ValueError, 'channel_session called without Message instance'):
+            inner(None, None, message)
+
     def test_channel_session_double(self):
         """
         Tests the channel_session decorator detects being wrapped in itself
@@ -106,6 +121,22 @@ class SessionTests(ChannelTestCase):
         session2 = session_for_reply_channel("test-reply")
         self.assertEqual(session2["num_ponies"], -1)
 
+    def test_channel_session_double_third_arg(self):
+        """
+        Tests the channel_session decorator detects being wrapped in itself
+        and doesn't blow up.
+        """
+        # Construct message to send
+        message = Message({"reply_channel": "test-reply"}, None, None)
+
+        # Run through a simple fake consumer that should trigger the error
+        @channel_session
+        @channel_session
+        def inner(a, b, message):
+            message.channel_session["num_ponies"] = -1
+        with self.assertRaisesMessage(ValueError, 'channel_session called without Message instance'):
+            inner(None, None, message)
+
     def test_channel_session_no_reply(self):
         """
         Tests the channel_session decorator detects no reply channel
@@ -138,6 +169,22 @@ class SessionTests(ChannelTestCase):
 
         with self.assertRaises(ValueError):
             Consumer().inner(message)
+
+    def test_channel_session_no_reply_third_arg(self):
+        """
+        Tests the channel_session decorator detects no reply channel
+        """
+        # Construct message to send
+        message = Message({}, None, None)
+
+        # Run through a simple fake consumer that should trigger the error
+        @channel_session
+        @channel_session
+        def inner(a, b, message):
+            message.channel_session["num_ponies"] = -1
+
+        with self.assertRaisesMessage(ValueError, 'channel_session called without Message instance'):
+            inner(None, None, message)
 
     def test_http_session(self):
         """


### PR DESCRIPTION
I've modified the `channel_session` decorator so that it can be used on methods of class-based consumers as well.