### PR TITLE
Fix issues surrounding multiplexers

### DIFF
--- a/channels/consumer.py
+++ b/channels/consumer.py
@@ -83,8 +83,7 @@ class SyncConsumer(AsyncConsumer):
 
     _sync = True
 
-    @sync_to_async
-    def dispatch(self, message):
+    async def dispatch(self, message):
         """
         Dispatches incoming messages to type-based handlers asynchronously.
         """


### PR DESCRIPTION
Very rough. Not suitable for merging yet. Some known problems.

Perhaps the biggest change is that I try to keep an instance for each consumer class recorded for each consumer instance, so it is possible to store per connection state variables.

In particular, if there are multiple consumers and they are derived from `WebsocketConsumer`, each one will call `accept()` when `connect()` is called. This is invalid, we can only call `accept()` once. 

This change also sets the `base_send` method in the consumer. This was so the call the `accept()` wouldn't crash when it tries to send the acceptance packet. This feels like the wrong solution to me.

I am wondering if maybe we need a new base class for multiplexer consumers, as a lot of the functionality for `WebsocketConsumer` is not really relevant anymore (at least in this implementation). Especially the sending stuff.

In my code, I have overridden the `connect()` method of the consumers not to call its super method. It works, but I don't consider this a good solution.

I also feel uncomfortable removing the error conditions on calling the `send()` and `group_send()` methods in the `Demultiplexer`, however, these methods are currently used for sending responses (assuming I have understood how to do this correctly).

I haven't extensively tested this yet to ensure it does the right thing, but it does seem to run without errors now. :-)

Still needed, but not implemented:

* Ability find Django user associated with websocket.
* Identical stuff with async.