### PR TITLE
Add de-multiplexer

### DIFF
--- a/channels/generic/demultiplexer.py
+++ b/channels/generic/demultiplexer.py
@@ -1,0 +1,200 @@
+import asyncio
+from functools import partial
+
+from channels.consumer import get_handler_name
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+
+
+class AsyncJsonWebsocketDemultiplexer(AsyncJsonWebsocketConsumer):
+    """
+    JSON-understanding WebSocket consumer subclass that handles de-multiplexing streams using a "stream" key in a
+    top-level dict and the actual payload in a sub-dict called "payload".
+    This lets you run multiple streams over a single WebSocket connection in a standardised way.
+    Incoming messages on streams are dispatched to consumers so you can just tie in consumers the normal way.
+    """
+    applications = {}
+    application_close_timeout = 5
+
+    def __init__(self, scope):
+        super().__init__(scope)
+        self.application_streams = {}
+        self.application_futures = {}
+        self.applications_accepting_frames = set()
+        self.closing = False
+
+    async def __call__(self, receive, send):
+        loop = asyncio.get_event_loop()
+        # create the child applications
+        await loop.create_task(self._create_upstream_applications())
+        # start observing for messages
+        message_consumer = loop.create_task(super().__call__(receive, send))
+        try:
+            # wait for either an upstream application to close or the message consumer loop.
+            await asyncio.wait(
+                list(self.application_futures.values()) + [message_consumer],
+                return_when=asyncio.FIRST_COMPLETED
+            )
+        finally:
+            # make sure we clean up the message consumer loop
+            message_consumer.cancel()
+            try:
+                # check if there were any exceptions raised
+                await message_consumer
+            except asyncio.CancelledError:
+                pass
+            finally:
+                # Make sure we clean up upstream applications on exit
+                for future in self.application_futures.values():
+                    future.cancel()
+                    try:
+                        # check for exceptions
+                        await future
+                    except asyncio.CancelledError:
+                        pass
+
+    async def _create_upstream_applications(self):
+        """
+        Create the upstream applications.
+        """
+        loop = asyncio.get_event_loop()
+        for steam_name, ApplicationsCls in self.applications.items():
+            application = ApplicationsCls(self.scope)
+            upstream_queue = asyncio.Queue()
+            self.application_streams[steam_name] = upstream_queue
+            self.application_futures[steam_name] = loop.create_task(
+                application(
+                    upstream_queue.get,
+                    partial(self.dispatch_downstream, steam_name=steam_name)
+                )
+            )
+
+    async def send_upstream(self, message, stream_name=None):
+        """
+        Send a message upstream to a de-multiplexed application.
+
+        If stream_name is includes will send just to that upstream steam, if not included will send ot all upstream
+        steams.
+        """
+        if stream_name is None:
+            for steam_queue in self.application_streams.values():
+                await steam_queue.put(message)
+            return
+        steam_queue = self.application_streams.get(stream_name)
+        if steam_queue is None:
+            raise ValueError("Invalid multiplexed frame received (stream not mapped)")
+        await steam_queue.put(message)
+
+    async def dispatch_downstream(self, message, steam_name):
+        """
+        Handle a downstream message coming from an upstream steam.
+
+        if there is not handling method set for this method type it will propagate the message further downstream.
+
+        This is called as part of the co-routine of an upstream steam, not the same loop as used for upstream messages
+        in the de-multiplexer.
+        """
+        handler = getattr(self, get_handler_name(message), None)
+        if handler:
+            await handler(message, stream_name=steam_name)
+        else:
+            # if there is not handler then just pass the message further downstream.
+            await self.base_send(message)
+
+    # Websocket upstream handlers
+
+    async def websocket_connect(self, message):
+        await self.send_upstream(message)
+
+    async def receive_json(self, content, **kwargs):
+        """
+        Rout the message down the correct stream.
+        """
+        # Check the frame looks good
+        if isinstance(content, dict) and "stream" in content and "payload" in content:
+            # Match it to a channel
+            steam_name = content["stream"]
+            payload = content["payload"]
+            # block upstream frames
+            if steam_name not in self.applications_accepting_frames:
+                raise ValueError("Invalid multiplexed frame received (stream not mapped)")
+            # send it on to the application that handles this stream
+            await self.send_upstream(
+                message={
+                    "type": "websocket.receive",
+                    "text": await self.encode_json(payload)
+                },
+                stream_name=steam_name
+            )
+            return
+        else:
+            raise ValueError("Invalid multiplexed **frame received (no channel/payload key)")
+
+    async def websocket_disconnect(self, message):
+        """
+        Handle the disconnect message.
+
+        This is propagated to all upstream applications.
+        """
+        # set this flag so as to ensure we don't send a downstream `websocket.close` message due to all
+        # child applications closing.
+        self.closing = True
+        # inform all children
+        await self.send_upstream(message)
+        await super().websocket_disconnect(message)
+
+    async def disconnect(self, code):
+        """
+        default is to wait for the child applications to close.
+        """
+        try:
+            await asyncio.wait(
+                self.application_futures.values(),
+                return_when=asyncio.ALL_COMPLETED,
+                timeout=self.application_close_timeout
+            )
+        except asyncio.TimeoutError:
+            pass
+
+    # Note if all child applications close within the timeout this cor-routine will be killed before we get here.
+
+    async def websocket_send(self, message, stream_name):
+        """
+        Capture downstream websocket.send messages from the upstream applications.
+        """
+        text = message.get("text")
+        # todo what to do on binary!
+        json = await self.decode_json(text)
+        data = {
+            "stream": stream_name,
+            "payload": json
+        }
+        await self.send_json(data)
+
+    async def websocket_accept(self, message, stream_name):
+        """
+        Intercept downstream `websocket.accept` message and thus allow this upsteam application to accept websocket
+        frames.
+        """
+        is_first = not self.applications_accepting_frames
+        self.applications_accepting_frames.add(stream_name)
+        # accept the connection after the first upstream application accepts.
+        if is_first:
+            await self.accept()
+
+    async def websocket_close(self, message, stream_name):
+        """
+        Handle downstream `websocket.close` message.
+
+        Will disconnect this upstream application from receiving any new frames.
+
+        If there are not more upstream applications accepting messages it will then call `close`.
+        """
+        if stream_name in self.applications_accepting_frames:
+            # remove from set of upsteams steams than can receive new messages
+            self.applications_accepting_frames.remove(stream_name)
+        # we are already closing due to an upstream websocket.disconnect command
+        if self.closing:
+            return
+        # if none of the upstream applications are listing we need to close.
+        if not self.applications_accepting_frames:
+            await self.close(message.get("code"))

