### PR TITLE
[WIP] Re implement de-multiplexing #825

### DIFF
--- a/channels/generic/multiplexer.py
+++ b/channels/generic/multiplexer.py
@@ -1,0 +1,322 @@
+import asyncio
+import logging
+from functools import partial
+from typing import Any, Dict
+
+from channels.consumer import get_handler_name
+from channels.exceptions import StopConsumer
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncJsonWebsocketDemultiplexer(AsyncJsonWebsocketConsumer):
+
+    """
+    JSON-understanding WebSocket consumer subclass that handles demultiplexing
+    streams using a "stream" key in a top-level dict and the actual payload
+    in a sub-dict called "payload". This lets you run multiple streams over
+    a single WebSocket connection in a standardised way.
+    Incoming messages on streams are dispatched to consumers so you can
+    just tie in consumers the normal way.
+
+    Set a mapping of streams to an application classes in the "applications"
+    keyword.
+    """
+
+    # timeout in seconds after close used before killing child applications.
+    application_close_timeout = 10
+
+    # the mapping of applications by stream_name
+    applications = {}  # type: Dict[str: 'typing.Type'[channels.consumer.AsyncConsumer]]
+
+    def __init__(self, scope: Dict[str, Any]):
+        super().__init__(scope)
+        self.stream_upstream_queues = {}  # type: Dict[str, asyncio.Queue]
+        self.accepted_upstream_stream = set()
+        self.disconnecting = False
+        self.sent_close = False
+        self._task_monitors = None  # type: typing.Optional[asyncio.Task]
+
+    # Methods to INTERCEPT Client -> Stream Applications
+
+    async def websocket_connect(self, message):
+        """
+        Connect and then inform each stream application.
+        """
+        await super().websocket_connect(message)
+        for queue in self.stream_upstream_queues.values():
+            queue.put_nowait(message)
+
+    async def websocket_disconnect(self, message):
+        """
+        Handle when the connection is lost.
+        """
+
+        # set the disconnecting so that we know to to send frames further down.
+        self.disconnecting = True
+
+        for stream_name, queue in self.stream_upstream_queues.items():
+            # inform all upstream applications that the connection is going
+            #  down (this includes ones that never accepted!)
+            queue.put_nowait(message)
+
+        if self._task_monitors is None:
+            await super().websocket_disconnect(message)
+            return
+
+        try:
+            # wait for all the upstream applications to close down
+            await asyncio.wait_for(
+                self._task_monitors,
+                timeout=self.application_close_timeout
+            )
+        except asyncio.TimeoutError:
+            # they did not close down fast enough!
+            # not to worry they will be killed very soon.
+            logger.warning(
+                "One or more child application stream of %r took too long to "
+                "shut down and was killed.",
+                self,
+            )
+        # the `disconnect` method on the de-multiplexer is called after
+        # all upstream applications have stopped or the timeout has passed
+        #  (whatever is faster).
+        await super().websocket_disconnect(message)
+
+    async def receive_json(self, content, **kwargs):
+        """
+        Rout the message down the correct stream.
+        """
+        # Check the frame looks good
+        if isinstance(content, dict) and "stream" in content and "payload" in content:
+            # Match it to a channel
+            stream_name = content["stream"]
+            try:
+                stream_queue = await self._get_stream_queue(stream_name)
+
+            except ValueError:
+                raise ValueError(
+                    "Invalid multiplexed frame received (stream not mapped)"
+                )
+
+            payload = content["payload"]
+
+            # send it on to the application that handles this stream
+            stream_queue.put_nowait(
+                {
+                    "type": "websocket.receive",
+                    "text": await self.encode_json(payload)
+                }
+            )
+            return
+
+        else:
+            raise ValueError("Invalid multiplexed **frame received (no channel/payload key)")
+
+    # Methods to INTERCEPT Stream Applications -> Client
+
+    async def websocket_send(self, message: Dict[str, Any], stream_name: str):
+        """
+        Capture downstream websocket.send messages from the stream applications.
+        """
+        text = message.get("text")
+        # todo what to do on binary!
+
+        json = await self.decode_json(text)
+        data = {
+            "stream": stream_name,
+            "payload": json
+        }
+
+        await self.send_json(data)
+
+    async def websocket_accept(self, message: Dict[str, Any], stream_name: str):
+        """
+        Intercept streams accepting the websocket connection and add them to
+        the set of accepted upstream streams.
+
+        An upstream Application must accept before messages will be
+        forwarded onto it.
+        """
+        self.accepted_upstream_stream.add(stream_name)
+
+    async def websocket_close(self, message: Dict[str, Any], stream_name: str):
+        """
+        Handle the downstream websocket.close message from a stream
+        application.
+        """
+        # just remove the stream from the set of open streams
+        self.accepted_upstream_stream.remove(stream_name)
+        # we don't cancel the task here, that will happen later.
+        # (when the main connection is closed).
+        # the application task could still send messages
+        # if it sends `websocket.accept` it will also start to recived messages
+        # again.
+        await self.close(code=message.get("code", None))
+
+    # De-multiplexing methods
+
+    async def __call__(self, receive, send):
+        """
+        Set up applications for each stream and set up self.
+        """
+        self.stream_upstream_queues, stream_tasks = await self._init_stream_applications()
+
+        # use gather here since we want to die as soon as any one raises
+        # an exception.
+
+        self._task_monitors = asyncio.gather(
+            *[self._monitor_task(name, task) for name, task in
+             stream_tasks.items()]
+        )
+
+        try:
+            # TODO this results in `Task was destroyed but it is pending!` sometimes
+
+            await asyncio.gather(
+                super().__call__(receive=receive, send=send),
+                self._task_monitors
+            )
+
+        finally:
+            try:
+                self._task_monitors.cancel()
+            finally:
+                # this might have raised an exception.
+                # cleanup stream applications
+                for task in stream_tasks.values():
+                    task.cancel()
+
+    async def _monitor_task(self, stream_name: str, task: asyncio.Task):
+        """
+        Monitor a stream application to detect if it raises an exception.
+        We need to wrap the task in this _monitor method so that we do not exit
+        on the first StopConsumer exception.
+        """
+        try:
+            await task
+        except StopConsumer:
+            # unlikely to come here since this would only happen if
+            # 'StopConsumer' is raised either before or after the
+            # `await_many_dispatch` in the __call__ but might sometimes happen.
+            if stream_name in self.stream_upstream_queues:
+                # remove this stream from the possible upstream streams.
+                if stream_name in self.accepted_upstream_stream:
+                    self.accepted_upstream_stream.remove(stream_name)
+                # remove queue as well the task is no longer running after all.
+                del self.stream_upstream_queues[stream_name]
+
+                await self.close()
+
+        except asyncio.CancelledError:
+            # the task was.
+            if stream_name in self.accepted_upstream_stream:
+                self.accepted_upstream_stream.remove(stream_name)
+
+            del self.stream_upstream_queues[stream_name]
+
+            await self.close()
+
+        except Exception as e:
+
+            # if we have already received a 'websocket.disconnect'
+            if not self.disconnecting:
+                # https://tools.ietf.org/html/rfc6455#section-7.1.5
+                # 1011 indicates that a server is terminating the connection because
+                # it encountered an unexpected condition that prevented it from
+                # fulfilling the request.
+                await self.close(1011, force=True)
+            # re raise the exception this will kill everything!
+            raise e
+        else:
+            # If an application ends with StopConsumer while inside of
+            # `await_many_dispatch` this is not re-raised in __call__
+            # so we end up here without any exception
+            if stream_name in self.accepted_upstream_stream:
+                self.accepted_upstream_stream.remove(stream_name)
+            del self.stream_upstream_queues[stream_name]
+
+            await self.close()
+
+    async def _multiplexing_send(self,
+                                 message: Dict[str, Any],
+                                 stream_name: str):
+        """
+        Called by stream applications when they `base_send(message)`.
+
+        if message.type matches a method of this De-multiplexer this method
+        will be called otherwise message will be passed directly up the
+        application stack.
+        """
+        handler = getattr(self, get_handler_name(message), None)
+
+        if handler:
+            await handler(message, stream_name=stream_name)
+        else:
+            await self.base_send(message)
+
+    async def _init_stream_applications(self) -> (
+            Dict[str, asyncio.Queue], Dict[str, asyncio.Task]):
+        """
+        Create instances for each stream application and return a mapped set of
+         upstream queues/tasks.
+        """
+        queues = {}  # type: Dict[str, asyncio.Queue]
+        tasks = {}  # type: Dict[str, asyncio.Task]
+
+        for (stream_name, application_class) in self.applications.items():
+            # Make an instance of the application
+
+            queue = asyncio.Queue()
+            application_instance = application_class(self.scope)
+
+            # Run it, and stash the future for later checking
+            stream_future = application_instance(
+                receive=queue.get,
+                send=partial(
+                    self._multiplexing_send,
+                    stream_name=stream_name
+                ),
+            )
+
+            tasks[stream_name] = asyncio.ensure_future(stream_future)
+            queues[stream_name] = queue
+
+        return queues, tasks
+
+    async def _get_stream_queue(self, stream_name: str) -> asyncio.Queue:
+        """
+        Get the queue for a given stream, so that one can send a message
+         upstream.
+        """
+
+        if stream_name in self.stream_upstream_queues:
+            if stream_name in self.accepted_upstream_stream:
+                return self.stream_upstream_queues[stream_name]
+
+        # do not include the `stream_name` in the exception to avoid the
+        # injection of bad strings from users into logs, this could result in
+        # a possible security issues depending on how logs are parsed later on.
+
+        raise ValueError(
+            "No child stream application for this lookup,"
+        )
+
+    async def close(self, code=None, force=False):
+        """
+        Send close command. This will not be sent if:
+        a) we have already sent it
+        b) we have already received a `websocket_disconnect` message
+        c) there is at least one upstream stream that is still open.
+
+        but if `force` is set it will still send the close command regardless.
+        """
+
+        if (len(self.accepted_upstream_stream) > 0 or self.sent_close or
+                self.disconnecting) and not force:
+            return
+
+        self.sent_close = True
+
+        await super().close(code=code)

