### PR TITLE
Various docs fixes

### DIFF
--- a/docs/channel_layer_spec.rst
+++ b/docs/channel_layer_spec.rst
@@ -122,7 +122,7 @@ Asynchronous Support
 
 All channel layers must provide asynchronous (coroutine) methods for their
 primary endpoints. End-users will be able to achieve synchronous versions
-using the ``asyncio.sync.async_to_sync`` wrapper.
+using the ``asgiref.sync.async_to_sync`` wrapper.
 
 
 Groups

--- a/docs/topics/databases.rst
+++ b/docs/topics/databases.rst
@@ -26,7 +26,7 @@ call it with ``database_sync_to_async`` like so::
     from channels.db import database_sync_to_async
 
     async def connect(self):
-        self.username = database_sync_to_async(self.get_name)()
+        self.username = await database_sync_to_async(self.get_name)()
 
     def get_name(self):
         return User.objects.all()[0].name
@@ -36,7 +36,7 @@ You can also use it as a decorator::
     from channels.db import database_sync_to_async
 
     async def connect(self):
-        self.username = self.get_name()
+        self.username = await self.get_name()
 
     @database_sync_to_async
     def get_name(self):

--- a/docs/topics/testing.rst
+++ b/docs/topics/testing.rst
@@ -70,7 +70,7 @@ To send an event, call ``send_input``::
 
 To receive an event, call ``receive_output``::
 
-    event = communicator.receive_output(timeout=1)
+    event = await communicator.receive_output(timeout=1)
     assert event["type"] == "http.response.start"
 
 To wait for an application to exit (you'll need to either do this or wait for


### PR DESCRIPTION
Also [one-to-two.rst#group-objects](https://github.com/django/channels/blob/fc2fb74740c3d652ef89d06b691d011857e6a68e/docs/one-to-two.rst#group-objects) looks weird: as if AsyncConsumer and SyncConsumer were mixed.