--- a/tests/test_demultiplexer.py
+++ b/tests/test_demultiplexer.py
@@ -1,0 +1,421 @@
+import asyncio
+
+import pytest
+from django.conf.urls import url
+
+from channels.generic.demultiplexer import AsyncJsonWebsocketDemultiplexer
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+from channels.routing import URLRouter
+from channels.testing import WebsocketCommunicator
+
+
+class EchoTestConsumer(AsyncJsonWebsocketConsumer):
+
+    async def receive_json(self, content=None, **kwargs):
+        await self.send_json(content)
+
+
+class AltEchoTestConsumer(AsyncJsonWebsocketConsumer):
+
+    async def receive_json(self, content=None, **kwargs):
+        await self.send_json({"received": content, "alt_value": 123})
+
+
+class EchoCloseAfterFirstTestConsumer(AsyncJsonWebsocketConsumer):
+
+    async def receive_json(self, content=None, **kwargs):
+        await self.send_json(content)
+        await self.close()
+
+
+class NeverAcceptTestConsumer(AsyncJsonWebsocketConsumer):
+    async def websocket_connect(self, message):
+        pass
+
+
+class RaiseInAcceptTestConsumer(AsyncJsonWebsocketConsumer):
+    async def websocket_connect(self, message):
+        raise ValueError("Test my error")
+
+
+class EchoDemultiplexerAsyncJson(AsyncJsonWebsocketDemultiplexer):
+    applications = {
+        "echostream": EchoTestConsumer,
+        "altechostream": AltEchoTestConsumer,
+        "closeafterfirst": EchoCloseAfterFirstTestConsumer,
+        "neveraccept": NeverAcceptTestConsumer
+    }
+
+
+class RaiseInAcceptDemultiplexerAsyncJson(AsyncJsonWebsocketDemultiplexer):
+    applications = {
+        "raiseinaccept": RaiseInAcceptTestConsumer
+    }
+
+
+@pytest.mark.asyncio
+async def test_stream_routing():
+
+    communicator = WebsocketCommunicator(
+        EchoDemultiplexerAsyncJson,
+        "/"
+    )
+
+    connected, _ = await communicator.connect()
+    assert connected
+
+    # Test sending
+    await communicator.send_json_to(
+        {
+            "stream": "echostream",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "stream": "echostream",
+        "payload": {"hello": "world"}
+    }
+
+    # Test sending
+    await communicator.send_json_to(
+        {
+            "stream": "altechostream",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "stream": "altechostream",
+        "payload": {"alt_value": 123, "received": {"hello": "world"}}
+    }
+
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_stream_routing_not_listed():
+
+    communicator = WebsocketCommunicator(
+        EchoDemultiplexerAsyncJson,
+        "/"
+    )
+
+    connected, _ = await communicator.connect()
+    assert connected
+
+    # Test sending
+    await communicator.send_json_to(
+        {
+            "stream": "notlisted",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    # We do not expect a response so we will timeout waiting for one.
+    with pytest.raises(ValueError, match="Invalid multiplexed frame received"):
+        await communicator.receive_output()
+
+
+@pytest.mark.asyncio
+async def test_stream_no_payload():
+
+    communicator = WebsocketCommunicator(
+        EchoDemultiplexerAsyncJson,
+        "/"
+    )
+
+    connected, _ = await communicator.connect()
+    assert connected
+
+    # Test sending
+    await communicator.send_json_to(
+        {
+            "stream": "echostream",
+            "no_payload": {"hello": "world"}
+        }
+    )
+
+    with pytest.raises(ValueError, match="Invalid multiplexed"):
+        await communicator.wait()
+
+
+@pytest.mark.asyncio
+async def test_stream_close():
+    """
+    Test behavior when upstream application closes.
+    """
+
+    communicator = WebsocketCommunicator(
+        EchoDemultiplexerAsyncJson,
+        "/"
+    )
+
+    connected, _ = await communicator.connect()
+    assert connected
+
+    # Send to normal echoe server
+    await communicator.send_json_to(
+        {
+            "stream": "echostream",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "stream": "echostream",
+        "payload": {"hello": "world"}
+    }
+
+    # send to consumer that will close after first message.
+    await communicator.send_json_to(
+        {
+            "stream": "closeafterfirst",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "stream": "closeafterfirst",
+        "payload": {"hello": "world"}
+    }
+
+    # there should be no downstream message
+    with pytest.raises(asyncio.TimeoutError):
+        await communicator.receive_output()
+
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_stream_routing_raiseinaccept():
+
+    communicator = WebsocketCommunicator(
+        RaiseInAcceptDemultiplexerAsyncJson,
+        "/"
+    )
+
+    with pytest.raises(ValueError, match="Test my error"):
+        await communicator.connect()
+
+
+@pytest.mark.asyncio
+async def test_stream_no_accept():
+    """
+    Test that we wait for the first child application to `accept`
+    """
+
+    class TestConsumer(EchoTestConsumer):
+        async def accept(self):
+            pass
+
+    class DemultiplexerAsyncJson(AsyncJsonWebsocketDemultiplexer):
+        applications = {
+            "test": TestConsumer
+        }
+
+    communicator = WebsocketCommunicator(
+        DemultiplexerAsyncJson,
+        "/"
+    )
+
+    with pytest.raises(asyncio.TimeoutError):
+        await communicator.connect()
+
+    class DemultiplexerAsyncJson(AsyncJsonWebsocketDemultiplexer):
+        applications = {
+            "test": TestConsumer,
+            "echo": EchoTestConsumer
+        }
+
+    communicator = WebsocketCommunicator(
+        DemultiplexerAsyncJson,
+        "/"
+    )
+
+    # check we do connect since the EchoTestConsumer `accepts`
+    connected, _ = await communicator.connect()
+    assert connected
+
+    # Test sending
+    await communicator.send_json_to(
+        {
+            "stream": "echo",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "stream": "echo",
+        "payload": {"hello": "world"}
+    }
+
+    # Test sending
+    await communicator.send_json_to(
+        {
+            "stream": "test",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    # we cant send to `test` since it did not yet `accept` the connection
+    with pytest.raises(ValueError, match="Invalid multiplexed frame received"):
+        await communicator.receive_output()
+
+
+@pytest.mark.asyncio
+async def test_slow_disconnect():
+    results = {}
+
+    class TestConsumer(AsyncJsonWebsocketConsumer):
+        async def disconnect(self, code):
+            results["sleep_start"] = True
+            await asyncio.sleep(1)
+            results["sleep_end"] = True
+
+    class DemultiplexerAsyncJson(AsyncJsonWebsocketDemultiplexer):
+
+        # reduce timeout to make tests run faster.
+        application_close_timeout = 0.1
+
+        applications = {
+            "mystream": TestConsumer,
+        }
+
+        async def disconnect(self, code):
+            await super().disconnect(code)
+            # check that this is called in the correct order!
+            if results.get("sleep_start") and results.get("sleep_end") is None:
+                results["de-multiplexer-disconnect-order"] = True
+
+    communicator = WebsocketCommunicator(DemultiplexerAsyncJson, "/testws/")
+
+    connected, _ = await communicator.connect()
+
+    assert connected
+
+    await communicator.disconnect()
+
+    assert "sleep_start" in results
+    assert "sleep_end" not in results
+    assert "de-multiplexer-disconnect-order" in results
+
+
+@pytest.mark.asyncio
+async def test_fast_disconnect():
+    results = {}
+
+    class TestConsumer(AsyncJsonWebsocketConsumer):
+        async def disconnect(self, code):
+            results["sleep_start"] = True
+            await asyncio.sleep(0.01)
+            results["sleep_end"] = True
+
+    class DemultiplexerAsyncJson(AsyncJsonWebsocketDemultiplexer):
+
+        # reduce timeout to make tests run faster.
+        application_close_timeout = 0.1
+
+        applications = {
+            "mystream": TestConsumer,
+        }
+
+        async def disconnect(self, code):
+            results["de-multiplexer-disconnect-order-pre-wait"] = True
+            await super().disconnect(code)
+            # check that this is called in the correct order!
+            results["de-multiplexer-disconnect-order-post-wait"] = False
+
+    communicator = WebsocketCommunicator(DemultiplexerAsyncJson, "/testws/")
+    connected, _ = await communicator.connect()
+
+    assert connected
+
+    await communicator.disconnect()
+
+    assert "sleep_start" in results
+    assert "sleep_end" in results
+    assert "de-multiplexer-disconnect-order-pre-wait" in results
+    assert "de-multiplexer-disconnect-order-post-wait" not in results
+
+
+@pytest.mark.asyncio
+async def test_nested_with_url_router():
+
+    class PathRoutedDemultiplexer(AsyncJsonWebsocketDemultiplexer):
+        applications = {
+            "pathfilter": URLRouter(
+                [
+                    url("^echo/?$", EchoTestConsumer),
+                    url("^altecho/?$", AltEchoTestConsumer),
+                ]
+            )
+        }
+
+    communicator = WebsocketCommunicator(
+        PathRoutedDemultiplexer,
+        "/test"
+    )
+
+    with pytest.raises(ValueError, match="No route found for path 'test'."):
+        await communicator.connect()
+
+    communicator = WebsocketCommunicator(
+        PathRoutedDemultiplexer,
+        "echo"
+    )
+
+    connected, _ = await communicator.connect()
+    assert connected
+
+    # Test sending
+    await communicator.send_json_to(
+        {
+            "stream": "pathfilter",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "stream": "pathfilter",
+        "payload": {"hello": "world"}
+    }
+
+    await communicator.disconnect()
+
+    communicator = WebsocketCommunicator(
+        PathRoutedDemultiplexer,
+        "altecho"
+    )
+
+    connected, _ = await communicator.connect()
+    assert connected
+
+    # Test sending
+    await communicator.send_json_to(
+        {
+            "stream": "pathfilter",
+            "payload": {"hello": "world"}
+        }
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "stream": "pathfilter",
+        "payload": {"alt_value": 123, "received": {"hello": "world"}}
+    }
+
+    await communicator.disconnect()


### PR DESCRIPTION
Adds `AsyncJsonWebsocketDemultiplexer`

@andrewgodwin  based on your changes in https://github.com/django/channels/commit/d6643d96dd59e153cda13681a6d5a8963b9d577c I was able to simplify this a lot :) without Futures/Tasks being raising lots of warnings.

key features of `AsyncJsonWebsocketDemultiplexer`

* will send `websocket.accept` back only after the first upstream application responds in kind.
* will block upstream `message frames` from being sent to upstream applications until said upstream application response with `websocket.accept`
* if an upstream application sends `websocket.close` will remove it from the set up upstream applications that can receive `message frames`
* if the last open upsteam application sends `websocket.close` then it will propagate that down to the server so that the connection closes.
* when a `websocket.disconect` is received this is sent to all the child applications so they can close. They have `application_close_timeout=5` to close before they will be killed by the parent.
* if the consumer loop of an upstream application completes then all upstream applications will be closed as well as the de-multiplexer!.


# TODO
- [ ] handle what happens if the upstream applications sends a binary frame?
- [ ] Add lots of docs