--- a/channels/generic/websocket.py
+++ b/channels/generic/websocket.py
@@ -2,9 +2,8 @@ import asyncio
 import json
 from typing import Any, Dict
 
-from channels.generic.multiplexer import Demultiplexer
-
 from asgiref.sync import async_to_sync
+from channels.generic.multiplexer import Demultiplexer
 
 from ..consumer import AsyncConsumer, SyncConsumer
 from ..exceptions import AcceptConnection, DenyConnection, InvalidChannelLayerError, StopConsumer

--- a/channels/generic/websocket.py
+++ b/channels/generic/websocket.py
@@ -1,4 +1,8 @@
+import asyncio
 import json
+from typing import Any, Dict
+
+from channels.generic.multiplexer import Demultiplexer
 
 from asgiref.sync import async_to_sync
 
@@ -274,3 +278,89 @@ class AsyncJsonWebsocketConsumer(AsyncWebsocketConsumer):
     @classmethod
     async def encode_json(cls, content):
         return json.dumps(content)
+
+
+class AsyncJsonWebsocketDemultiplexer(Demultiplexer, AsyncJsonWebsocketConsumer):
+
+    """
+    JSON-understanding WebSocket consumer subclass that handles de-multiplexing
+    streams using a "stream" key in a top-level dict and the actual payload
+    in a sub-dict called "payload". This lets you run multiple streams over
+    a single WebSocket connection in a standardised way.
+    Incoming messages on streams are dispatched to consumers so you can
+    just tie in consumers the normal way.
+    """
+
+    # Methods to INTERCEPT Client -> Stream Applications
+
+    application_close_timeout = 5
+
+    async def websocket_connect(self, message):
+        """
+        Connect and then inform each stream application.
+        """
+        await self.base_send({"type": "websocket.accept"})
+
+        await self.send_to_all_upstream(message)
+
+    async def receive_json(self, content, **kwargs):
+        """
+        Rout the message down the correct stream.
+        """
+        # Check the frame looks good
+        if isinstance(content, dict) and "stream" in content and "payload" in content:
+            # Match it to a channel
+
+            stream = content["stream"]
+            payload = content["payload"]
+
+            # send it on to the application that handles this stream
+            await self.send_upstream(
+                stream=stream,
+                message={
+                    "type": "websocket.receive",
+                    "text": await self.encode_json(payload)
+                }
+            )
+            return
+        else:
+            raise ValueError("Invalid multiplexed **frame received (no channel/payload key)")
+
+    # Methods to INTERCEPT Stream Applications -> Client
+
+    async def websocket_send(self, message: Dict[str, Any], stream_name: str):
+        """
+        Capture downstream websocket.send messages from the stream applications.
+        """
+        text = message.get("text")
+        # todo what to do on binary!
+
+        json = await self.decode_json(text)
+        data = {
+            "stream": stream_name,
+            "payload": json
+        }
+
+        await self.send_json(data)
+
+    async def websocket_accept(self, message: Dict[str, Any], stream_name: str):
+        """
+        do not send this on.
+        """
+        pass
+
+    async def websocket_disconnect(self, message):
+        await self.send_to_all_upstream(message)
+        try:
+            # wait for the children to die before calling the
+            # `disconnect method`
+            await asyncio.wait(
+                self._child_application_tasks.values(),
+                return_when=asyncio.ALL_COMPLETED,
+                timeout=self.application_close_timeout
+            )
+        except TimeoutError:
+            # TODO warning!
+            pass
+
+        await super().websocket_disconnect(message)

