### PR TITLE
Add missing import in authentication example

### DIFF
--- a/docs/topics/authentication.rst
+++ b/docs/topics/authentication.rst
@@ -21,6 +21,8 @@ as a combined callable called ``AuthMiddlewareStack`` that includes all three.
 To use the middleware, wrap it around the appropriate level of consumer
 in your ``routing.py``::
 
+    from django.conf.urls import url
+    
     from channels.routing import ProtocolTypeRouter, URLRouter
     from channels.auth import AuthMiddlewareStack
 


### PR DESCRIPTION
`url` was not imported from `django.conf.urls` in the first authentication example in the docs, which seems like it was a mistake – the code doesn't work as-is.