### PR TITLE
preventing attribute error

### DIFF
--- a/channels/message.py
+++ b/channels/message.py
@@ -116,7 +116,9 @@ class PendingMessageStore(object):
                     "or handle the ChannelFull exception yourself after adding\n"
                     "immediately=True to send()." % (sender, self.retry_time)
                 )
-        delattr(self.threadlocal, "messages")
+
+        if self.active:
+            delattr(self.threadlocal, "messages")
 
 
 pending_message_store = PendingMessageStore()


### PR DESCRIPTION
Since `messages` is being deleted without being checked it is possible to generate a `AttributeError: messages`.

The for-loop above the potential error spot provides a default so it skips this potential