### PR TITLE
Added channels version to the runserver command

### DIFF
--- a/channels/management/commands/runserver.py
+++ b/channels/management/commands/runserver.py
@@ -60,7 +60,8 @@ class Command(RunserverCommand):
         self.stdout.write(now)
         self.stdout.write((
             "Django version %(version)s, using settings %(settings)r\n"
-            "Starting ASGI/Channels development server version %(channels_version)s at %(protocol)s://%(addr)s:%(port)s/\n"
+            "Starting ASGI/Channels version %(channels_version)s development server"
+            " at %(protocol)s://%(addr)s:%(port)s/\n"
             "Quit the server with %(quit_command)s.\n"
         ) % {
             "version": self.get_version(),

--- a/channels/management/commands/runserver.py
+++ b/channels/management/commands/runserver.py
@@ -8,6 +8,7 @@ from django.core.management.commands.runserver import Command as RunserverComman
 from django.utils import six
 from django.utils.encoding import get_system_encoding
 
+from channels import __version__
 from channels.log import setup_logger
 from channels.routing import get_default_application
 from daphne.endpoints import build_endpoint_description_strings
@@ -59,10 +60,11 @@ class Command(RunserverCommand):
         self.stdout.write(now)
         self.stdout.write((
             "Django version %(version)s, using settings %(settings)r\n"
-            "Starting ASGI/Channels development server at %(protocol)s://%(addr)s:%(port)s/\n"
+            "Starting ASGI/Channels development server version %(channels_version)s at %(protocol)s://%(addr)s:%(port)s/\n"
             "Quit the server with %(quit_command)s.\n"
         ) % {
             "version": self.get_version(),
+            "channels_version": __version__,
             "settings": settings.SETTINGS_MODULE,
             "protocol": self.protocol,
             "addr": "[%s]" % self.addr if self._raw_ipv6 else self.addr,


### PR DESCRIPTION
Shows channels version when starting the development server:
```
Performing system checks...

System check identified no issues (0 silenced).
February 22, 2018 - 07:43:51
Django version 2.0.2, using settings 'brownpapersession.settings'
Starting ASGI/Channels development server version 2.0.2 at http://0:8000/
Quit the server with CONTROL-C.
```