### PR TITLE
Added shortcut to simplify the common case of sending JSON text on a channel

### DIFF
--- a/channels/shortcuts.py
+++ b/channels/shortcuts.py
@@ -33,7 +33,7 @@ class JSON_Dict(dict):
 
     def update(self, *args, **kwargs):
         __doc__ = self._data.update.__doc__
-        [__doc__] # Silence test complaint about __doc__ being assigned but not used.
+        [__doc__]  # Silence test complaint about __doc__ being assigned but not used.
         self._data.update(*args, **kwargs)
         self._update_text()
 
@@ -52,7 +52,7 @@ class JSON_Dict(dict):
             raise ValueError("The key name 'text' is reserved.")
         del self._data[key]
         self._update_text()
-    
+
     def __repr__(self):
         return 'JSON_Dict({})'.format(repr(self._data))
 

--- a/channels/shortcuts.py
+++ b/channels/shortcuts.py
@@ -1,0 +1,61 @@
+import json
+
+class JSON_Dict(dict):
+    '''Convenience class for Channels' send() method when all you want to send is
+    JSON text. Use this class as you would a (write-only) dictionary; all data
+    will be automatically converted to the format Channels expects.
+
+    You can add and change dictionary keys, as well as deleting them, all as you
+    normally would with a dictionary. However, attempting to read them normally
+    will raise KeyError (a consequence of having to deceive Channels). Instead,
+    use the get_key method to read a value.
+
+    Finally, the key 'text' is reserved and can't be used. Attempting to do so
+    will raise ValueError.'''
+    
+    def __init__(self, input_dict=None, **kwargs):
+        '''Initialize the instance with a single dictionary instance or subclass
+        thereof or with keyword arguments defining the keys and values of the
+        dictionary.'''
+        if input_dict:
+            if not isinstance(input_dict, dict):
+                raise TypeError('input_dict must be a dictionary or a subclass thereof.')
+            kwargs.update(input_dict)
+        if 'text' in kwargs:
+            raise ValueError("The key name 'text' is reserved.")
+        self._data = kwargs
+        self._update_text()
+    
+    def get_key(self, key):
+        '''Call this method instead of instance[key] to read the value of a key.'''
+        return self._data[key]
+    
+    def update(self, *args, **kwargs):
+        __doc__ = self._data.update.__doc__
+        self._data.update(*args, **kwargs)
+        self._update_text()
+    
+    def __setitem__(self, key, value, autocall=False):
+        if key == 'text':
+            if autocall:
+                dict.__setitem__(self, key, value)
+            else:
+                raise ValueError("The key name 'text' is reserved.")
+        else:
+            dict.__setitem__(self._data, key, value)
+            self._update_text()
+    
+    def __delitem__(self, key):
+        if key == 'text':
+            raise ValueError("The key name 'text' is reserved.")
+        del self._data[key]
+        self._update_text()
+    
+    def __repr__(self):
+        return 'JSON_Dict({})'.format(repr(self._data))
+    
+    def __str__(self):
+        return str(self._data)
+    
+    def _update_text(self):
+        self.__setitem__('text', json.dumps(self._data), autocall=True)

--- a/channels/shortcuts.py
+++ b/channels/shortcuts.py
@@ -1,5 +1,6 @@
 import json
 
+
 class JSON_Dict(dict):
     '''Convenience class for Channels' send() method when all you want to send is
     JSON text. Use this class as you would a (write-only) dictionary; all data
@@ -12,7 +13,7 @@ class JSON_Dict(dict):
 
     Finally, the key 'text' is reserved and can't be used. Attempting to do so
     will raise ValueError.'''
