### PR TITLE
Fixed missing keyword argument in testing documentation

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -157,7 +157,7 @@ For example::
                 username='test', email='test@test.com', password='123456')
             client.login(username='test', password='123456')
 
-            client.send_and_consume('websocket.connect', '/rooms/')
+            client.send_and_consume('websocket.connect', path='/rooms/')
             # check that there is nothing to receive
             self.assertIsNone(client.receive())
 


### PR DESCRIPTION
In the example code for testing consumers under the Clients heading, client.send_and_consume is being called with a string path as the second positional argument. This fails in practice because the second argument is 'content' and is expecting a dictionary. Adding a path keyword fixes this error.