### PR TITLE
Fix bug #915 in Session Cookie Middleware

### DIFF
--- a/channels/sessions.py
+++ b/channels/sessions.py
@@ -96,7 +96,7 @@ class CookieMiddleware:
         # Write out the cookies to the response
         for c in cookies.values():
             message.setdefault("headers", []).append(
-                (b"Set-Cookie", bytes(c.output(header=""))),
+                (b"Set-Cookie", bytes(c.output(header=""), encoding="utf-8")),
             )
 
     @classmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,4 +2,17 @@ from django.conf import settings
 
 
 def pytest_configure():
-    settings.configure()
+    settings.configure(
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+            }
+        },
+        INSTALLED_APPS=[
+            "django.contrib.auth",
+            "django.contrib.contenttypes",
+            "django.contrib.sessions",
+            "django.contrib.admin",
+            "channels",
+        ],
+    )


### PR DESCRIPTION
It seems the `bytes(c.output(header=""))` requires a `encoding='utf-8'` if the input is a `str`
see #915 