### PR TITLE
Add WebsocketConsumer group join/leave functionality

### DIFF
--- a/channels/generic/websocket.py
+++ b/channels/generic/websocket.py
@@ -89,7 +89,7 @@ class WebsocketConsumer(SyncConsumer):
         """
         if self.channel_layer:
             for group in self.groups:
-                async_to_sync(self.channel_layer.group_add)(group, self.channel_name)
+                async_to_sync(self.channel_layer.group_discard)(group, self.channel_name)
         self.disconnect(message["code"])
         raise StopConsumer()
 

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -5,13 +5,15 @@ import fnmatch
 import random
 import re
 import string
+import time
+from copy import deepcopy
 
 from django.conf import settings
 from django.utils.module_loading import import_string
 
 from channels import DEFAULT_CHANNEL_LAYER
 
-from .exceptions import InvalidChannelLayerError
+from .exceptions import ChannelFull, InvalidChannelLayerError
 
 
 class ChannelLayerManager:
@@ -174,12 +176,19 @@ class BaseChannelLayer:
 
 class InMemoryChannelLayer(BaseChannelLayer):
     """
-    In-memory channel layer implementation for testing purposes.
+    In-memory channel layer implementation
     """
+    local_poll_interval = 0.01
 
-    def __init__(self, *args, **kwargs):
-        super(InMemoryChannelLayer, self).__init__(*args, **kwargs)
+    def __init__(self, expiry=60, group_expiry=86400, capacity=100, channel_capacity=None, **kwargs):
+        super().__init__(expiry=expiry, capacity=capacity, channel_capacity=channel_capacity, **kwargs)
         self.channels = {}
+        self.groups = {}
+        self.group_expiry = group_expiry
+
+    ### Channel layer API ###
+
+    extensions = ["groups", "flush"]
 
     async def send(self, channel, message):
         """
@@ -190,12 +199,17 @@ class InMemoryChannelLayer(BaseChannelLayer):
         assert self.valid_channel_name(channel), "Channel name not valid"
         # If it's a process-local channel, strip off local part and stick full name in message
         assert "__asgi_channel__" not in message
-        if "!" in channel:
-            message = dict(message.items())
-            message["__asgi_channel__"] = channel
-            channel = self.non_local_name(channel)
-        # Store it in our channels list
-        self.channels.setdefault(channel, []).append(message)
+
+        queue = self.channels.setdefault(channel, asyncio.Queue())
+        # Are we full
+        if queue.qsize() >= self.capacity:
+            raise ChannelFull(channel)
+
+        # Add message
+        await queue.put((
+            time.time() + self.expiry,
+            deepcopy(message),
+        ))
 
     async def receive(self, channel):
         """
@@ -204,13 +218,18 @@ class InMemoryChannelLayer(BaseChannelLayer):
         of the waiting coroutines will get the result.
         """
         assert self.valid_channel_name(channel)