-    
+
     def __init__(self, input_dict=None, **kwargs):
         '''Initialize the instance with a single dictionary instance or subclass
         thereof or with keyword arguments defining the keys and values of the
@@ -25,16 +26,17 @@ class JSON_Dict(dict):
             raise ValueError("The key name 'text' is reserved.")
         self._data = kwargs
         self._update_text()
-    
+
     def get_key(self, key):
         '''Call this method instead of instance[key] to read the value of a key.'''
         return self._data[key]
-    
+
     def update(self, *args, **kwargs):
         __doc__ = self._data.update.__doc__
+        [__doc__] # Silence test complaint about __doc__ being assigned but not used.
         self._data.update(*args, **kwargs)
         self._update_text()
-    
+
     def __setitem__(self, key, value, autocall=False):
         if key == 'text':
             if autocall:
@@ -44,7 +46,7 @@ class JSON_Dict(dict):
         else:
             dict.__setitem__(self._data, key, value)
             self._update_text()
-    
+
     def __delitem__(self, key):
         if key == 'text':
             raise ValueError("The key name 'text' is reserved.")
@@ -53,9 +55,9 @@ class JSON_Dict(dict):
     
     def __repr__(self):
         return 'JSON_Dict({})'.format(repr(self._data))
-    
+
     def __str__(self):
         return str(self._data)
-    
+
     def _update_text(self):
         self.__setitem__('text', json.dumps(self._data), autocall=True)

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,0 +1,50 @@
+from __future__ import unicode_literals
+
+import json
+
+from channels import Group
+from channels.shortcuts import JSON_Dict
+
+
+class JSONDictTests(ChannelTestCase):
+    """
+    Tests the JSON_Dict
+    """
+
+    def test_basic(self):
+        """
+        Tests that object creation works as expected.
+        """
+        d = JSON_Dict(test=1, another=False)
+        d['still_more'] = 42
+        self.assertIn('text', d)
+        self.assertNotIn('test', d)
+        with self.assertRaises(ValueError):
+            d['text'] = 'something'
+        self.assertEqual(json.loads(d['text']), json.loads('{"another": false, "test": 1, "still_more": 42}'))
+
+    def test_get_key(self):
+        """
+        Tests that the get_key method works as expected.
+        """
+        d = JSON_Dict(test=1, another=False)
+        self.assertEqual(d.get_key('test'), 1)
+        self.assertEqual(d.get_key('another'), False)
+        with self.assertRaises(KeyError):
+            tmp = d['test']
+
+    def test_update(self):
+        '''
+        Tests that the update method works as expected.
+        '''
+        d = JSON_Dict(test=1, another=False)
+        d.update({'another': True, 'answer': 42})
+        self.assertEqual(json.loads(d['text']), json.loads('{"another": true, "test": 1, "answer": 42}'))
+
+    def test_delete(self):
+        '''
+        Tests that deleting keys works
+        '''
+        d = JSON_Dict(test=1, another=False)
+        del d['test']
+        self.assertEqual(json.loads(d['text']), json.loads('{"another": false'))

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import json
 
-from channels import Group
 from channels.test import ChannelTestCase
 from channels.shortcuts import JSON_Dict
 
@@ -32,7 +31,7 @@ class JSONDictTests(ChannelTestCase):
         self.assertEqual(d.get_key('test'), 1)
         self.assertEqual(d.get_key('another'), False)
         with self.assertRaises(KeyError):
-            tmp = d['test']
+            d['test']
 
     def test_update(self):
         '''

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import json
 
 from channels import Group
+from channels.test import ChannelTestCase
 from channels.shortcuts import JSON_Dict
 
 

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -48,4 +48,4 @@ class JSONDictTests(ChannelTestCase):
         '''
         d = JSON_Dict(test=1, another=False)
         del d['test']
-        self.assertEqual(json.loads(d['text']), json.loads('{"another": false'))
+        self.assertEqual(json.loads(d['text']), json.loads('{"another": false}'))


### PR DESCRIPTION
While the Channels' send API is generic, it can be helpful to have some shortcut classes available for common uses, to simplify the use of Channels. This pull request adds a `JSON_Dict` class (a subclass of `dict`) which makes it easier to send JSON data over a channel, such as a WebSocket.

Here's an example of how it might be used:

    from channels import Group
    from channels.shortcuts import JSON_Dict
    
    def send(**kwargs):
        Group('somegroup').send(JSON_Dict(**kwargs))

This improves encapsulation by not requiring API users to know or care much about the send protocol--at least if this shortcut matches their use case.