### PR TITLE
Add Asyncio Childwatcher to main thread

### DIFF
--- a/channels/management/commands/runserver.py
+++ b/channels/management/commands/runserver.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import sys
 
@@ -38,6 +39,9 @@ class Command(RunserverCommand):
         # Check Channels is installed right
         if not hasattr(settings, "ASGI_APPLICATION"):
             raise CommandError("You have not set ASGI_APPLICATION, which is needed to run the server.")
+        # Init the asyncio child watcher
+        asyncio.get_event_loop()
+        asyncio.get_child_watcher()
         # Dispatch upward
         super().handle(*args, **options)
 


### PR DESCRIPTION
Hi,

I want to use asyncio.create_subprocess_exec which allows me to start processes and pass along its  output to a channel.
It does need a childwatcher which must be initialized in the main thread.
I added the code in the runserver.py for running it locally, can you merge it?

Thanks and best
Sven