### PR TITLE
HTTP/2 support is currently available in Daphne

### DIFF
--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -148,7 +148,7 @@ features, you'll need to run a native ASGI interface server, as the WSGI
 specification has no support for running these kinds of requests concurrently.
 We ship with an interface server that we recommend you use called
 `Daphne <http://github.com/django/daphne/>`_; it supports WebSockets,
-long-poll HTTP requests, HTTP/2 *(soon)* and performs quite well.
+long-poll HTTP requests, HTTP/2 and performs quite well.
 
 You can just keep running your Django code as a WSGI app if you like, behind
 something like uwsgi or gunicorn; this won't let you support WebSockets, though,


### PR DESCRIPTION
Drop the 'soon' qualifier when mentioning HTTP/2 support in Daphne in the documentation.