### PR TITLE
Define TEST_CONFIG for testproject redis layer.

### DIFF
--- a/testproject/testproject/settings/channels_redis.py
+++ b/testproject/testproject/settings/channels_redis.py
@@ -11,6 +11,9 @@ CHANNEL_LAYERS = {
         "ROUTING": "testproject.urls.channel_routing",
         "CONFIG": {
             "hosts": [os.environ.get('REDIS_URL', 'redis://127.0.0.1:6379')],
-        }
+        },
+        "TEST_CONFIG": {
+            "hosts": [os.environ.get('REDIS_URL', 'redis://127.0.0.1:6379')],
+        },
     },
 }


### PR DESCRIPTION
Needed by live server test case.