### PR TITLE
Fix strict ordering with multiplexed consumers

### DIFF
--- a/channels/sessions.py
+++ b/channels/sessions.py
@@ -137,7 +137,7 @@ def enforce_ordering(func=None, slight=False):
             # See what the current next order should be
             next_order = message.channel_session.get("__channels_next_order", 0)
             # If order is 0 no messages exist before and we could be demultiplexing
-            # more than one message with order == 0
+            # more than one connect event with order == 0
             if order == 0 and next_order > 0:
                 order = next_order
             if order == next_order:

--- a/channels/sessions.py
+++ b/channels/sessions.py
@@ -136,6 +136,10 @@ def enforce_ordering(func=None, slight=False):
             order = int(message.content['order'])
             # See what the current next order should be
             next_order = message.channel_session.get("__channels_next_order", 0)
+            # If order is 0 no messages exist before and we could be demultiplexing
+            # more than one message with order == 0
+            if order == 0 and next_order > 0:
+                order = next_order
             if order == next_order:
                 # Run consumer
                 func(message, *args, **kwargs)


### PR DESCRIPTION
My solution to #656. I have added a test that fails without the changes to the `enforce_ordering` decorator.

**This PR does not solve the equivalent problem with demultiplexer `disconnect` events, which means we probably need a more robust solution! Any ideas?**