### PR TITLE
Upgrade reconnecting-websocket

### DIFF
--- a/js_client/package.json
+++ b/js_client/package.json
@@ -23,7 +23,7 @@
   ],
   "license": "BSD-3-Clause",
   "dependencies": {
-    "reconnecting-websocket": "^3.0.3"
+    "reconnecting-websocket": "^3.2.1"
   },
   "jest": {
     "roots": [

--- a/js_client/src/index.js
+++ b/js_client/src/index.js
@@ -30,7 +30,7 @@ export class WebSocketBridge {
    * @param      {String}  [url]     The url of the websocket. Defaults to
    * `window.location.host`
    * @param      {String[]|String}  [protocols] Optional string or array of protocols.
-   * @param      {Object} options Object of options for [`reconnecting-websocket`](https://github.com/joewalnes/reconnecting-websocket#options-1).
+   * @param      {Object} options Object of options for [`reconnecting-websocket`](https://github.com/pladaria/reconnecting-websocket#configure).
    * @example
    * const webSocketBridge = new WebSocketBridge();
    * webSocketBridge.connect();


### PR DESCRIPTION
This fixes 2 issues.

1. The comment in source code for `WebSocketBridge` was pointing to the wrong `reconnecting-websocket` library. 
2. I've upgraded the underlying `reconnecting-websocket` to the latest version.