-        while True:
-            try:
-                message = self.channels.get(channel, []).pop(0)
-            except IndexError:
-                asyncio.sleep(0.01)
-            else:
-                return message
+        self._clean_expired()
+
+        queue = self.channels.setdefault(channel, asyncio.Queue())
+
+        # Do a plain direct receive
+        _, message = await queue.get()
+
+        # Delete if empty
+        if queue.empty():
+            del self.channels[channel]
+
+        return message
 
     async def new_channel(self, prefix="specific."):
         """
@@ -221,6 +240,91 @@ class InMemoryChannelLayer(BaseChannelLayer):
             prefix,
             "".join(random.choice(string.ascii_letters) for i in range(12)),
         )
+
+    ### Expire cleanup ###
+
+    def _clean_expired(self):
+        """
+        Goes through all messages and groups and removes those that are expired.
+        Any channel with an expired message is removed from all groups.
+        """
+        # Channel cleanup
+        for channel, queue in list(self.channels.items()):
+            remove = False
+            # See if it's expired
+            while not queue.empty() and queue._queue[0][0] < time.time():
+                queue.get_nowait()
+                remove = True
+            # Any removal prompts group discard
+            if remove:
+                self._remove_from_groups(channel)
+            # Is the channel now empty and needs deleting?
+            if not queue:
+                del self.channels[channel]
+
+        # Group Expiration
+        timeout = int(time.time()) - self.group_expiry
+        for group in self.groups:
+            for channel in self.groups.get(group, set()):
+                # If join time is older than group_expiry end the group membership
+                if self.groups[group][channel] and int(self.groups[group][channel]) < timeout:
+                    # Delete from group
+                    del self.groups[group][channel]
+
+    ### Flush extension ###
+
+    async def flush(self):
+        self.channels = {}
+        self.groups = {}
+
+    async def close(self):
+        # Nothing to go
+        pass
+
+    def _remove_from_groups(self, channel):
+        """
+        Removes a channel from all groups. Used when a message on it expires.
+        """
+        for channels in self.groups.values():
+            if channel in channels:
+                del channels[channel]
+
+    ### Groups extension ###
+
+    async def group_add(self, group, channel):
+        """
+        Adds the channel name to a group.
+        """
+        # Check the inputs
+        assert self.valid_group_name(group), "Group name not valid"
+        assert self.valid_channel_name(channel), "Channel name not valid"
+        # Add to group dict
+        self.groups.setdefault(group, {})
+        self.groups[group][channel] = time.time()
+
+    async def group_discard(self, group, channel):
+        # Both should be text and valid
+        assert self.valid_channel_name(channel), "Invalid channel name"
+        assert self.valid_group_name(group), "Invalid group name"
+        # Remove from group set
+        if group in self.groups:
+            if channel in self.groups[group]:
+                del self.groups[group][channel]
+            if not self.groups[group]:
+                del self.groups[group]
+
+    async def group_send(self, group, message):
+        # Check types
+        assert isinstance(message, dict), "Message is not a dict"
+        assert self.valid_group_name(group), "Invalid group name"
+        # Run clean
+        self._clean_expired()
+        # Send to each channel
+        for channel in self.groups.get(group, set()):
+            try:
+                await self.send(channel, message)
+            except ChannelFull:
+                pass
 
 
 def get_channel_layer(alias=DEFAULT_CHANNEL_LAYER):

--- a/docs/topics/channel_layers.rst
+++ b/docs/topics/channel_layers.rst
@@ -176,6 +176,8 @@ we could crawl the database), and use ``channel_layer.send``::
     })
 
 
+.. _groups:
+
 Groups
 ------
 

--- a/docs/topics/consumers.rst
+++ b/docs/topics/consumers.rst
@@ -155,6 +155,7 @@ wraps the verbose plain-ASGI message sending and receiving into handling that
 just deals with text and binary frames::
 
     class MyConsumer(WebsocketConsumer):
+        groups = ["broadcast"]
 
         def connect(self):
             # Called on connection. Either call
@@ -181,6 +182,16 @@ You can also raise ``channels.exceptions.AcceptConnection`` or
 method in order to accept or reject a connection, if you want reuseable
 authentication or rate-limiting code that doesn't need to use mixins.
 
+A ``WebsocketConsumer``'s channel will automatically be added to (on connect)
+and removed from (on disconnect) any groups whose names appear in the
+consumer's ``groups`` class attribute. ``groups`` must be an iterable, and a
+channel layer with support for groups must be set as the channel backend
+(``channels.layers.InMemoryChannelLayer`` and
+``channels_redis.core.RedisChannelLayer`` both support groups). If no channel
+layer is configured or the channel layer doesn't support groups, connecting
+to a ``WebsocketConsumer`` with a non-empty ``groups`` attribute will raise
+``channels.exceptions.InvalidChannelLayerError``. See :ref:`groups` for more.
+
 
 AsyncWebsocketConsumer
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -190,6 +201,7 @@ the exact same methods and signature as ``WebsocketConsumer`` but everything
 is async, and the functions you need to write have to be as well::
 
     class MyConsumer(AsyncWebsocketConsumer):
+        groups = ["broadcast"]
 
         async def connect(self):
             # Called on connection. Either call

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ setup(
             'pytest~=3.3',
             "pytest-django~=3.1",
             "pytest-asyncio~=0.8",
+            "async_generator~=1.8",
+            "async-timeout~=2.0",
             'coverage~=4.4',
         ],
     },

--- a/tests/test_generic_websocket.py
+++ b/tests/test_generic_websocket.py
@@ -1,8 +1,10 @@
 import pytest
+from django.test import override_settings
 
 from channels.generic.websocket import (
     AsyncJsonWebsocketConsumer, AsyncWebsocketConsumer, JsonWebsocketConsumer, WebsocketConsumer,
 )
+from channels.layers import get_channel_layer
 from channels.testing import WebsocketCommunicator
 
 
@@ -46,6 +48,39 @@ async def test_websocket_consumer():
 
 
 @pytest.mark.asyncio
+async def test_websocket_consumer_groups():
+    """
+    Tests that WebsocketConsumer adds and removes channels from groups.
+    """
+    results = {}
+
+    class TestConsumer(WebsocketConsumer):
+        groups = ["chat"]
+
+        def receive(self, text_data=None, bytes_data=None):
+            results["received"] = (text_data, bytes_data)
+            self.send(text_data=text_data, bytes_data=bytes_data)
+
+    channel_layers_setting = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+        },
+    }
+    with override_settings(CHANNEL_LAYERS=channel_layers_setting):
+        communicator = WebsocketCommunicator(TestConsumer, "/testws/")
+        await communicator.connect()
+
+        channel_layer = get_channel_layer()
+        message = {"type": "websocket.receive", "text": "hello"}
+        await channel_layer.group_send("chat", message)
+        response = await communicator.receive_from()
+        assert response == "hello"
+        assert results["received"] == ("hello", None)
+
+        await communicator.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_async_websocket_consumer():
     """
     Tests that AsyncWebsocketConsumer is implemented correctly.
