### PR TITLE
Upgrade package.json to NPM v5

### DIFF
--- a/js_client/package.json
+++ b/js_client/package.json
@@ -12,8 +12,11 @@
     "docs": "rm -rf docs && esdoc -c esdoc.json",
     "test": "jest",
     "browserify": "browserify src/index.js -p browserify-banner -s channels -o ../channels/static/channels/js/websocketbridge.js",
-    "prepublish": "npm run transpile",
+    "prepare": "npm run transpile",
     "compile": "npm run transpile && npm run browserify"
+  },
+  "engines": {
+    "npm": "^5.0.0"
   },
   "files": [
     "lib/index.js"

--- a/js_client/package.json
+++ b/js_client/package.json
@@ -38,7 +38,6 @@
     ]
   },
   "devDependencies": {
-    "babel": "^6.5.2",
     "babel-cli": "^6.24.0",
     "babel-core": "^6.16.0",
     "babel-plugin-transform-inline-environment-variables": "^6.8.0",


### PR DESCRIPTION
I've update the `package.json` to the latest npm changes.

something I'm not clear about is if we should include `package-lock.json` or `shrinkwrap.json`. If we include `shrinkwrap.json`, it will need to be updated for every release, and I'd like to not have any additional step to the release process