### PR TITLE
Improve graceful stop logic for WorkerGroup

### DIFF
--- a/channels/worker.py
+++ b/channels/worker.py
@@ -16,6 +16,14 @@ from .utils import name_that_thing
 logger = logging.getLogger('django.channels')
 
 
+class StopWorkerGroupLoop(Exception):
+    """The exception is used to break worker group main thread loop from
+    SIGTERM/SIGINT handler when there is no job in process. If there is
+    a job in process, the loop will end by itself after processing it due
+    to self.termed flag and manual interruption is not needed.
+    """
+
+
 class Worker(object):
     """
     A "worker" process that continually looks for available messages to run
@@ -173,10 +181,11 @@ class WorkerGroup(Worker):
         msg_prefix = "Shutdown signal received by WorkerGroup, "
         if self.stop_gracefully:
             logger.info(msg_prefix + "waiting for sub-workers.")
-            self.wait_for_workers()
+            if not self.in_job:
+                raise StopWorkerGroupLoop()
         else:
             logger.info(msg_prefix + "terminating immediately.")
-        sys.exit(0)
+            sys.exit(0)
 
     def ready(self):
         super(WorkerGroup, self).ready()
@@ -192,13 +201,15 @@ class WorkerGroup(Worker):
         for t in self.threads:
             t.daemon = True
             t.start()
-        super(WorkerGroup, self).run()
+        try:
+            super(WorkerGroup, self).run()
+        except StopWorkerGroupLoop:
+            pass
         if self.stop_gracefully:
             self.wait_for_workers()
 
     def wait_for_workers(self):
-        while self.in_job or any(
-                self.threads[worker_id].is_alive() and
-                self.workers[worker_id].in_job
-                for worker_id in range(len(self.workers))):
+        while any(self.threads[worker_id].is_alive() and
+                  self.workers[worker_id].in_job
+                  for worker_id in range(len(self.workers))):
             time.sleep(0.1)

--- a/channels/worker.py
+++ b/channels/worker.py
@@ -93,11 +93,11 @@ class Worker(object):
         while not self.termed:
             self.in_job = False
             channel, content = self.channel_layer.receive_many(channels, block=True)
-            self.in_job = True
             # If no message, stall a little to avoid busy-looping then continue
             if channel is None:
                 time.sleep(0.01)
                 continue
+            self.in_job = True
             # Create message wrapper
             logger.debug("Got message on %s (reply %s)", channel, content.get("reply_channel", "none"))
             message = Message(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -129,7 +129,10 @@ class WorkerGroupTests(ChannelTestCase):
         worker_group_t.start()
         # wait when a worker starts the callback and terminate the worker group
         callback_is_running.wait()
-        self.assertRaises(StopWorkerGroupLoop, worker_group.sigterm_handler, None, None)
+        try:
+            worker_group.sigterm_handler(None, None)
+        except StopWorkerGroupLoop:
+            pass
         self.assertTrue(callback_is_stopped.wait(1))
         worker_group_t.join()
         for worker_id in range(len(worker_group.workers)):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2,9 +2,11 @@ from __future__ import unicode_literals
 
 import time
 import threading
+from contextlib import contextmanager
 
+from asgiref.inmemory import ChannelLayer as InMemoryChannelLayer
 from channels import DEFAULT_CHANNEL_LAYER, Channel, route
-from channels.asgi import channel_layers
+from channels.asgi import channel_layers, ChannelLayerWrapper
 from channels.exceptions import ConsumeLater
 from channels.test import ChannelTestCase
 from channels.worker import Worker, WorkerGroup, StopWorkerGroupLoop
@@ -98,45 +100,118 @@ class WorkerTests(ChannelTestCase):
         self.assertEqual(channel_layer.send.call_count, 0)
 
 
+@contextmanager
+def test_channel_layer(name):
+    """Setup test channel to apply custom routing."""
+    test_layer = ChannelLayerWrapper(
+        channel_layer=InMemoryChannelLayer(),
+        alias=name, routing=[],
+    )
+    old_layer = channel_layers.set(name, test_layer)
+    yield test_layer
+    channel_layers.set(name, old_layer)
+
+
+@contextmanager
+def test_worker_group(layer, n_threads, callback=None):
+    """Setup test worker group and validate it's finished."""
+    worker_group = WorkerGroup(layer,
+                               n_threads=n_threads,
+                               signal_handlers=False,
+                               stop_gracefully=True,
+                               callback=callback)
+    worker_group_t = threading.Thread(target=worker_group.run)
+    worker_group_t.daemon = True
+    worker_group_t.start()
+    yield worker_group
+    worker_group_t.join()
+    for worker_id in range(len(worker_group.workers)):
+        assert worker_group.workers[worker_id].in_job is False
+        assert worker_group.threads[worker_id].is_alive() is False
+
+
 class WorkerGroupTests(ChannelTestCase):
 
-    def test_graceful_stop(self):
-        """
-        Test that worker group is stopped gracefully on termination signal:
-        it should finish processing current messages and exit.
-        """
+    CALLBACK_TIME_LIMIT = 1  # seconds
 
-        callback_is_running = threading.Event()
-        callback_is_stopped = threading.Event()
+    def _tracked_callback(self):
+        """
+        Helper to create a callback with tracking logic based on events:
+        it allows to wait for callback start and check that it's completed.
+        """
+        is_running = threading.Event()
+        is_stopped = threading.Event()
 
         def callback(channel, message):