@@ -82,6 +117,39 @@ async def test_async_websocket_consumer():
     # Close out
     await communicator.disconnect()
     assert "disconnected" in results
+
+
+@pytest.mark.asyncio
+async def test_async_websocket_consumer_groups():
+    """
+    Tests that AsyncWebsocketConsumer adds and removes channels from groups.
+    """
+    results = {}
+
+    class TestConsumer(AsyncWebsocketConsumer):
+        groups = ["chat"]
+
+        async def receive(self, text_data=None, bytes_data=None):
+            results["received"] = (text_data, bytes_data)
+            await self.send(text_data=text_data, bytes_data=bytes_data)
+
+    channel_layers_setting = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+        },
+    }
+    with override_settings(CHANNEL_LAYERS=channel_layers_setting):
+        communicator = WebsocketCommunicator(TestConsumer, "/testws/")
+        await communicator.connect()
+
+        channel_layer = get_channel_layer()
+        message = {"type": "websocket.receive", "text": "hello"}
+        await channel_layer.group_send("chat", message)
+        response = await communicator.receive_from()
+        assert response == "hello"
+        assert results["received"] == ("hello", None)
+
+        await communicator.disconnect()
 
 
 @pytest.mark.asyncio

--- a/tests/test_generic_websocket.py
+++ b/tests/test_generic_websocket.py
@@ -71,13 +71,15 @@ async def test_websocket_consumer_groups():
         await communicator.connect()
 
         channel_layer = get_channel_layer()
+        # Test that the websocket channel was added to the group on connect
         message = {"type": "websocket.receive", "text": "hello"}
         await channel_layer.group_send("chat", message)
         response = await communicator.receive_from()
         assert response == "hello"
         assert results["received"] == ("hello", None)
-
+        # Test that the websocket channel was discarded from the group on disconnect
         await communicator.disconnect()
+        assert channel_layer.groups == {}
 
 
 @pytest.mark.asyncio
@@ -143,13 +145,16 @@ async def test_async_websocket_consumer_groups():
         await communicator.connect()
 
         channel_layer = get_channel_layer()
+        # Test that the websocket channel was added to the group on connect
         message = {"type": "websocket.receive", "text": "hello"}
         await channel_layer.group_send("chat", message)
         response = await communicator.receive_from()
         assert response == "hello"
         assert results["received"] == ("hello", None)
 
+        # Test that the websocket channel was discarded from the group on disconnect
         await communicator.disconnect()
