### PR TITLE
Allow relative url in `WebsocketBridge.connect()`

### DIFF
--- a/channels/static/channels/js/websocketbridge.js
+++ b/channels/static/channels/js/websocketbridge.js
@@ -270,12 +270,18 @@ var WebSocketBridge = function () {
     key: 'connect',
     value: function connect(url, protocols, options) {
       var _url = void 0;
+      // Use wss:// if running on https://
+      var scheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+      var base_url = scheme + '://' + window.location.host;
       if (url === undefined) {
-        // Use wss:// if running on https://
-        var scheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
-        _url = scheme + '://' + window.location.host + '/ws';
+        _url = base_url;
       } else {
-        _url = url;
+        // Support relative URLs
+        if (url[0] == '/') {
+          _url = '' + base_url + url;
+        } else {
+          _url = url;
+        }
       }
       this._socket = new _reconnectingWebsocket2.default(_url, protocols, options);
     }

--- a/docs/javascript.rst
+++ b/docs/javascript.rst
@@ -23,7 +23,7 @@ specific integration on top of it.
 To process messages::
 
     const webSocketBridge = new channels.WebSocketBridge();
-    webSocketBridge.connect();
+    webSocketBridge.connect('/ws/');
     webSocketBridge.listen(function(action, stream) {
       console.log(action, stream);
     });
@@ -38,7 +38,7 @@ To send messages, use the `send` method::
 To demultiplex specific streams::
 
     webSocketBridge.connect();
-    webSocketBridge.listen();
+    webSocketBridge.listen('/ws/');
     webSocketBridge.demultiplex('mystream', function(action, stream) {
       console.log(action, stream);
     });

--- a/js_client/src/index.js
+++ b/js_client/src/index.js
@@ -36,12 +36,18 @@ export class WebSocketBridge {
    */
   connect(url, protocols, options) {
     let _url;
+    // Use wss:// if running on https://
+    const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const base_url = `${scheme}://${window.location.host}`;
     if (url === undefined) {
-      // Use wss:// if running on https://
-      const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
-      _url = `${scheme}://${window.location.host}/ws`;
+      _url = base_url;
     } else {
-      _url = url;
+      // Support relative URLs
+      if (url[0] == '/') {
+        _url = `${base_url}${url}`;
+      } else {
+        _url = url;
+      }
     }
     this._socket = new ReconnectingWebSocket(_url, protocols, options);
   }

--- a/js_client/tests/websocketbridge.test.js
+++ b/js_client/tests/websocketbridge.test.js
@@ -16,6 +16,11 @@ describe('WebSocketBridge', () => {
     const webSocketBridge = new WebSocketBridge();
     webSocketBridge.connect('ws://localhost');
   });
+  it('Supports relative urls', () => {
+    const webSocketBridge = new WebSocketBridge();
+    webSocketBridge.connect('/somepath/');
+  });
+
   it('Processes messages', () => {
     const webSocketBridge = new WebSocketBridge();
     const myMock = jest.fn();


### PR DESCRIPTION
This patch allows to connect to the websocket by calling `websocketbridge.connect('/mypath/')`, instead of having to pass the full URL with scheme and everything