### PR TITLE
WIP Worker decoupled from channels.

### DIFF
--- a/channels/utils.py
+++ b/channels/utils.py
@@ -1,3 +1,4 @@
+import fnmatch
 import types
 
 
@@ -24,3 +25,26 @@ def name_that_thing(thing):
     if hasattr(thing, "__class__"):
         return name_that_thing(thing.__class__)
     return repr(thing)
+
+
+def apply_channel_filters(channels, only_channels, exclude_channels):
+    """
+    Applies our include and exclude filters to the channel list and returns it
+    """
+    if only_channels:
+        channels = [
+            channel for channel in channels
+            if any(
+                fnmatch.fnmatchcase(channel, pattern)
+                for pattern in only_channels
+            )
+        ]
+    if exclude_channels:
+        channels = [
+            channel for channel in channels
+            if not any(
+                fnmatch.fnmatchcase(channel, pattern)
+                for pattern in exclude_channels
+            )
+        ]
+    return channels


### PR DESCRIPTION
In current implementation channels worker do constant polling of the channel layer. Some channel layers can benefit from worker based on underlying technology internals. I want to give an ability to the layer to substitute default behavior with its own worker.

This PR allow public tracking for related issue

- [ ] Main channel layers PoC implementations
  - [ ] RabbitMQ
  - [ ] Redis
  - [ ] IPC
- [ ] Generic Implementation
  - [ ] asgiref worker 
  - [ ] well defined API
  - [ ] conformance tests
  - [ ] spec documentation
  - [ ] inmemory worker will call this API directly
- [ ] Uvicorn integration
- [ ] Channels code cleanup
  - [ ] Remove worker module