--- a/channels/utils.py
+++ b/channels/utils.py
@@ -36,7 +36,7 @@ async def await_many_dispatch(consumer_callables, dispatch):
     tasks = [
         asyncio.ensure_future(consumer_callable())
         for consumer_callable in consumer_callables
-    ]
+    ]  # type: typing.List[asyncio.Task]
     try:
         while True:
             # Wait for any of them to complete
@@ -50,4 +50,9 @@ async def await_many_dispatch(consumer_callables, dispatch):
     finally:
         # Make sure we clean up tasks on exit
         for task in tasks:
-            task.cancel()
+            # this is a nasty hack :( seems like the run-loop sometimes closes
+            #  before we get here.
+            try:
+                task.cancel()
+            except RuntimeError:
+                pass

--- a/tests/test_multiplexer.py
+++ b/tests/test_multiplexer.py
@@ -1,0 +1,308 @@
+import asyncio
+
+import pytest
+
+from channels.generic.multiplexer import AsyncJsonWebsocketDemultiplexer
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+from channels.testing import WebsocketCommunicator
+
+
+class EchoTestConsumer(AsyncJsonWebsocketConsumer):
+
+    async def receive_json(self, content=None, **kwargs):
+        await self.send_json(content)
+
+
+class AltEchoTestConsumer(AsyncJsonWebsocketConsumer):
+
+    async def receive_json(self, content=None, **kwargs):
+        await self.send_json({"received": content, "alt_value": 123})
+
+
+class EchoCloseAfterFirstTestConsumer(AsyncJsonWebsocketConsumer):
+
+    async def receive_json(self, content=None, **kwargs):
+        await self.send_json(content)
+        await self.close()
+
+
+class NeverAcceptTestConsumer(AsyncJsonWebsocketConsumer):
+    async def websocket_connect(self, message):
+        pass
+
+
+class RaiseInAcceptTestConsumer(AsyncJsonWebsocketConsumer):
+    async def websocket_connect(self, message):
+        raise ValueError("Test my error")
+
+
+class EchoDemultiplexerAsyncJson(AsyncJsonWebsocketDemultiplexer):
+    applications = {
+        "echostream": EchoTestConsumer,
+        "altechostream": AltEchoTestConsumer,
+        "closeafterfirst": EchoCloseAfterFirstTestConsumer,
+        "neveraccept": NeverAcceptTestConsumer,
+    }
+
+
+class RaiseInAcceptDemultiplexerAsyncJson(AsyncJsonWebsocketDemultiplexer):
+    applications = {
+        "raiseinaccept": RaiseInAcceptTestConsumer
+    }
+
+
+@pytest.mark.asyncio
+async def test_stream_routing():
+
+    communicator = WebsocketCommunicator(
+        EchoDemultiplexerAsyncJson,
+        "/"
+    )
+
+    connected, _ = await communicator.connect()
+    assert connected
+
+    # Test sending
+    await communicator.send_json_to(
+        {
+            "stream": "echostream",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "stream": "echostream",
+        "payload": {"hello": "world"}
+    }
+
+    # Test sending
+    await communicator.send_json_to(
+        {
+            "stream": "altechostream",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "stream": "altechostream",
+        "payload": {"alt_value": 123, "received": {"hello": "world"}}
+    }
+
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_stream_routing_not_listed():
+
+    communicator = WebsocketCommunicator(
+        EchoDemultiplexerAsyncJson,
+        "/"
+    )
+
+    connected, _ = await communicator.connect()
+    assert connected
+
+    # Test sending
+    await communicator.send_json_to(
+        {
+            "stream": "notlisted",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    message = await communicator.receive_output()
+
+    assert message == {
+        "type": "websocket.close"
+    }
+
+    with pytest.raises(ValueError, message="Invalid multiplexed frame received (stream not mapped)"):
+        await communicator.wait()
+
+
+@pytest.mark.asyncio
+async def test_stream_no_payload():
+
+    communicator = WebsocketCommunicator(
+        EchoDemultiplexerAsyncJson,
+        "/"
+    )
+
+    connected, _ = await communicator.connect()
+    assert connected
+
+    # Test sending
+    await communicator.send_json_to(
+        {
+            "stream": "echostream",
+            "no_payload": {"hello": "world"}
+        }
+    )
+
+    message = await communicator.receive_output()
+
+    assert message == {
+        "type": "websocket.close"
+    }
+
+    with pytest.raises(ValueError, message="Invalid multiplexed **frame received (no channel/payload key)"):
+        await communicator.wait()
+
+
+@pytest.mark.asyncio
+async def test_stream_close():
+
+    communicator = WebsocketCommunicator(
+        EchoDemultiplexerAsyncJson,
+        "/"
+    )
+
+    connected, _ = await communicator.connect()
+    assert connected
+
+    # Test sending
+    await communicator.send_json_to(
+        {
+            "stream": "echostream",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "stream": "echostream",
+        "payload": {"hello": "world"}
+    }
+
+    await communicator.send_json_to(
+        {
+            "stream": "closeafterfirst",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "stream": "closeafterfirst",
+        "payload": {"hello": "world"}
+    }
+
+    # Test to a non closed endpoint
+    await communicator.send_json_to(
+        {
+            "stream": "echostream",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "stream": "echostream",
+        "payload": {"hello": "world"}
+    }
+
+    await communicator.send_json_to(
+        {
+            "stream": "closeafterfirst",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    message = await communicator.receive_output()
+
+    assert message == {
+        "type": "websocket.close"
+    }
+
+    with pytest.raises(
+            ValueError,
+            message="Invalid multiplexed frame received (stream not mapped)"):
+        await communicator.wait()
+
+
+@pytest.mark.asyncio
+async def test_stream_routing_neveraccept():
+
+    communicator = WebsocketCommunicator(
+        EchoDemultiplexerAsyncJson,
+        "/"
+    )
+
+    connected, _ = await communicator.connect()
+    assert connected
+
+    # Test sending
+    await communicator.send_json_to(
+        {
+            "stream": "neveraccept",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    message = await communicator.receive_output()
+
+    assert message == {
+        "type": "websocket.close"
+    }
+
+    with pytest.raises(ValueError, message="Invalid multiplexed frame received (stream not mapped)"):
+        await communicator.wait()
+
+
+@pytest.mark.asyncio
+async def test_stream_routing_raiseinaccept():
+
+    communicator = WebsocketCommunicator(
+        RaiseInAcceptDemultiplexerAsyncJson,
+        "/"
+    )
+
+    connected, _ = await communicator.connect()
+    assert connected
+
+    message = await communicator.receive_output()
+
+    assert message == {
+        "type": "websocket.close", "code": 1011
+    }
+
+    with pytest.raises(ValueError, message="Test my error"):
+        await communicator.wait()
+
+
+@pytest.mark.asyncio
+async def test_slow_disconnect():
+    results = {}
+
+    class TestConsumer(AsyncJsonWebsocketConsumer):
+        async def disconnect(self, code):
+            results["sleep_start"] = True
+            await asyncio.sleep(1)
+            results["sleep_end"] = True
+
+    class DemultiplexerAsyncJson(AsyncJsonWebsocketDemultiplexer):
+
+        # reduce timeout to make tests run faster.
+        application_close_timeout = 0.1
+
+        applications = {
+            "mystream": TestConsumer,
+        }
+
+    communicator = WebsocketCommunicator(DemultiplexerAsyncJson, "/testws/")
+
+    connected, _ = await communicator.connect()
+
+    assert connected
+
+    await communicator.disconnect()
+
+    assert "sleep_start" in results
+    assert "sleep_end" not in results

--- a/tests/test_multiplexer.py
+++ b/tests/test_multiplexer.py
@@ -1,9 +1,10 @@
 import asyncio
 
 import pytest
+from django.conf.urls import url
 
-from channels.generic.multiplexer import AsyncJsonWebsocketDemultiplexer
-from channels.generic.websocket import AsyncJsonWebsocketConsumer
+from channels.generic.websocket import AsyncJsonWebsocketConsumer, AsyncJsonWebsocketDemultiplexer
+from channels.routing import URLRouter
 from channels.testing import WebsocketCommunicator
 
 
@@ -41,7 +42,7 @@ class EchoDemultiplexerAsyncJson(AsyncJsonWebsocketDemultiplexer):
         "echostream": EchoTestConsumer,
         "altechostream": AltEchoTestConsumer,
         "closeafterfirst": EchoCloseAfterFirstTestConsumer,
-        "neveraccept": NeverAcceptTestConsumer,
+        "neveraccept": NeverAcceptTestConsumer
     }
 
 
@@ -114,14 +115,9 @@ async def test_stream_routing_not_listed():
         }
     )
 
-    message = await communicator.receive_output()
-
-    assert message == {
-        "type": "websocket.close"
-    }
-
-    with pytest.raises(ValueError, message="Invalid multiplexed frame received (stream not mapped)"):
-        await communicator.wait()
+    # We do not expect a response so we will timeout waiting for one.
+    with pytest.raises(asyncio.TimeoutError):
+        await communicator.receive_output()
 
 
 @pytest.mark.asyncio
@@ -142,12 +138,6 @@ async def test_stream_no_payload():
             "no_payload": {"hello": "world"}
         }
     )
-
-    message = await communicator.receive_output()
-
-    assert message == {
-        "type": "websocket.close"
-    }
 
     with pytest.raises(ValueError, message="Invalid multiplexed **frame received (no channel/payload key)"):
         await communicator.wait()
@@ -193,67 +183,13 @@ async def test_stream_close():
         "payload": {"hello": "world"}
     }
 
-    # Test to a non closed endpoint
-    await communicator.send_json_to(
-        {
-            "stream": "echostream",
-            "payload": {"hello": "world"}
-        }
-    )
-
-    response = await communicator.receive_json_from()
-
-    assert response == {
-        "stream": "echostream",
-        "payload": {"hello": "world"}
-    }
-
-    await communicator.send_json_to(
-        {
-            "stream": "closeafterfirst",
-            "payload": {"hello": "world"}
-        }
-    )
-
     message = await communicator.receive_output()
 
     assert message == {
         "type": "websocket.close"
     }
 
-    with pytest.raises(
-            ValueError,
-            message="Invalid multiplexed frame received (stream not mapped)"):
-        await communicator.wait()
-
-
-@pytest.mark.asyncio
-async def test_stream_routing_neveraccept():
-
-    communicator = WebsocketCommunicator(
-        EchoDemultiplexerAsyncJson,
-        "/"
-    )
-
-    connected, _ = await communicator.connect()
-    assert connected
-
-    # Test sending
-    await communicator.send_json_to(
-        {
-            "stream": "neveraccept",
-            "payload": {"hello": "world"}
-        }
-    )
-
-    message = await communicator.receive_output()
-
-    assert message == {
-        "type": "websocket.close"
-    }
-
-    with pytest.raises(ValueError, message="Invalid multiplexed frame received (stream not mapped)"):
-        await communicator.wait()
+    await communicator.disconnect()
 
 
 @pytest.mark.asyncio
@@ -267,13 +203,7 @@ async def test_stream_routing_raiseinaccept():
     connected, _ = await communicator.connect()
     assert connected
 
-    message = await communicator.receive_output()
-
-    assert message == {
-        "type": "websocket.close", "code": 1011
-    }
-
-    with pytest.raises(ValueError, message="Test my error"):
+    with pytest.raises(ValueError, match="Test my error"):
         await communicator.wait()
 
 
@@ -296,6 +226,18 @@ async def test_slow_disconnect():
             "mystream": TestConsumer,
         }
 
+        async def disconnect(self, code):
+            # check that this is called in the correct order!
+            if results.get("sleep_start") and results.get("sleep_end") is None:
+                results["de-multiplexer-disconnect-order"] = True
+
+        async def _child_application_closed(self, application_key: str):
+            """
+            This should not be called since the timeout runs over and thus
+            the child is force closed after the observation run loop
+            """
+            results["_child_application_closed_callback"] = True
+
     communicator = WebsocketCommunicator(DemultiplexerAsyncJson, "/testws/")
 
     connected, _ = await communicator.connect()
@@ -306,3 +248,128 @@ async def test_slow_disconnect():
 
     assert "sleep_start" in results
     assert "sleep_end" not in results
+    assert "de-multiplexer-disconnect-order" in results
+
+    assert "_child_application_closed_callback" not in results
+
+
+@pytest.mark.asyncio
+async def test_fast_disconnect():
+    results = {}
+
+    class TestConsumer(AsyncJsonWebsocketConsumer):
+        async def disconnect(self, code):
+            results["sleep_start"] = True
+            await asyncio.sleep(0.01)
+            results["sleep_end"] = True
+
+    class DemultiplexerAsyncJson(AsyncJsonWebsocketDemultiplexer):
+
+        # reduce timeout to make tests run faster.
+        application_close_timeout = 0.1
+
+        applications = {
+            "mystream": TestConsumer,
+        }
+
+        async def disconnect(self, code):
+            # check that this is called in the correct order!
+            if results.get("sleep_start") and results.get("sleep_end"):
+                results["de-multiplexer-disconnect-order"] = True
+
+        async def _child_application_closed(self, application_key: str):
+            """
+            This should be called since the timeout did not go over.
+            """
+            if results.get("sleep_start") and results.get("sleep_end"):
+                results["_child_application_closed_callback"] = True
+
+        # note since `disconnect` is on a different co-routine to
+        # `_child_application_closed` we cant assert relative the order of
+        # these!
+
+    communicator = WebsocketCommunicator(DemultiplexerAsyncJson, "/testws/")
+
+    connected, _ = await communicator.connect()
+
+    assert connected
+
+    await communicator.disconnect()
+
+    assert "sleep_start" in results
+    assert "sleep_end" in results
+    assert "de-multiplexer-disconnect-order" in results
+
+    assert "_child_application_closed_callback" in results
+
+
+@pytest.mark.asyncio
+async def test_nested_with_url_router():
+
+    class PathRoutedDemultiplexer(AsyncJsonWebsocketDemultiplexer):
+        applications = {
+            "pathfilter": URLRouter(
+                [
+                    url("^echo/?$", EchoTestConsumer),
+                    url("^altecho/?$", AltEchoTestConsumer),
+                ]
+            )
+        }
+
+    communicator = WebsocketCommunicator(
+        PathRoutedDemultiplexer,
+        "/test"
+    )
+
+    with pytest.raises(ValueError, match="No route found for path 'test'."):
+        await communicator.connect()
+
+    communicator = WebsocketCommunicator(
+        PathRoutedDemultiplexer,
+        "echo"
+    )
+
+    connected, _ = await communicator.connect()
+    assert connected
+
+    # Test sending
+    await communicator.send_json_to(
+        {
+            "stream": "pathfilter",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "stream": "pathfilter",
+        "payload": {"hello": "world"}
+    }
+
+    await communicator.disconnect()
+
+    communicator = WebsocketCommunicator(
+        PathRoutedDemultiplexer,
+        "altecho"
+    )
+
+    connected, _ = await communicator.connect()
+    assert connected
+
+    # Test sending
+    await communicator.send_json_to(
+        {
+            "stream": "pathfilter",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "stream": "pathfilter",
+        "payload": {"alt_value": 123, "received": {"hello": "world"}}
+    }
+
+    await communicator.disconnect()


### PR DESCRIPTION
This brings a version of de-multiplexing (for json websockets only) to v2. https://github.com/django/channels/issues/825

this adds 3 classes:

1) `class ApplicationWithChildren:`

(maybe we should find a better name)

this class managed the child Application coroutiens along side the Task/Dispatch for both the upstream and downstream queues for messages. 

2) `class Demultiplexer(ApplicationWithChildren):`

the base class for a `Demultiplexer`, compliant with ASGI application spec.

3) `class AsyncJsonWebsocketDemultiplexer(Demultiplexer, AsyncJsonWebsocketConsumer):`

this works as it used to (more or less, it now supports any valid JSON values for the `payload` since messages are in v2 passed within the same python thread so fewer limitations than before).

and example usage
```python
class MyDemultiplexer(AsyncJsonWebsocketDemultiplexer):
    applications = {
        "user": UserConsumer, 
        "posts": URLRouter([
            url("^/admin/$", AdminPostsConsumer),
            url("^/public/$", PublicPostsConsumer),
        ])
    }
```
---

There is an issue with the cleanup of tasks, https://github.com/hishnash/channels/blob/Re-Implement-Multiplexing-%23825/channels/utils.py#L54-L61  tasks are being cancelled even though the run loop is already closed. 

---

I still need to add Documentation before this is merged just wanted to check that this is a good approach to the problem before it put the time in for those bits.