-            callback_is_running.set()
+            is_running.set()
             # emulate some delay to validate graceful stop
             time.sleep(0.1)
-            callback_is_stopped.set()
+            is_stopped.set()
 
-        consumer = mock.Mock()
-        Channel('test').send({'test': 'test'}, immediately=True)
-        channel_layer = channel_layers[DEFAULT_CHANNEL_LAYER]
-        channel_layer.router.add_route(route('test', consumer))
-        old_send = channel_layer.send
-        channel_layer.send = mock.Mock(side_effect=old_send)  # proxy 'send' for counting
-        worker_group = WorkerGroup(channel_layer, n_threads=3,
-                                   signal_handlers=False, stop_gracefully=True,
-                                   callback=callback)
-        worker_group_t = threading.Thread(target=worker_group.run)
-        worker_group_t.daemon = True
-        worker_group_t.start()
-        # wait when a worker starts the callback and terminate the worker group
-        callback_is_running.wait()
-        try:
-            worker_group.sigterm_handler(None, None)
-        except StopWorkerGroupLoop:
-            pass
-        self.assertTrue(callback_is_stopped.wait(1))
-        worker_group_t.join()
-        for worker_id in range(len(worker_group.workers)):
-            self.assertFalse(worker_group.workers[worker_id].in_job)
-            self.assertFalse(worker_group.threads[worker_id].is_alive())
-        self.assertEqual(consumer.call_count, 1)
-        self.assertEqual(channel_layer.send.call_count, 0)
+        return callback, (is_running, is_stopped)
+
+    def test_graceful_stop_when_main_worker_is_idle(self):
+        """
+        Test to stop a worker group when main worker is idle, there must be
+        an exception to break main loop.
+        """
+        with test_channel_layer('test') as channel_layer:
+            with test_worker_group(channel_layer, n_threads=1) as worker_group:
+                self.assertRaises(StopWorkerGroupLoop,
+                                  worker_group.sigterm_handler, None, None)
+
+    def test_graceful_stop_when_waiting_for_main_worker(self):
+        """
+        Test to stop a worker group when main worker is processing a message.
+        SIGTERM handler shouldn't raise an exception allowing to finish
+        processing the message and exit gracefully.
+        """
+        callback, (cb_is_running, cb_is_stopped) = self._tracked_callback()
+
+        with test_channel_layer('test') as channel_layer:
+            Channel('test', alias='test').send({'test': 'test'}, immediately=True)
+            consumer = mock.Mock()
+            channel_layer.router.add_route(route('test', consumer))
+            # proxy 'send' for counting
+            channel_layer.send = mock.Mock(side_effect=channel_layer.send)
+
+            with test_worker_group(channel_layer, n_threads=1,
+                                   callback=callback) as worker_group:
+                self.assertTrue(cb_is_running.wait(self.CALLBACK_TIME_LIMIT))
+                # main worker processing msg, wait for it and exit gracefully
+                worker_group.sigterm_handler(None, None)
+                self.assertTrue(cb_is_stopped.wait(self.CALLBACK_TIME_LIMIT))
+
+            self.assertEqual(consumer.call_count, 1)
+            self.assertEqual(channel_layer.send.call_count, 0)
+
+    def test_graceful_stop_with_multiple_threads(self):
+        """
+        Test that the whole worker group is stopped gracefully on termination
+        signal: it should finish processing current messages and exit.
+        """
+        callback, (cb_is_running, cb_is_stopped) = self._tracked_callback()
+
+        with test_channel_layer('test') as channel_layer:
+            Channel('test', alias='test').send({'test': 'test'}, immediately=True)
+            consumer = mock.Mock()
+            channel_layer.router.add_route(route('test', consumer))
+            # proxy 'send' for counting
+            channel_layer.send = mock.Mock(side_effect=channel_layer.send)
+
+            with test_worker_group(channel_layer, n_threads=3,
+                                   callback=callback) as worker_group:
+                self.assertTrue(cb_is_running.wait(self.CALLBACK_TIME_LIMIT))
+                # sub-workers threads are started before main thread and most
+                # often pick the message, so main thread is idle on termination
+                # signal and causes raising StopWorkerGroupLoop, but that's not
+                # always the case and sometimes main thread picks the message
+                # and exception is not raised.
+                try:
+                    worker_group.sigterm_handler(None, None)
+                except StopWorkerGroupLoop:
+                    pass
+                self.assertTrue(cb_is_stopped.wait(self.CALLBACK_TIME_LIMIT))
+
+            self.assertEqual(consumer.call_count, 1)
+            self.assertEqual(channel_layer.send.call_count, 0)


### PR DESCRIPTION
This PR is a follow-up to #790 to handle an important case when a worker group gets a termination signal while there's a message being processed by main thread: as of now it may lead to an infinite loop and rejection to stop because [the call](https://github.com/django/channels/blob/master/channels/worker.py#L176) blocks the main thread (`while self.in_job or ..`).

A proposed work-around is to raise an exception from a signal handler (if main thread is awaiting for next message, so `self.in_job is False`), catch it within main thread and gracefully wait for sub-worker threads. Otherwise if main thread is processing a message right now, it will finish the processing step, exit from the main loop and end in a similar way.

@andrewgodwin @proofit404 Let me know what do you think, my deep apologises I didn't spot it before.