### PR TITLE
Add protocol/server_cls attributes to runserver for extensibility

### DIFF
--- a/channels/management/commands/runserver.py
+++ b/channels/management/commands/runserver.py
@@ -17,6 +17,8 @@ from channels.worker import Worker
 
 
 class Command(RunserverCommand):
+    protocol = 'http'
+    server_cls = Server
 
     def add_arguments(self, parser):
         super(Command, self).add_arguments(parser)
@@ -58,12 +60,13 @@ class Command(RunserverCommand):
         self.stdout.write(now)
         self.stdout.write((
             "Django version %(version)s, using settings %(settings)r\n"
-            "Starting Channels development server at http://%(addr)s:%(port)s/\n"
+            "Starting Channels development server at %(protocol)s://%(addr)s:%(port)s/\n"
             "Channel layer %(layer)s\n"
             "Quit the server with %(quit_command)s.\n"
         ) % {
             "version": self.get_version(),
             "settings": settings.SETTINGS_MODULE,
+            "protocol": self.protocol,
             "addr": '[%s]' % self.addr if self._raw_ipv6 else self.addr,
             "port": self.port,
             "quit_command": quit_command,
@@ -84,7 +87,7 @@ class Command(RunserverCommand):
         # build the endpoint description string from host/port options
         endpoints = build_endpoint_description_strings(host=self.addr, port=self.port)
         try:
-            Server(
+            self.server_cls(
                 channel_layer=self.channel_layer,
                 endpoints=endpoints,
                 signal_handlers=not options['use_reloader'],

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -122,7 +122,7 @@ class RunServerTests(TestCase):
         channels.log.handler = logging.StreamHandler(self.stream)
 
     @mock.patch('channels.management.commands.runserver.sys.stdout', new_callable=StringIO)
-    @mock.patch('channels.management.commands.runserver.Server')
+    @mock.patch('channels.management.commands.runserver.Command.server_cls')
     @mock.patch('channels.management.commands.runworker.Worker')
     def test_runserver_basic(self, mocked_worker, mocked_server, mock_stdout):
         # Django's autoreload util uses threads and this is not needed
@@ -142,7 +142,7 @@ class RunServerTests(TestCase):
         )
 
     @mock.patch('channels.management.commands.runserver.sys.stdout', new_callable=StringIO)
-    @mock.patch('channels.management.commands.runserver.Server')
+    @mock.patch('channels.management.commands.runserver.Command.server_cls')
     @mock.patch('channels.management.commands.runworker.Worker')
     def test_runserver_debug(self, mocked_worker, mocked_server, mock_stdout):
         """
@@ -180,7 +180,7 @@ class RunServerTests(TestCase):
         )
 
     @mock.patch('channels.management.commands.runserver.sys.stdout', new_callable=StringIO)
-    @mock.patch('channels.management.commands.runserver.Server')
+    @mock.patch('channels.management.commands.runserver.Command.server_cls')
     @mock.patch('channels.management.commands.runworker.Worker')
     def test_runserver_noworker(self, mocked_worker, mocked_server, mock_stdout):
         '''


### PR DESCRIPTION
Same change as [in Django upstream](https://github.com/django/django/commit/e5e37473573ab5813479a8e570ac379e87bb81a1). Makes it easier to subclass the `runserver` command and extend it to add say HTTPS support.