### PR TITLE
Update the docs to provide info on how to use Group.send()

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -88,7 +88,17 @@ They have the following attributes:
   representing the underlying channel layer to send messages on.
 
 * ``send(content)``: Sends the ``dict`` provided as *content* to all
-  members of the group.
+  members of the group. The ``dict`` keys are as follows:
+
+  * ``bytes``: Byte string of frame content, if in bytes mode, or ``None``.
+  * ``text``: Unicode string of frame content, if in text mode, or ``None``.
+  * ``close``: Boolean indicating if the connection should be closed after data
+    is sent, if any. Alternatively, a positive integer specifying the response
+    code. The response code will be 1000 if you pass ``True``. Optional, default
+    ``False``.
+  * ``accept``: Boolean saying if the connection should be accepted without
+    sending a frame if it is in the handshake phase. Optional.
+  * Note: A maximum of one of bytes or text may be provided.
 
 * ``add(channel)``: Adds the given channel (as either a :ref:`Channel <ref-channel>`
   object or a unicode string name) to the group. If the channel is already in


### PR DESCRIPTION
Discussion in bug #651 revealed that the docs didn't explain how to use `Group.send()`.  This pull request attempts to address this issue.

Rationale
=======
I was initially referred to [the specification](http://channels.readthedocs.io/en/latest/asgi/www.html). The problem is that specs are for those who are implementing the relevant protocol. They aren't for API users. A user of the API shouldn't have to know anything of the internals unless they want to alter the internals. An API reference should provide all of the information necessary to correctly use it.