+        assert channel_layer.groups == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_inmemorychannel.py
+++ b/tests/test_inmemorychannel.py
@@ -1,0 +1,116 @@
+import asyncio
+
+import async_timeout
+import pytest
+from async_generator import async_generator, yield_
+
+from channels.exceptions import ChannelFull
+from channels.layers import InMemoryChannelLayer
+
+
+@pytest.fixture()
+@async_generator
+async def channel_layer():
+    """
+    Channel layer fixture that flushes automatically.
+    """
+    channel_layer = InMemoryChannelLayer(capacity=3)
+    await yield_(channel_layer)
+    await channel_layer.flush()
+    await channel_layer.close()
+
+
+@pytest.mark.asyncio
+async def test_send_receive(channel_layer):
+    """
+    Makes sure we can send a message to a normal channel then receive it.
+    """
+    await channel_layer.send(
+        "test-channel-1",
+        {
+            "type": "test.message",
+            "text": "Ahoy-hoy!",
+        },
+    )
+    message = await channel_layer.receive("test-channel-1")
+    assert message["type"] == "test.message"
+    assert message["text"] == "Ahoy-hoy!"
+
+
+@pytest.mark.asyncio
+async def test_send_capacity(channel_layer):
+    """
+    Makes sure we get ChannelFull when we hit the send capacity
+    """
+    await channel_layer.send("test-channel-1", {"type": "test.message"})
+    await channel_layer.send("test-channel-1", {"type": "test.message"})
+    await channel_layer.send("test-channel-1", {"type": "test.message"})
+    with pytest.raises(ChannelFull):
+        await channel_layer.send("test-channel-1", {"type": "test.message"})
+
+
+@pytest.mark.asyncio
+async def test_process_local_send_receive(channel_layer):
+    """
+    Makes sure we can send a message to a process-local channel then receive it.
+    """
+    channel_name = await channel_layer.new_channel()
+    await channel_layer.send(
+        channel_name,
+        {
+            "type": "test.message",
+            "text": "Local only please",
+        },
+    )
+    message = await channel_layer.receive(channel_name)
+    assert message["type"] == "test.message"
+    assert message["text"] == "Local only please"
+
+
+@pytest.mark.asyncio
+async def test_multi_send_receive(channel_layer):
+    """
+    Tests overlapping sends and receives, and ordering.
+    """
+    channel_layer = InMemoryChannelLayer()
+    await channel_layer.send("test-channel-3", {"type": "message.1"})
+    await channel_layer.send("test-channel-3", {"type": "message.2"})
+    await channel_layer.send("test-channel-3", {"type": "message.3"})
+    assert (await channel_layer.receive("test-channel-3"))["type"] == "message.1"
+    assert (await channel_layer.receive("test-channel-3"))["type"] == "message.2"
+    assert (await channel_layer.receive("test-channel-3"))["type"] == "message.3"
+
+
+@pytest.mark.asyncio
+async def test_groups_basic(channel_layer):
+    """
+    Tests basic group operation.
+    """
+    channel_layer = InMemoryChannelLayer()
+    await channel_layer.group_add("test-group", "test-gr-chan-1")
+    await channel_layer.group_add("test-group", "test-gr-chan-2")
+    await channel_layer.group_add("test-group", "test-gr-chan-3")
+    await channel_layer.group_discard("test-group", "test-gr-chan-2")
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+    # Make sure we get the message on the two channels that were in
+    async with async_timeout.timeout(1):
+        assert (await channel_layer.receive("test-gr-chan-1"))["type"] == "message.1"
+        assert (await channel_layer.receive("test-gr-chan-3"))["type"] == "message.1"
+    # Make sure the removed channel did not get the message
+    with pytest.raises(asyncio.TimeoutError):
+        async with async_timeout.timeout(1):
+            await channel_layer.receive("test-gr-chan-2")
+
+
+@pytest.mark.asyncio
+async def test_groups_channel_full(channel_layer):
+    """
+    Tests that group_send ignores ChannelFull
+    """
+    channel_layer = InMemoryChannelLayer()
+    await channel_layer.group_add("test-group", "test-gr-chan-1")
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+    await channel_layer.group_send("test-group", {"type": "message.1"})


### PR DESCRIPTION
Addresses #852, adding auto group/leave functionality to `WebsocketConsumer` and `AsyncWebsocketConsumer` via the `groups` attribute. The tests will not pass as-is (in fact, they will hang) due to their reliance on `InMemoryChannelLayer`, but they pass with the implementation of `InMemoryChannelLayer` proposed in #863.