### PR TITLE
Fixes #612 - Log channels to "django.channels.server" instead of stderr

### DIFF
--- a/channels/apps.py
+++ b/channels/apps.py
@@ -1,6 +1,8 @@
 from django.apps import AppConfig
+from django.conf import settings
 
 from .binding.base import BindingMetaclass
+from .log import configure_logging
 from .package_checks import check_all
 
 
@@ -17,3 +19,5 @@ class ChannelsConfig(AppConfig):
         monkeypatch_django()
         # Instantiate bindings
         BindingMetaclass.register_all()
+
+        configure_logging(settings.LOGGING_CONFIG, settings.LOGGING)

--- a/channels/delay/management/commands/rundelay.py
+++ b/channels/delay/management/commands/rundelay.py
@@ -1,10 +1,11 @@
 from __future__ import unicode_literals
 
+import logging
+
 from django.core.management import BaseCommand, CommandError
 
 from channels import DEFAULT_CHANNEL_LAYER, channel_layers
 from channels.delay.worker import Worker
-from channels.log import setup_logger
 
 
 class Command(BaseCommand):
@@ -23,8 +24,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        self.verbosity = options.get("verbosity", 1)
-        self.logger = setup_logger('django.channels', self.verbosity)
+        self.logger = logging.getLogger('django.channels.server')
         self.channel_layer = channel_layers[options.get("layer", DEFAULT_CHANNEL_LAYER)]
         # Check that handler isn't inmemory
         if self.channel_layer.local_only():

--- a/channels/management/commands/runserver.py
+++ b/channels/management/commands/runserver.py
@@ -12,7 +12,6 @@ from django.utils.encoding import get_system_encoding
 
 from channels import DEFAULT_CHANNEL_LAYER, channel_layers
 from channels.handler import ViewConsumer
-from channels.log import setup_logger
 from channels.staticfiles import StaticFilesConsumer
 from channels.worker import Worker
 
@@ -30,7 +29,7 @@ class Command(RunserverCommand):
 
     def handle(self, *args, **options):
         self.verbosity = options.get("verbosity", 1)
-        self.logger = setup_logger('django.channels', self.verbosity)
+        self.logger = logging.getLogger('django.channels.server')
         self.http_timeout = options.get("http_timeout", 60)
         super(Command, self).handle(*args, **options)
 

--- a/channels/management/commands/runserver.py
+++ b/channels/management/commands/runserver.py
@@ -1,6 +1,7 @@
 import datetime
 import sys
 import threading
+import logging
 
 from daphne.server import Server, build_endpoint_description_strings
 from django.apps import apps
@@ -100,11 +101,13 @@ class Command(RunserverCommand):
         """
         Logs various different kinds of requests to the console.
         """
-        # All start with timestamp
-        msg = "[%s] " % datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S")
+        # Sets default level to INFO
+        level = logging.INFO
+        msg = ""
+
         # HTTP requests
         if protocol == "http" and action == "complete":
-            msg += "HTTP %(method)s %(path)s %(status)s [%(time_taken).2f, %(client)s]\n" % details
+            msg += "HTTP %(method)s %(path)s %(status)s [%(time_taken).2f, %(client)s]" % details
             # Utilize terminal colors, if available
             if 200 <= details['status'] < 300:
                 # Put 2XX first, since it should be the common case
@@ -117,22 +120,26 @@ class Command(RunserverCommand):
                 msg = self.style.HTTP_REDIRECT(msg)
             elif details['status'] == 404:
                 msg = self.style.HTTP_NOT_FOUND(msg)
+                level = logging.WARN
             elif 400 <= details['status'] < 500:
                 msg = self.style.HTTP_BAD_REQUEST(msg)
+                level = logging.WARN
             else:
                 # Any 5XX, or any other response
                 msg = self.style.HTTP_SERVER_ERROR(msg)
+                level = logging.ERROR
         # Websocket requests
         elif protocol == "websocket" and action == "connected":
-            msg += "WebSocket CONNECT %(path)s [%(client)s]\n" % details
+            msg += "WebSocket CONNECT %(path)s [%(client)s]" % details
         elif protocol == "websocket" and action == "disconnected":
-            msg += "WebSocket DISCONNECT %(path)s [%(client)s]\n" % details
+            msg += "WebSocket DISCONNECT %(path)s [%(client)s]" % details
         elif protocol == "websocket" and action == "connecting":
-            msg += "WebSocket HANDSHAKING %(path)s [%(client)s]\n" % details
+            msg += "WebSocket HANDSHAKING %(path)s [%(client)s]" % details
         elif protocol == "websocket" and action == "rejected":
-            msg += "WebSocket REJECT %(path)s [%(client)s]\n" % details
+            msg += "WebSocket REJECT %(path)s [%(client)s]" % details
+            level = logging.WARN
 
-        sys.stderr.write(msg)
+        self.logger.log(level, msg)
 
     def get_consumer(self, *args, **options):
         """

--- a/channels/management/commands/runworker.py
+++ b/channels/management/commands/runworker.py
@@ -1,11 +1,12 @@
 from __future__ import unicode_literals
 
+import logging
+
 from django.apps import apps
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError
 
 from channels import DEFAULT_CHANNEL_LAYER, channel_layers
-from channels.log import setup_logger
 from channels.signals import worker_process_ready
 from channels.staticfiles import StaticFilesConsumer
 from channels.worker import Worker, WorkerGroup
@@ -38,7 +39,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # Get the backend to use
         self.verbosity = options.get("verbosity", 1)
-        self.logger = setup_logger('django.channels', self.verbosity)
+        self.logger = logging.getLogger('django.channels.server')
         self.channel_layer = channel_layers[options.get("layer", DEFAULT_CHANNEL_LAYER)]
         self.n_threads = options.get('threads', 1)
         # Check that handler isn't inmemory


### PR DESCRIPTION
I updated django's DEFAULT_LOGGING dictionary to add channels options.

There is a small code duplicate from django configure_logging. If I don't do this, I remove the user option to create their own LOGGING in settings.

I'm still not sure how I should test this, any guidance?