### PR TITLE
Add reference to run interface servers in docs.

### DIFF
--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -136,6 +136,8 @@ Or telling a worker to ignore all messages on the "thumbnail" channel::
     python manage.py runworker --exclude-channels=thumbnail
 
 
+.. _run-interface-servers:
+
 Run interface servers
 ---------------------
 


### PR DESCRIPTION
My mistake, I forgot to make a link to the section before referencing it. Added a link to the "Run Interface Servers" section.