### PR TITLE
Use serializer better on bindings (a.k.a. rename "data" to "fields" on data binding)

### DIFF
--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -92,7 +92,7 @@ class WebsocketBinding(Binding):
         body = json.loads(message['text'])
         action = body['action']
         pk = body.get('pk', None)
-        data = body.get('data', None)
+        data = body.get('fields', None)
         return action, pk, data
 
     def _hydrate(self, pk, data):

--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -41,12 +41,8 @@ class WebsocketBinding(Binding):
         return WebsocketMultiplexer.encode(stream, payload)
 
     def serialize(self, instance, action):
-        payload = {
-            "action": action,
-            "pk": instance.pk,
-            "data": self.serialize_data(instance),
-            "model": self.model_label,
-        }
+        payload = self.serialize_data(instance)
+        payload["action"] = action
         return payload
 
     def serialize_data(self, instance):
@@ -60,8 +56,7 @@ class WebsocketBinding(Binding):
                 fields = self.fields
         else:
             fields = [f.name for f in instance._meta.get_fields() if f.name not in self.exclude]
-        data = serializers.serialize('json', [instance], fields=fields)
-        return json.loads(data)[0]['fields']
+        return serializers.serialize('python', [instance], fields=fields)[0]
 
     # Inbound
     @classmethod

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -36,11 +36,11 @@ class TestsBinding(ChannelTestCase):
         received = client.receive()
         self.assertTrue('payload' in received)
         self.assertTrue('action' in received['payload'])
-        self.assertTrue('data' in received['payload'])
-        self.assertTrue('username' in received['payload']['data'])
-        self.assertTrue('email' in received['payload']['data'])
-        self.assertTrue('password' in received['payload']['data'])
-        self.assertTrue('last_name' in received['payload']['data'])
+        self.assertTrue('fields' in received['payload'])
+        self.assertTrue('username' in received['payload']['fields'])
+        self.assertTrue('email' in received['payload']['fields'])
+        self.assertTrue('password' in received['payload']['fields'])
+        self.assertTrue('last_name' in received['payload']['fields'])
         self.assertTrue('model' in received['payload'])
         self.assertTrue('pk' in received['payload'])
 
@@ -48,10 +48,10 @@ class TestsBinding(ChannelTestCase):
         self.assertEqual(received['payload']['model'], 'auth.user')
         self.assertEqual(received['payload']['pk'], user.pk)
 
-        self.assertEqual(received['payload']['data']['email'], 'test@test.com')
-        self.assertEqual(received['payload']['data']['username'], 'test')
-        self.assertEqual(received['payload']['data']['password'], '')
-        self.assertEqual(received['payload']['data']['last_name'], '')
+        self.assertEqual(received['payload']['fields']['email'], 'test@test.com')
+        self.assertEqual(received['payload']['fields']['username'], 'test')
+        self.assertEqual(received['payload']['fields']['password'], '')
+        self.assertEqual(received['payload']['fields']['last_name'], '')
 
         received = client.receive()
         self.assertIsNone(received)
@@ -78,8 +78,8 @@ class TestsBinding(ChannelTestCase):
         received = client.receive()
         self.assertTrue('payload' in received)
         self.assertTrue('action' in received['payload'])
-        self.assertTrue('data' in received['payload'])
-        self.assertTrue('name' in received['payload']['data'])
+        self.assertTrue('fields' in received['payload'])
+        self.assertTrue('name' in received['payload']['fields'])
         self.assertTrue('model' in received['payload'])
         self.assertTrue('pk' in received['payload'])
 
@@ -87,7 +87,7 @@ class TestsBinding(ChannelTestCase):
         self.assertEqual(received['payload']['model'], 'tests.testuuidmodel')
         self.assertEqual(received['payload']['pk'], str(instance.pk))
 
-        self.assertEqual(received['payload']['data']['name'], 'testname')
+        self.assertEqual(received['payload']['fields']['name'], 'testname')
 
         received = client.receive()
         self.assertIsNone(received)
@@ -114,23 +114,23 @@ class TestsBinding(ChannelTestCase):
 
             self.assertTrue('payload' in received)
             self.assertTrue('action' in received['payload'])
-            self.assertTrue('data' in received['payload'])
-            self.assertTrue('username' in received['payload']['data'])
-            self.assertTrue('email' in received['payload']['data'])
-            self.assertTrue('password' in received['payload']['data'])
+            self.assertTrue('fields' in received['payload'])
+            self.assertTrue('username' in received['payload']['fields'])
+            self.assertTrue('email' in received['payload']['fields'])
+            self.assertTrue('password' in received['payload']['fields'])
             self.assertTrue('model' in received['payload'])
             self.assertTrue('pk' in received['payload'])
 
-            self.assertFalse('last_name' in received['payload']['data'])
-            self.assertFalse('first_name' in received['payload']['data'])
+            self.assertFalse('last_name' in received['payload']['fields'])
+            self.assertFalse('first_name' in received['payload']['fields'])
 
             self.assertEqual(received['payload']['action'], 'create')
             self.assertEqual(received['payload']['model'], 'auth.user')
             self.assertEqual(received['payload']['pk'], user.pk)
 
-            self.assertEqual(received['payload']['data']['email'], 'test@test.com')
-            self.assertEqual(received['payload']['data']['username'], 'test')
-            self.assertEqual(received['payload']['data']['password'], '')
+            self.assertEqual(received['payload']['fields']['email'], 'test@test.com')
+            self.assertEqual(received['payload']['fields']['username'], 'test')
+            self.assertEqual(received['payload']['fields']['password'], '')
 
             received = client.receive()
             self.assertIsNone(received)
