### PR TITLE
Add StaticFilesWrapper to ChannelsLiveServerTestCase

### DIFF
--- a/channels/testing/live.py
+++ b/channels/testing/live.py
@@ -72,7 +72,7 @@ class ChannelsLiveServerTestCase(LiveServerTestCase):
 
     In order to serve static files create a subclass with serve_static = True.
     """
-    
+
     server_thread_class = DaphneServerThread
     static_wrapper = StaticFilesWrapper
     serve_static = False
@@ -89,4 +89,4 @@ class ChannelsLiveServerTestCase(LiveServerTestCase):
             application,
             connections_override=connections_override,
             port=cls.port,
-    )
+        )

--- a/channels/testing/live.py
+++ b/channels/testing/live.py
@@ -6,12 +6,17 @@ from daphne.endpoints import build_endpoint_description_strings
 from daphne.server import Server
 
 from ..routing import get_default_application
+from ..staticfiles import StaticFilesWrapper
 
 
 class DaphneServerThread(LiveServerThread):
     """
     LiveServerThread subclass that runs Daphne
     """
+
+    def __init__(self, host, application, *args, **kwargs):
+        self.application = application
+        super().__init__(host, None, *args, **kwargs)
 
     def run(self):
         """
@@ -46,7 +51,7 @@ class DaphneServerThread(LiveServerThread):
     def _create_server(self):
         endpoints = build_endpoint_description_strings(host=self.host, port=self._port)
         return Server(
-            application=get_default_application(),
+            application=self.application,
             endpoints=endpoints,
             signal_handlers=False,
             ws_protocols=getattr(settings, "CHANNELS_WS_PROTOCOLS", None),
@@ -62,5 +67,26 @@ class DaphneServerThread(LiveServerThread):
 
 
 class ChannelsLiveServerTestCase(LiveServerTestCase):
+    """
+    Drop-in replacement for Django's LiveServerTestCase.
 
+    In order to serve static files create a subclass with serve_static = True.
+    """
+    
     server_thread_class = DaphneServerThread
+    static_wrapper = StaticFilesWrapper
+    serve_static = False
+
+    @classmethod
+    def _create_server_thread(cls, connections_override):
+        if cls.serve_static:
+            application = cls.static_wrapper(get_default_application())
+        else:
+            application = get_default_application()
+
+        return cls.server_thread_class(
+            cls.host,
+            application,
+            connections_override=connections_override,
+            port=cls.port,
+    )

--- a/docs/topics/testing.rst
+++ b/docs/topics/testing.rst
@@ -226,3 +226,10 @@ standard Django ``LiveServerTestCase``::
 
         def test_live_stuff(self):
             call_external_testing_thing(self.live_server_url)
+
+serve_static
+~~~~~~~~~~~~
+
+Subclass ``ChannelsLiveServerTestCase`` with ``serve_static = True`` in order
+to serve static files (comparable to Django's ``StaticLiveServerTestCase``, you
+don't need to run collectstatic before or as a part of your tests setup).


### PR DESCRIPTION
This fixes #880

**Some notes:**

Maybe it is better to serve static files by default because you will need it in most cases in order to serve some JavaScript library.

I didn't check `apps.is_installed("django.contrib.staticfiles")` because I think you will use static files in your tests only if you installed `staticfiles`. Or shall I raise an `ImproperlyConfigured` if you try to serve static files in the tests without installed `staticfiles` before?

I tried to copy the tests in question from Django but I saw that there are multiple files involved. Therefore I stopped my efforts to include them in this PR.