### PR TITLE
Pin mock-socket to 6.0.4

### DIFF
--- a/js_client/package.json
+++ b/js_client/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-jsx-a11y": "^1.5.3",
     "eslint-plugin-react": "^5.2.2",
     "jest": "^19.0.1",
-    "mock-socket": "^6.0.4",
+    "mock-socket": "6.0.4",
     "react": "^15.4.0",
     "react-cookie": "^0.4.8",
     "react-dom": "^15.4.0",

--- a/js_client/package.json
+++ b/js_client/package.json
@@ -35,7 +35,6 @@
     ]
   },
   "devDependencies": {
-    "babel": "^6.5.2",
     "babel-cli": "^6.24.0",
     "babel-core": "^6.16.0",
     "babel-plugin-transform-inline-environment-variables": "^6.8.0",


### PR DESCRIPTION
`npm install` will install `mock-server` `v6.1.0`, which breaks our tests.