### PR TITLE
Provide TEST_CONFIG alias.

### DIFF
--- a/channels/test/liveserver.py
+++ b/channels/test/liveserver.py
@@ -82,17 +82,18 @@ class WorkerProcess(ProcessSetup):
         try:
             self.common_setup()
             channel_layers = ChannelLayerManager()
-            channel_layers[DEFAULT_CHANNEL_LAYER].router.check_default(
+            channel_layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+            channel_layer.router.check_default(
                 http_consumer=StaticFilesConsumer(),
             )
             if self.n_threads == 1:
                 self.worker = Worker(
-                    channel_layer=channel_layers[DEFAULT_CHANNEL_LAYER],
+                    channel_layer=channel_layer,
                     signal_handlers=False,
                 )
             else:
                 self.worker = WorkerGroup(
-                    channel_layer=channel_layers[DEFAULT_CHANNEL_LAYER],
+                    channel_layer=channel_layer,
                     signal_handlers=False,
                     n_threads=self.n_threads,
                 )
@@ -123,8 +124,9 @@ class DaphneProcess(ProcessSetup):
         try:
             self.common_setup()
             channel_layers = ChannelLayerManager()
+            channel_layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
             self.server = Server(
-                channel_layer=channel_layers[DEFAULT_CHANNEL_LAYER],
+                channel_layer=channel_layer,
                 endpoints=['tcp:interface=%s:port=0' % (self.host)],
                 signal_handlers=False,
             )
@@ -178,7 +180,7 @@ class ChannelLiveServerTestCase(TransactionTestCase):
                 'ChannelLiveServerTestCase does not support multiple CHANNEL_LAYERS at this time'
             )
 
-        channel_layer = channel_layers[DEFAULT_CHANNEL_LAYER]
+        channel_layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
         if 'flush' in channel_layer.extensions:
             channel_layer.flush()
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -299,8 +299,26 @@ Live Server Test Case
 ---------------------
 
 You can use browser automation libraries like Selenium or Splinter to
-check your application against real layer installation.  Use
-``ChannelLiveServerTestCase`` for your acceptance tests.
+check your application against real layer installation.  First of all
+provide ``TEST_CONFIG`` setting to prevent overlapping with running
+dev environment.
+
+.. code:: python
+
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "asgi_redis.RedisChannelLayer",
+            "ROUTING": "my_project.routing.channel_routing",
+            "CONFIG": {
+                "hosts": [("redis-server-name", 6379)],
+            },
+            "TEST_CONFIG": {
+                "hosts": [("localhost", 6379)],
+            },
+        },
+    }
+
+Now use ``ChannelLiveServerTestCase`` for your acceptance tests.
 
 .. code:: python
 

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -1,0 +1,34 @@
+from channels import DEFAULT_CHANNEL_LAYER
+from channels.asgi import InvalidChannelLayerError, channel_layers
+from channels.test import ChannelTestCase
+from django.test import override_settings
+
+
+class TestChannelLayerManager(ChannelTestCase):
+
+    def test_config_error(self):
+        """
+        If channel layer doesn't specify TEST_CONFIG, `make_test_backend`
+        should result into error.
+        """
+
+        with self.assertRaises(InvalidChannelLayerError):
+            channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+
+    @override_settings(CHANNEL_LAYERS={
+        'default': {
+            'BACKEND': 'asgiref.inmemory.ChannelLayer',
+            'ROUTING': [],
+            'TEST_CONFIG': {
+                'expiry': 100500,
+            },
+        },
+    })
+    def test_config_instance(self):
+        """
+        If channel layer provides TEST_CONFIG, `make_test_backend` should
+        return channel layer instance appropriate for testing.
+        """
+
+        layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+        self.assertEqual(layer.channel_layer.expiry, 100500)


### PR DESCRIPTION
As we discussed in the #497 we need test aliases to prevent integration test overlap with running dev environment.