### PR TITLE
Add login, logout for scope based operations (#917)

### DIFF
--- a/channels/auth.py
+++ b/channels/auth.py
@@ -1,16 +1,163 @@
-from django.contrib import auth
-from django.utils.functional import SimpleLazyObject
+from typing import Any, Dict, Optional
 
+from django.conf import settings
+from django.contrib.auth import (
+    BACKEND_SESSION_KEY, HASH_SESSION_KEY, SESSION_KEY, _get_backends, get_user_model, load_backend, user_logged_in,
+    user_logged_out,
+)
+from django.contrib.auth.models import AbstractUser, AnonymousUser
+from django.utils.crypto import constant_time_compare
+from django.utils.functional import SimpleLazyObject
+from django.utils.translation import LANGUAGE_SESSION_KEY
+
+from channels.db import database_sync_to_async
 from channels.sessions import CookieMiddleware, SessionMiddleware
 
 
-def get_user(scope):
-    if "_cached_user" not in scope:
-        # We need to fake a request so the auth code works until we get to
-        # refactor it to take sessions, not requests.
-        fake_request = type("FakeRequest", (object, ), {"session": scope["session"]})
-        scope["_cached_user"] = auth.get_user(fake_request)
-    return scope["_cached_user"]
+def get_user(scope: Dict[str, Any]) -> AbstractUser:
+    """
+    Return the user model instance associated with the given scope.
+    If no user is retrieved, return an instance of `AnonymousUser`.
+    """
+    if "session" not in scope:
+        raise ValueError(
+            "Cannot find session in scope. "
+            "You should wrap your consumer in SessionMiddleware.")
+
+    session = scope["session"]
+
+    user = None
+    try:
+        user_id = _get_user_session_key(session)
+        backend_path = session[BACKEND_SESSION_KEY]
+    except KeyError:
+        pass
+    else:
+        if backend_path in settings.AUTHENTICATION_BACKENDS:
+            backend = load_backend(backend_path)
+            user = backend.get_user(user_id)
+
+            # Verify the session
+            if hasattr(user, "get_session_auth_hash"):
+                session_hash = session.get(HASH_SESSION_KEY)
+                session_hash_verified = session_hash and constant_time_compare(
+                    session_hash,
+                    user.get_session_auth_hash()
+                )
+                if not session_hash_verified:
+                    session.flush()
+                    user = None
+
+    return user or AnonymousUser()
+
+
+def login(scope: Dict[str, Any], user: Optional[AbstractUser], backend=None):
+    """
+    Persist a user id and a backend in the request. This way a user doesn't
+    have to reauthenticate on every request. Note that data set during
+    the anonymous session is retained when the user logs in.
+    """
+
+    if "session" not in scope:
+        raise ValueError(
+            "Cannot find session in scope. "
+            "You should wrap your consumer in SessionMiddleware.")
+
+    session = scope["session"]
+    session_auth_hash = ""
+
+    if user is None:
+        user = scope.get("user", None)
+
+    if user is None:
+        raise ValueError(
+            "User must be passed as an argument or must be "
+            "present in the scope."
+        )
+
+    if hasattr(user, "get_session_auth_hash"):
+        session_auth_hash = user.get_session_auth_hash()
+
+    if SESSION_KEY in session:
+        if _get_user_session_key(session) != user.pk or (
+                session_auth_hash and
+                not constant_time_compare(
+                    session.get(HASH_SESSION_KEY, ""),
+                    session_auth_hash)):
+            # To avoid reusing another user's session, create a new, empty
+            # session if the existing session corresponds to a different
+            # authenticated user.
+            session.flush()
+    else:
+        session.cycle_key()
+
+    try:
+        backend = backend or user.backend
+    except AttributeError:
+        backends = _get_backends(return_tuples=True)
+        if len(backends) == 1:
+            _, backend = backends[0]
+        else:
+            raise ValueError(
+                "You have multiple authentication backends configured and "
+                "therefore must provide the `backend` argument or set the "
+                "`backend` attribute on the user."
+            )
+
+    session[SESSION_KEY] = user._meta.pk.value_to_string(user)
+    session[BACKEND_SESSION_KEY] = backend
+    session[HASH_SESSION_KEY] = session_auth_hash
+    scope["user"] = user
+
+    # note this does not reset the CSRF_COOKIE/Token
+
+    user_logged_in.send(sender=user.__class__, request=None, user=user)
+
+
+def logout(scope: Dict[str, Any]):
+    """
+    Remove the authenticated user's ID from the request and flush their session
+    data.
+    """
+
+    if "session" not in scope:
+        raise ValueError(
+            "Login cannot find session in scope. "
+            "You should wrap your consumer in SessionMiddleware.")
+
+    session = scope["session"]
+
+    # Dispatch the signal before the user is logged out so the receivers have a
+    # chance to find out *who* logged out.
+
+    user = scope.get("user", None)
+
+    if hasattr(user, "is_authenticated") and not user.is_authenticated:
+        user = None
+
+    if user is not None:
+        user_logged_out.send(sender=user.__class__, request=None, user=user)
+
+    # remember language choice saved to session
+    language = session.get(LANGUAGE_SESSION_KEY)
+    session.flush()
+
+    if language is not None:
+        session[LANGUAGE_SESSION_KEY] = language
+
+    if "user" in scope:
+        scope["user"] = AnonymousUser()
+
+
+# It depends on your auth backend if you need `database_sync_to_async`
+async_login = database_sync_to_async(login)
+async_logout = database_sync_to_async(logout)
+
+
+def _get_user_session_key(session):
+    # This value in the session is always serialized to a string, so we need
+    # to convert it back to Python whenever we access it.
+    return get_user_model()._meta.pk.to_python(session[SESSION_KEY])
 
 
 class AuthMiddleware:

--- a/channels/auth.py
+++ b/channels/auth.py
@@ -5,6 +5,7 @@ from django.contrib.auth import (
 )
 from django.contrib.auth.models import AnonymousUser
 from django.utils.crypto import constant_time_compare
+from django.utils.functional import SimpleLazyObject
 from django.utils.translation import LANGUAGE_SESSION_KEY
 
 from asgiref.sync import async_to_sync
@@ -137,7 +138,7 @@ class AuthMiddleware:
             raise ValueError("AuthMiddleware cannot find session in scope. SessionMiddleware must be above it.")
         # Add it to the scope if it's not there already
         if "user" not in scope:
-            scope["user"] = async_to_sync(get_user)(scope)
+            scope["user"] = SimpleLazyObject(lambda: async_to_sync(get_user)(scope))
         # Pass control to inner application
         return self.inner(scope)
 

--- a/channels/auth.py
+++ b/channels/auth.py
@@ -8,7 +8,6 @@ from django.utils.crypto import constant_time_compare
 from django.utils.functional import SimpleLazyObject
 from django.utils.translation import LANGUAGE_SESSION_KEY
 
-from channels.db import database_sync_to_async
 from channels.sessions import CookieMiddleware, SessionMiddleware
 
 
@@ -111,11 +110,6 @@ def logout(scope):
         session[LANGUAGE_SESSION_KEY] = language
     if "user" in scope:
         scope["user"] = AnonymousUser()
-
-
-# It depends on your auth backend if you need `database_sync_to_async`
-async_login = database_sync_to_async(login)
-async_logout = database_sync_to_async(logout)
 
 
 def _get_user_session_key(session):

--- a/docs/topics/sessions.rst
+++ b/docs/topics/sessions.rst
@@ -93,17 +93,31 @@ after login in your consumer code::
 
     from channels.auth import login
 
-    class ChatConsumer(WebsocketConsumer):
+    class ChatConsumer(AsyncWebsocketConsumer):
+
+        ...
+
+        async def receive(self, text_data):
+            ...
+            # login the user to this session.
+            await login(self.scope, user)
+            # save the session (if the session backend does not access the db you an use `sync_to_async`)
+            await database_sync_to_async(self.scope["session"].save)()
+
+When calling ``login(scope, user)``, ``logout(scope)`` or ``get_user(scope)`` from an sync function you will need to
+wrap them in ``async_to_sync``::
+
+
+    from channels.auth import login
+
+    class SyncChatConsumer(WebsocketConsumer):
 
         ...
 
         def receive(self, text_data):
             ...
-            login(self.scope, user)
+            async_to_sync(login)(self.scope, user)
             self.scope["session"].save()
-
-When calling ``login(scope, user)``, ``logout(scope)`` or ``get_user(scope)`` from an async function you will need to
-wrap them in ``sync_to_async`` or in ``database_sync_to_async`` if your authentication backend uses a database.
 
 .. note::
 

--- a/docs/topics/sessions.rst
+++ b/docs/topics/sessions.rst
@@ -80,16 +80,15 @@ connections or HTTP views won't be able to see the changes.
 How to log a user in/out
 ------------------------
 
-Within your consumer you can call ``login(scope, user, backend=None)`` to login a user.
-This requires that your scope has a ``session`` object the best way to do this is to
+Within your consumer you can await ``login(scope, user, backend=None)`` to log a user in.
+This requires that your scope has a ``session`` object; the best way to do this is to
 ensure your consumer is wrapped in a ``SessionMiddlewareStack`` or a ``AuthMiddlewareStack``.
 
-You can logout a user with the ``logout(scope)`` function.
+You can logout a user with the ``logout(scope)`` async function.
 
 If you are in a WebSocket consumer, or logging-in after the first response has been sent in a http consumer,
 the session is populated **but will never be saved automatically** - you must call ``scope["session"].save()``
 after login in your consumer code::
-
 
     from channels.auth import login
 
@@ -107,7 +106,6 @@ after login in your consumer code::
 When calling ``login(scope, user)``, ``logout(scope)`` or ``get_user(scope)`` from an sync function you will need to
 wrap them in ``async_to_sync``::
 
-
     from channels.auth import login
 
     class SyncChatConsumer(WebsocketConsumer):
@@ -122,5 +120,5 @@ wrap them in ``async_to_sync``::
 .. note::
 
     If you are using a long running consumer, websocket or long-polling HTTP it is possible
-    the user has been logged out of their session elsewere.
-    Use ``get_user(scope)`` to be sure that the user is still logged in.
+    the user has been logged out of their session elsewhere.
+    You can periodically use ``get_user(scope)`` to be sure that the user is still logged in.

--- a/docs/topics/sessions.rst
+++ b/docs/topics/sessions.rst
@@ -100,7 +100,7 @@ after login in your consumer code::
             ...
             # login the user to this session.
             await login(self.scope, user)
-            # save the session (if the session backend does not access the db you an use `sync_to_async`)
+            # save the session (if the session backend does not access the db you can use `sync_to_async`)
             await database_sync_to_async(self.scope["session"].save)()
 
 When calling ``login(scope, user)``, ``logout(scope)`` or ``get_user(scope)`` from an sync function you will need to

--- a/docs/topics/sessions.rst
+++ b/docs/topics/sessions.rst
@@ -102,6 +102,9 @@ after login in your consumer code::
             login(self.scope, user)
             self.scope["session"].save()
 
+When calling ``login(scope, user)``, ``logout(scope)`` or ``get_user(scope)`` from an async function you will need to
+wrap them in ``sync_to_async`` or in ``database_sync_to_async`` if your authentication backend uses a database.
+
 .. note::
 
     If you are using a long running consumer, websocket or long-polling HTTP it is possible

--- a/docs/topics/sessions.rst
+++ b/docs/topics/sessions.rst
@@ -75,3 +75,35 @@ connections or HTTP views won't be able to see the changes.
     If you are in a long-polling HTTP consumer, you might want to save changes
     to the session before you send a response. If you want to do this,
     call ``scope["session"].save()``.
+
+
+How to log a user in/out
+------------------------
+
+Within your consumer you can call ``login(scope, user, backend=None)`` to login a user.
+This requires that your scope has a ``session`` object the best way to do this is to
+ensure your consumer is wrapped in a ``SessionMiddlewareStack`` or a ``AuthMiddlewareStack``.
+
+You can logout a user with the ``logout(scope)`` function.
+
+If you are in a WebSocket consumer, or logging-in after the first response has been sent in a http consumer,
+the session is populated **but will never be saved automatically** - you must call ``scope["session"].save()``
+after login in your consumer code::
+
+
+    from channels.auth import login
+
+    class ChatConsumer(WebsocketConsumer):
+
+        ...
+
+        def receive(self, text_data):
+            ...
+            login(self.scope, user)
+            self.scope["session"].save()
+
+.. note::
+
+    If you are using a long running consumer, websocket or long-polling HTTP it is possible
+    the user has been logged out of their session elsewere.
+    Use ``get_user(scope)`` to be sure that the user is still logged in.

--- a/tests/security/test_auth.py
+++ b/tests/security/test_auth.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 from importlib import import_module
 from unittest import mock
 
@@ -9,16 +8,22 @@ from django.contrib.auth import (
 )
 from django.contrib.auth.models import AnonymousUser
 
+from asgiref.sync import sync_to_async
 from channels.auth import get_user, login, logout
+from channels.db import database_sync_to_async
 
 
-@contextmanager
-def catch_signal(signal):
-    """Catch django signal and return the mocked call."""
-    handler = mock.Mock()
-    signal.connect(handler)
-    yield handler
-    signal.disconnect(handler)
+class catch_signal():
+    def __init__(self, signal):
+        self.handler = mock.Mock()
+        self.signal = signal
+
+    async def __aenter__(self):
+        await sync_to_async(self.signal.connect)(self.handler)
+        return self.handler
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await sync_to_async(self.signal.disconnect)(self.handler)
 
 
 @pytest.fixture
@@ -39,7 +44,7 @@ def session():
     return session
 
 
-def assert_is_logged_in(scope, user):
+async def assert_is_logged_in(scope, user):
     assert "user" in scope
     assert scope["user"] == user
     session = scope["session"]
@@ -49,137 +54,145 @@ def assert_is_logged_in(scope, user):
     assert BACKEND_SESSION_KEY in session
     assert HASH_SESSION_KEY in session
 
-    assert isinstance(get_user(scope), get_user_model())
-    assert get_user(scope) == user
+    assert isinstance(await get_user(scope), await database_sync_to_async(get_user_model)())
+    assert await get_user(scope) == user
 
 
-def test_login_no_session_in_scope():
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_login_no_session_in_scope():
 
     with pytest.raises(
             ValueError,
             match="Cannot find session in scope. You should wrap your consumer in SessionMiddleware."):
-        login(scope={}, user=None)
+        await login(scope={}, user=None)
 
 
 @pytest.mark.django_db(transaction=True)
-def test_login_no_user_in_scope(session):
+@pytest.mark.asyncio
+async def test_login_no_user_in_scope(session):
     scope = {
         "session": session
     }
 
     with pytest.raises(ValueError, match="User must be passed as an argument or must be present in the scope."):
-        login(scope, user=None)
+        await login(scope, user=None)
 
 
 @pytest.mark.django_db(transaction=True)
-def test_login_user_as_argument(session, user_bob):
+@pytest.mark.asyncio
+async def test_login_user_as_argument(session, user_bob):
     scope = {
         "session": session
     }
 
-    assert isinstance(get_user(scope), AnonymousUser)
+    assert isinstance(await get_user(scope), AnonymousUser)
     # not logged in
     assert SESSION_KEY not in session
 
-    with catch_signal(user_logged_in) as handler:
+    async with catch_signal(user_logged_in) as handler:
         assert not handler.called
-        login(scope, user=user_bob)
+        await login(scope, user=user_bob)
         assert handler.called
 
-    assert_is_logged_in(scope, user_bob)
+    await assert_is_logged_in(scope, user_bob)
 
 
 @pytest.mark.django_db(transaction=True)
-def test_login_user_on_scope(session, user_bob):
+@pytest.mark.asyncio
+async def test_login_user_on_scope(session, user_bob):
     scope = {
         "session": session,
         "user": user_bob
     }
 
     # check that we are not logged in on the session
-    assert isinstance(get_user(scope), AnonymousUser)
+    assert isinstance(await get_user(scope), AnonymousUser)
 
-    with catch_signal(user_logged_in) as handler:
+    async with catch_signal(user_logged_in) as handler:
         assert not handler.called
-        login(scope, user=None)
+        await login(scope, user=None)
         assert handler.called
 
-    assert_is_logged_in(scope, user_bob)
+    await assert_is_logged_in(scope, user_bob)
 
 
 @pytest.mark.django_db(transaction=True)
-def test_login_change_user(session, user_bob, user_bill):
+@pytest.mark.asyncio
+async def test_login_change_user(session, user_bob, user_bill):
     scope = {
         "session": session,
     }
 
     # check that we are not logged in on the session
-    assert isinstance(get_user(scope), AnonymousUser)
+    assert isinstance(await get_user(scope), AnonymousUser)
 
-    with catch_signal(user_logged_in) as handler:
+    async with catch_signal(user_logged_in) as handler:
         assert not handler.called
-        login(scope, user=user_bob)
+        await login(scope, user=user_bob)
         assert handler.called
 
-    assert_is_logged_in(scope, user_bob)
+    await assert_is_logged_in(scope, user_bob)
 
     session_key = session[SESSION_KEY]
     assert session_key
 
-    with catch_signal(user_logged_in) as handler:
+    async with catch_signal(user_logged_in) as handler:
         assert not handler.called
-        login(scope, user=user_bill)
+        await login(scope, user=user_bill)
         assert handler.called
 
-    assert_is_logged_in(scope, user_bill)
+    await assert_is_logged_in(scope, user_bill)
 
     assert session_key != session[SESSION_KEY]
 
 
 @pytest.mark.django_db(transaction=True)
-def test_logout(session, user_bob):
+@pytest.mark.asyncio
+async def test_logout(session, user_bob):
     scope = {
         "session": session,
     }
 
     # check that we are not logged in on the session
-    assert isinstance(get_user(scope), AnonymousUser)
+    assert isinstance(await get_user(scope), AnonymousUser)
 
-    with catch_signal(user_logged_in) as handler:
+    async with catch_signal(user_logged_in) as handler:
         assert not handler.called
-        login(scope, user=user_bob)
+        await login(scope, user=user_bob)
         assert handler.called
 
-    assert_is_logged_in(scope, user_bob)
+    await assert_is_logged_in(scope, user_bob)
 
     assert SESSION_KEY in session
     session_key = session[SESSION_KEY]
     assert session_key
 
-    with catch_signal(user_logged_out) as handler:
+    async with catch_signal(user_logged_out) as handler:
         assert not handler.called
-        logout(scope)
+        await logout(scope)
         assert handler.called
 
-    assert isinstance(get_user(scope), AnonymousUser)
+    assert isinstance(await get_user(scope), AnonymousUser)
     assert isinstance(scope["user"], AnonymousUser)
 
     assert SESSION_KEY not in session
 
 
 @pytest.mark.django_db(transaction=True)
-def test_logout_not_logged_in(session):
+@pytest.mark.asyncio
+async def test_logout_not_logged_in(session):
     scope = {
         "session": session,
     }
 
     # check that we are not logged in on the session
-    assert isinstance(get_user(scope), AnonymousUser)
+    assert isinstance(await get_user(scope), AnonymousUser)
 
-    with catch_signal(user_logged_out) as handler:
+    async with catch_signal(user_logged_out) as handler:
         assert not handler.called
-        logout(scope)
+        await logout(scope)
         assert not handler.called
 
     assert "user" not in scope
-    assert isinstance(get_user(scope), AnonymousUser)
+    assert isinstance(await get_user(scope), AnonymousUser)

--- a/tests/security/test_auth.py
+++ b/tests/security/test_auth.py
@@ -2,12 +2,12 @@ from contextlib import contextmanager
 from importlib import import_module
 from unittest import mock
 
+import pytest
 from django.conf import settings
 from django.contrib.auth import (
     BACKEND_SESSION_KEY, HASH_SESSION_KEY, SESSION_KEY, get_user_model, user_logged_in, user_logged_out,
 )
 from django.contrib.auth.models import AnonymousUser
-from django.test import TransactionTestCase
 
 from channels.auth import get_user, login, logout
 
@@ -21,158 +21,165 @@ def catch_signal(signal):
     signal.disconnect(handler)
 
 
-class LoginLogoutTests(TransactionTestCase):
+@pytest.fixture
+def user_bob():
+    return get_user_model().objects.create(username="bob", email="bob@example.com")
 
-    def setUp(self):
-        self.SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
-        self.session = self.SessionStore()  # type: SessionBase
-        self.session.create()
-        self.user = get_user_model().objects.create(
-            username="bob",
-            email="bob@example.com"
-        )  # type: AbstractUser
 
-        self.user2 = get_user_model().objects.create(
-            username="bil",
-            email="bill@example.com"
-        )  # type: AbstractUser
+@pytest.fixture
+def user_bill():
+    return get_user_model().objects.create(username="bill", email="bill@example.com")
 
-    def test_no_session_in_scope(self):
 
-        with self.assertRaises(ValueError) as cm:
-            login(scope={}, user=None)
+@pytest.fixture
+def session():
+    SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
+    session = SessionStore()
+    session.create()
+    return session
 
-        exc = cm.exception
-        self.assertEqual(str(exc), "Cannot find session in scope. "
-                                   "You should wrap your consumer in "
-                                   "SessionMiddleware.")
 
-    def test_no_user_no_user_in_scope(self):
-        scope = {
-            "session": self.session
-        }
+def assert_is_logged_in(scope, user):
+    assert "user" in scope
+    assert scope["user"] == user
+    session = scope["session"]
 
-        with self.assertRaises(ValueError) as cm:
-            login(scope, user=None)
+    # logged in!
+    assert SESSION_KEY in session
+    assert BACKEND_SESSION_KEY in session
+    assert HASH_SESSION_KEY in session
 
-        exc = cm.exception
-        self.assertEqual(str(exc),
-                         "User must be passed as an argument or must be "
-                         "present in the scope.")
+    assert isinstance(get_user(scope), get_user_model())
+    assert get_user(scope) == user
 
-    def assertIsLoggedIn(self, scope, user):
-        assert "user" in scope
-        assert scope["user"] == user
-        session = scope["session"]
 
-        # logged in!
-        assert SESSION_KEY in session
-        assert BACKEND_SESSION_KEY in session
-        assert HASH_SESSION_KEY in session
+def test_login_no_session_in_scope():
 
-        self.assertIsInstance(get_user(scope), get_user_model())
-        assert get_user(scope) == user
+    with pytest.raises(
+            ValueError,
+            match="Cannot find session in scope. You should wrap your consumer in SessionMiddleware."):
+        login(scope={}, user=None)
 
-    def test_login_user_as_argument(self):
-        scope = {
-            "session": self.session
-        }
 
-        self.assertIsInstance(get_user(scope), AnonymousUser)
-        # not logged in
-        assert SESSION_KEY not in self.session
+@pytest.mark.django_db(transaction=True)
+def test_login_no_user_in_scope(session):
+    scope = {
+        "session": session
+    }
 
-        with catch_signal(user_logged_in) as handler:
-            assert not handler.called
-            login(scope, user=self.user)
-            assert handler.called
+    with pytest.raises(ValueError, match="User must be passed as an argument or must be present in the scope."):
+        login(scope, user=None)
 
-        self.assertIsLoggedIn(scope, self.user)
 
-    def test_login_user_on_scope(self):
-        scope = {
-            "session": self.session,
-            "user": self.user
-        }
+@pytest.mark.django_db(transaction=True)
+def test_login_user_as_argument(session, user_bob):
+    scope = {
+        "session": session
+    }
 
-        # check that we are not logged in on the session
-        self.assertIsInstance(get_user(scope), AnonymousUser)
+    assert isinstance(get_user(scope), AnonymousUser)
+    # not logged in
+    assert SESSION_KEY not in session
 
-        with catch_signal(user_logged_in) as handler:
-            assert not handler.called
-            login(scope, user=None)
-            assert handler.called
+    with catch_signal(user_logged_in) as handler:
+        assert not handler.called
+        login(scope, user=user_bob)
+        assert handler.called
 
-        self.assertIsLoggedIn(scope, self.user)
+    assert_is_logged_in(scope, user_bob)
 
-    def test_change_user(self):
-        scope = {
-            "session": self.session,
-        }
 
-        # check that we are not logged in on the session
-        self.assertIsInstance(get_user(scope), AnonymousUser)
+@pytest.mark.django_db(transaction=True)
+def test_login_user_on_scope(session, user_bob):
+    scope = {
+        "session": session,
+        "user": user_bob
+    }
 
-        with catch_signal(user_logged_in) as handler:
-            assert not handler.called
-            login(scope, user=self.user)
-            assert handler.called
+    # check that we are not logged in on the session
+    assert isinstance(get_user(scope), AnonymousUser)
 
-        self.assertIsLoggedIn(scope, self.user)
+    with catch_signal(user_logged_in) as handler:
+        assert not handler.called
+        login(scope, user=None)
+        assert handler.called
 
-        session_key = self.session[SESSION_KEY]
-        assert session_key
+    assert_is_logged_in(scope, user_bob)
 
-        with catch_signal(user_logged_in) as handler:
-            assert not handler.called
-            login(scope, user=self.user2)
-            assert handler.called
 
-        self.assertIsLoggedIn(scope, self.user2)
+@pytest.mark.django_db(transaction=True)
+def test_login_change_user(session, user_bob, user_bill):
+    scope = {
+        "session": session,
+    }
 
-        assert session_key != self.session[SESSION_KEY]
+    # check that we are not logged in on the session
+    assert isinstance(get_user(scope), AnonymousUser)
 
-    def test_logout(self):
-        scope = {
-            "session": self.session,
-        }
+    with catch_signal(user_logged_in) as handler:
+        assert not handler.called
+        login(scope, user=user_bob)
+        assert handler.called
 
-        # check that we are not logged in on the session
-        self.assertIsInstance(get_user(scope), AnonymousUser)
+    assert_is_logged_in(scope, user_bob)
 
-        with catch_signal(user_logged_in) as handler:
-            assert not handler.called
-            login(scope, user=self.user)
-            assert handler.called
+    session_key = session[SESSION_KEY]
+    assert session_key
 
-        self.assertIsLoggedIn(scope, self.user)
+    with catch_signal(user_logged_in) as handler:
+        assert not handler.called
+        login(scope, user=user_bill)
+        assert handler.called
 
-        assert SESSION_KEY in self.session
-        session_key = self.session[SESSION_KEY]
-        assert session_key
+    assert_is_logged_in(scope, user_bill)
 
-        with catch_signal(user_logged_out) as handler:
-            assert not handler.called
-            logout(scope)
-            assert handler.called
+    assert session_key != session[SESSION_KEY]
 
-        self.assertIsInstance(get_user(scope), AnonymousUser)
-        self.assertIsInstance(scope["user"], AnonymousUser)
 
-        assert SESSION_KEY not in self.session
+@pytest.mark.django_db(transaction=True)
+def test_logout(session, user_bob):
+    scope = {
+        "session": session,
+    }
 
-    def test_logout_not_logged_in(self):
-        scope = {
-            "session": self.session,
-        }
+    # check that we are not logged in on the session
+    assert isinstance(get_user(scope), AnonymousUser)
 
-        # check that we are not logged in on the session
-        self.assertIsInstance(get_user(scope), AnonymousUser)
+    with catch_signal(user_logged_in) as handler:
+        assert not handler.called
+        login(scope, user=user_bob)
+        assert handler.called
 
-        with catch_signal(user_logged_out) as handler:
-            assert not handler.called
-            logout(scope)
-            assert not handler.called
+    assert_is_logged_in(scope, user_bob)
 
-        assert "user" not in scope
-        self.assertIsInstance(get_user(scope), AnonymousUser)
+    assert SESSION_KEY in session
+    session_key = session[SESSION_KEY]
+    assert session_key
+
+    with catch_signal(user_logged_out) as handler:
+        assert not handler.called
+        logout(scope)
+        assert handler.called
+
+    assert isinstance(get_user(scope), AnonymousUser)
+    assert isinstance(scope["user"], AnonymousUser)
+
+    assert SESSION_KEY not in session
+
+
+@pytest.mark.django_db(transaction=True)
+def test_logout_not_logged_in(session):
+    scope = {
+        "session": session,
+    }
+
+    # check that we are not logged in on the session
+    assert isinstance(get_user(scope), AnonymousUser)
+
+    with catch_signal(user_logged_out) as handler:
+        assert not handler.called
+        logout(scope)
+        assert not handler.called
+
+    assert "user" not in scope
+    assert isinstance(get_user(scope), AnonymousUser)

--- a/tests/security/test_auth.py
+++ b/tests/security/test_auth.py
@@ -1,0 +1,178 @@
+from contextlib import contextmanager
+from importlib import import_module
+from unittest import mock
+
+from django.conf import settings
+from django.contrib.auth import (
+    BACKEND_SESSION_KEY, HASH_SESSION_KEY, SESSION_KEY, get_user_model, user_logged_in, user_logged_out,
+)
+from django.contrib.auth.models import AnonymousUser
+from django.test import TransactionTestCase
+
+from channels.auth import get_user, login, logout
+
+
+@contextmanager
+def catch_signal(signal):
+    """Catch django signal and return the mocked call."""
+    handler = mock.Mock()
+    signal.connect(handler)
+    yield handler
+    signal.disconnect(handler)
+
+
+class LoginLogoutTests(TransactionTestCase):
+
+    def setUp(self):
+        self.SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
+        self.session = self.SessionStore()  # type: SessionBase
+        self.session.create()
+        self.user = get_user_model().objects.create(
+            username="bob",
+            email="bob@example.com"
+        )  # type: AbstractUser
+
+        self.user2 = get_user_model().objects.create(
+            username="bil",
+            email="bill@example.com"
+        )  # type: AbstractUser
+
+    def test_no_session_in_scope(self):
+
+        with self.assertRaises(ValueError) as cm:
+            login(scope={}, user=None)
+
+        exc = cm.exception
+        self.assertEqual(str(exc), "Cannot find session in scope. "
+                                   "You should wrap your consumer in "
+                                   "SessionMiddleware.")
+
+    def test_no_user_no_user_in_scope(self):
+        scope = {
+            "session": self.session
+        }
+
+        with self.assertRaises(ValueError) as cm:
+            login(scope, user=None)
+
+        exc = cm.exception
+        self.assertEqual(str(exc),
+                         "User must be passed as an argument or must be "
+                         "present in the scope.")
+
+    def assertIsLoggedIn(self, scope, user):
+        assert "user" in scope
+        assert scope["user"] == user
+        session = scope["session"]
+
+        # logged in!
+        assert SESSION_KEY in session
+        assert BACKEND_SESSION_KEY in session
+        assert HASH_SESSION_KEY in session
+
+        self.assertIsInstance(get_user(scope), get_user_model())
+        assert get_user(scope) == user
+
+    def test_login_user_as_argument(self):
+        scope = {
+            "session": self.session
+        }
+
+        self.assertIsInstance(get_user(scope), AnonymousUser)
+        # not logged in
+        assert SESSION_KEY not in self.session
+
+        with catch_signal(user_logged_in) as handler:
+            assert not handler.called
+            login(scope, user=self.user)
+            assert handler.called
+
+        self.assertIsLoggedIn(scope, self.user)
+
+    def test_login_user_on_scope(self):
+        scope = {
+            "session": self.session,
+            "user": self.user
+        }
+
+        # check that we are not logged in on the session
+        self.assertIsInstance(get_user(scope), AnonymousUser)
+
+        with catch_signal(user_logged_in) as handler:
+            assert not handler.called
+            login(scope, user=None)
+            assert handler.called
+
+        self.assertIsLoggedIn(scope, self.user)
+
+    def test_change_user(self):
+        scope = {
+            "session": self.session,
+        }
+
+        # check that we are not logged in on the session
+        self.assertIsInstance(get_user(scope), AnonymousUser)
+
+        with catch_signal(user_logged_in) as handler:
+            assert not handler.called
+            login(scope, user=self.user)
+            assert handler.called
+
+        self.assertIsLoggedIn(scope, self.user)
+
+        session_key = self.session[SESSION_KEY]
+        assert session_key
+
+        with catch_signal(user_logged_in) as handler:
+            assert not handler.called
+            login(scope, user=self.user2)
+            assert handler.called
+
+        self.assertIsLoggedIn(scope, self.user2)
+
+        assert session_key != self.session[SESSION_KEY]
+
+    def test_logout(self):
+        scope = {
+            "session": self.session,
+        }
+
+        # check that we are not logged in on the session
+        self.assertIsInstance(get_user(scope), AnonymousUser)
+
+        with catch_signal(user_logged_in) as handler:
+            assert not handler.called
+            login(scope, user=self.user)
+            assert handler.called
+
+        self.assertIsLoggedIn(scope, self.user)
+
+        assert SESSION_KEY in self.session
+        session_key = self.session[SESSION_KEY]
+        assert session_key
+
+        with catch_signal(user_logged_out) as handler:
+            assert not handler.called
+            logout(scope)
+            assert handler.called
+
+        self.assertIsInstance(get_user(scope), AnonymousUser)
+        self.assertIsInstance(scope["user"], AnonymousUser)
+
+        assert SESSION_KEY not in self.session
+
+    def test_logout_not_logged_in(self):
+        scope = {
+            "session": self.session,
+        }
+
+        # check that we are not logged in on the session
+        self.assertIsInstance(get_user(scope), AnonymousUser)
+
+        with catch_signal(user_logged_out) as handler:
+            assert not handler.called
+            logout(scope)
+            assert not handler.called
+
+        assert "user" not in scope
+        self.assertIsInstance(get_user(scope), AnonymousUser)


### PR DESCRIPTION
See issue: #917

added:
* `login(scope, user)`
* `logout(scope)`

updated:
* `get_user(scope)`

this removed the `_cached_user` key from `scope` since if you are logging in and out on another level in the stack we cant assume that modifications to the scope on that level will be acceptable to the scope in other levels so I think it best to always fall back to checking the session.

---

TODO:
- [x] Tests
- [-] CSRF_COOKIE/Token middleware will do this as part of a separate pull request
- [x] Add docs