@@ -174,11 +174,11 @@ class TestsBinding(ChannelTestCase):
         received = client.receive()
         self.assertTrue('payload' in received)
         self.assertTrue('action' in received['payload'])
-        self.assertTrue('data' in received['payload'])
-        self.assertTrue('username' in received['payload']['data'])
-        self.assertTrue('email' in received['payload']['data'])
-        self.assertTrue('password' in received['payload']['data'])
-        self.assertTrue('last_name' in received['payload']['data'])
+        self.assertTrue('fields' in received['payload'])
+        self.assertTrue('username' in received['payload']['fields'])
+        self.assertTrue('email' in received['payload']['fields'])
+        self.assertTrue('password' in received['payload']['fields'])
+        self.assertTrue('last_name' in received['payload']['fields'])
         self.assertTrue('model' in received['payload'])
         self.assertTrue('pk' in received['payload'])
 
@@ -186,10 +186,10 @@ class TestsBinding(ChannelTestCase):
         self.assertEqual(received['payload']['model'], 'auth.user')
         self.assertEqual(received['payload']['pk'], user.pk)
 
-        self.assertEqual(received['payload']['data']['email'], 'test@test.com')
-        self.assertEqual(received['payload']['data']['username'], 'test_new')
-        self.assertEqual(received['payload']['data']['password'], '')
-        self.assertEqual(received['payload']['data']['last_name'], '')
+        self.assertEqual(received['payload']['fields']['email'], 'test@test.com')
+        self.assertEqual(received['payload']['fields']['username'], 'test_new')
+        self.assertEqual(received['payload']['fields']['password'], '')
+        self.assertEqual(received['payload']['fields']['last_name'], '')
 
         received = client.receive()
         self.assertIsNone(received)
@@ -218,15 +218,15 @@ class TestsBinding(ChannelTestCase):
         received = client.receive()
         self.assertTrue('payload' in received)
         self.assertTrue('action' in received['payload'])
-        self.assertTrue('data' in received['payload'])
-        self.assertTrue('username' in received['payload']['data'])
+        self.assertTrue('fields' in received['payload'])
+        self.assertTrue('username' in received['payload']['fields'])
         self.assertTrue('model' in received['payload'])
         self.assertTrue('pk' in received['payload'])
 
         self.assertEqual(received['payload']['action'], 'delete')
         self.assertEqual(received['payload']['model'], 'auth.user')
         self.assertEqual(received['payload']['pk'], 1)
-        self.assertEqual(received['payload']['data']['username'], 'test')
+        self.assertEqual(received['payload']['fields']['username'], 'test')
 
         received = client.receive()
         self.assertIsNone(received)
@@ -260,7 +260,7 @@ class TestsBinding(ChannelTestCase):
                 'stream': 'users',
                 'payload': {
                     'action': CREATE,
-                    'data': {'username': 'test_inbound', 'email': 'test@user_steam.com'},
+                    'fields': {'username': 'test_inbound', 'email': 'test@user_steam.com'},
                 },
             })
 
@@ -298,7 +298,7 @@ class TestsBinding(ChannelTestCase):
             client.send_and_consume('websocket.connect', path='/')
             client.send_and_consume('websocket.receive', path='/', text={
                 'stream': 'users',
-                'payload': {'action': UPDATE, 'pk': user.pk, 'data': {'username': 'test_inbound'}}
+                'payload': {'action': UPDATE, 'pk': user.pk, 'fields': {'username': 'test_inbound'}}
             })
 
             user = User.objects.get(pk=user.pk)
@@ -308,7 +308,7 @@ class TestsBinding(ChannelTestCase):
             # trying change field that not in binding fields
             client.send_and_consume('websocket.receive', path='/', text={
                 'stream': 'users',
-                'payload': {'action': UPDATE, 'pk': user.pk, 'data': {'email': 'new@test.com'}}
+                'payload': {'action': UPDATE, 'pk': user.pk, 'fields': {'email': 'new@test.com'}}
             })
 
             user = User.objects.get(pk=user.pk)


### PR DESCRIPTION
I wanted to provide initial data from my web app using an "initial" stream like so:

```
class TodoBinding(WebsocketBinding):
    model = Todo
    stream = "todo"
    fields = ["id", "description", "is_done"]

    @classmethod
    def group_names(cls, instance):
        return ["todo"]

    def has_permission(self, user, action, pk):
        return True


class InitialDataConsumer(JsonWebsocketConsumer):
    def connect(self, message, multiplexer, **kwargs):
        todos = Todo.objects.all()
        serialized_todos = serializers.serialize(
            'python', 
            todos
        )
        multiplexer.send(serialized_todos)


class Demultiplexer(WebsocketDemultiplexer):
    consumers = {
        "initial": InitialDataConsumer,
        "todo": TodoBinding.consumer
    }

    def connection_groups(self):
        return ["todo"]

```

This way I would get data like this on connection:

```
{
    "stream": "initial", 
    "payload": [
        {
            "model": "todo.todo", 
            "pk": "<UUID-string>", 
            "fields": {
                "description": "Write some awesome apps using django channels.",
                "is_done": false
            }
        },
        ...
    ]
}
```

and like this on, for instance, creation of a todo:

```
{
	"stream": "todo", 
	"payload": {
		"model": "todo.todo", 
		"pk": "<UUID-string>", 
		"data": {
			"description": "New todo", 
			"is_done": false
		}, 
		"action": "create"
	}
}
```

The problem here is that the shape of the data is almost the same, only the name of "fields" and "data" differ.

So the patch is about making channels use serializers without renaming the fields key-value-pair and as a result hereof rename "data" to "fields" in both the outbound and inbound data format.

I might be overseeing something, so just shoot with questions and such :)