### PR TITLE
AsyncHttpConsumer with docs for long polling/SSE

### DIFF
--- a/channels/generic/http.py
+++ b/channels/generic/http.py
@@ -1,3 +1,5 @@
+from django.utils import six
+
 from channels.consumer import AsyncConsumer
 
 
@@ -47,16 +49,16 @@ class AsyncHttpConsumer(AsyncConsumer):
 
     async def send_body(self, body, *, more_body=False):
         """
-        Sends a response body to the client. The method expects a unicode
-        string.
+        Sends a response body to the client. The method expects a bytestring.
 
         Set ``more_body=True`` if you want to send more body content later.
         The default behavior closes the response, and further messages on
         the channel will be ignored.
         """
+        assert isinstance(body, six.binary_type), "Body is not bytes"
         await self.send({
             "type": "http.response.body",
-            "body": body.encode("utf-8"),
+            "body": body,
             "more_body": more_body,
         })
 

--- a/channels/generic/http.py
+++ b/channels/generic/http.py
@@ -1,5 +1,3 @@
-from django.utils import six
-
 from channels.consumer import AsyncConsumer
 
 
@@ -55,7 +53,7 @@ class AsyncHttpConsumer(AsyncConsumer):
         The default behavior closes the response, and further messages on
         the channel will be ignored.
         """
-        assert isinstance(body, six.binary_type), "Body is not bytes"
+        assert isinstance(body, bytes), "Body is not bytes"
         await self.send({
             "type": "http.response.body",
             "body": body,

--- a/channels/generic/http.py
+++ b/channels/generic/http.py
@@ -1,0 +1,80 @@
+from channels.consumer import AsyncConsumer
+
+
+class AsyncHttpConsumer(AsyncConsumer):
+    """
+    Async HTTP consumer. Provides basic primitives for building asynchronous
+    HTTP endpoints.
+    """
+
+    async def __call__(self, receive, send):
+        """
+        Async entrypoint - concatenates body fragments and hands off control
+        to ``self.handle`` when the body has been completely received.
+        """
+        self.send = send
+        body = []
+        while True:
+            message = await receive()
+            if message["type"] == "http.disconnect":
+                return
+            else:
+                if "body" in message:
+                    body.append(message["body"])
+                if not message.get("more_body"):
+                    await self.handle(b"".join(body))
+                    return
+
+    async def send_headers(self, *, status=200, headers=None):
+        """
+        Sets the HTTP response status and headers. Headers may be provided as
+        a list of tuples or as a dictionary.
+
+        Note that the ASGI spec requires that the protocol server only starts
+        sending the response to the client after ``self.send_body`` has been
+        called the first time.
+        """
+        if headers is None:
+            headers = []
+        elif isinstance(headers, dict):
+            headers = list(headers.items())
+
+        await self.send({
+            "type": "http.response.start",
+            "status": status,
+            "headers": headers,
+        })
+
+    async def send_body(self, body, *, more_body=False):
+        """
+        Sends a response body to the client. The method expects a unicode
+        string.
+
+        Set ``more_body=True`` if you want to send more body content later.
+        The default behavior closes the response, and further messages on
+        the channel will be ignored.
+        """
+        await self.send({
+            "type": "http.response.body",
+            "body": body.encode("utf-8"),
+            "more_body": more_body,
+        })
+
+    async def send_response(self, status, body, **kwargs):
+        """
+        Sends a response to the client. This is a thin wrapper over
+        ``self.send_headers`` and ``self.send_body``, and everything said
+        above applies here as well. This method may only be called once.
+        """
+        await self.send_headers(status=status, **kwargs)
+        await self.send_body(body)
+
+    async def handle(self, body):
+        """
+        Receives the request body as a bytestring. Response may be composed
+        using the ``self.send*`` methods; the return value of this method is
+        thrown away.
+        """
+        raise NotImplementedError(
+            "Subclasses of AsyncHttpConsumer must provide a handle() method."
+        )

--- a/docs/topics/consumers.rst
+++ b/docs/topics/consumers.rst
@@ -294,8 +294,8 @@ primitives to implement a HTTP endpoint::
     class BasicHttpConsumer(AsyncHttpConsumer):
         async def handle(self, body):
             await asyncio.sleep(10)
-            await self.send_response(200, b'Your response bytes', headers=[
-                ('Content-Type', 'text/plain'),
+            await self.send_response(200, b"Your response bytes", headers=[
+                ("Content-Type", "text/plain"),
             ])
 
 You are expected to implement your own ``self.handle`` method. The
@@ -314,16 +314,16 @@ be explained in detail later::
     class LongPollConsumer(AsyncHttpConsumer):
         async def handle(self, body):
             await self.send_headers(headers=[
-                ('Content-Type', 'application/json'),
+                ("Content-Type", "application/json"),
             ])
             # Headers are only sent after the first body event.
             # Set "more_body" to tell the interface server to not
             # finish the response yet:
-            await self.send_body(b'', more_body=True)
+            await self.send_body(b"", more_body=True)
 
         async def chat_message(self, event):
             # Send JSON and finish the response:
-            await self.send_body(json.dumps(event).encode('utf-8'))
+            await self.send_body(json.dumps(event).encode("utf-8"))
 
 Of course you can also use those primitives to implement a HTTP endpoint for
 `Server-sent events`_::
@@ -334,13 +334,13 @@ Of course you can also use those primitives to implement a HTTP endpoint for
     class ServerSentEventsConsumer(AsyncHttpConsumer):
         async def handle(self, body):
             await self.send_headers(headers=[
-                ('Cache-Control', 'no-cache'),
-                ('Content-Type', 'text/event-stream'),
-                ('Transfer-Encoding', 'chunked'),
+                ("Cache-Control", "no-cache"),
+                ("Content-Type", "text/event-stream"),
+                ("Transfer-Encoding", "chunked"),
             ])
             while True:
-                payload = 'data: %s\n\n' % datetime.now().isoformat()
-                await self.send_body(payload.encode('utf-8'), more_body=True)
+                payload = "data: %s\n\n" % datetime.now().isoformat()
+                await self.send_body(payload.encode("utf-8"), more_body=True)
                 await asyncio.sleep(1)
 
 .. _Server-sent events: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events

--- a/docs/topics/consumers.rst
+++ b/docs/topics/consumers.rst
@@ -326,7 +326,7 @@ be explained in detail later::
             await self.send_body(json.dumps(event).encode("utf-8"))
 
 Of course you can also use those primitives to implement a HTTP endpoint for
-`Server-sent events`_::
+`Server-sent events <https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events>`_::
 
     from datetime import datetime
     from channels.generic.http import AsyncHttpConsumer
@@ -342,5 +342,3 @@ Of course you can also use those primitives to implement a HTTP endpoint for
                 payload = "data: %s\n\n" % datetime.now().isoformat()
                 await self.send_body(payload.encode("utf-8"), more_body=True)
                 await asyncio.sleep(1)
-
-.. _Server-sent events: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events

--- a/docs/topics/consumers.rst
+++ b/docs/topics/consumers.rst
@@ -181,7 +181,9 @@ WebsocketConsumer
 Available as ``channels.generic.websocket.WebsocketConsumer``, this
 wraps the verbose plain-ASGI message sending and receiving into handling that
 just deals with text and binary frames::
+
     from channels.generic.websocket import WebsocketConsumer
+
     class MyConsumer(WebsocketConsumer):
         groups = ["broadcast"]
 
@@ -227,7 +229,9 @@ AsyncWebsocketConsumer
 Available as ``channels.generic.websocket.AsyncWebsocketConsumer``, this has
 the exact same methods and signature as ``WebsocketConsumer`` but everything
 is async, and the functions you need to write have to be as well::
+
     from channels.generic.websocket import AsyncWebsocketConsumer
+
     class MyConsumer(AsyncWebsocketConsumer):
         groups = ["broadcast"]
 
@@ -285,6 +289,8 @@ AsyncHttpConsumer
 Available as ``channels.generic.http.AsyncHttpConsumer``, this offers basic
 primitives to implement a HTTP endpoint::
 
+    from channels.generic.http import AsyncHttpConsumer
+
     class BasicHttpConsumer(AsyncHttpConsumer):
         async def handle(self, body):
             await asyncio.sleep(10)
@@ -302,6 +308,9 @@ polling, use the lower level ``self.send_headers`` and ``self.send_body``
 methods instead. This example already mentions channel layers which will
 be explained in detail later::
 
+    import json
+    from channels.generic.http import AsyncHttpConsumer
+
     class LongPollConsumer(AsyncHttpConsumer):
         async def handle(self, body):
             await self.send_headers(headers=[
@@ -318,6 +327,9 @@ be explained in detail later::
 
 Of course you can also use those primitives to implement a HTTP endpoint for
 `Server-sent events`_::
+
+    from datetime import datetime
+    from channels.generic.http import AsyncHttpConsumer
 
     class ServerSentEventsConsumer(AsyncHttpConsumer):
         async def handle(self, body):

--- a/docs/topics/consumers.rst
+++ b/docs/topics/consumers.rst
@@ -294,14 +294,14 @@ primitives to implement a HTTP endpoint::
     class BasicHttpConsumer(AsyncHttpConsumer):
         async def handle(self, body):
             await asyncio.sleep(10)
-            await self.send_response(200, 'Your response text', headers=[
+            await self.send_response(200, b'Your response bytes', headers=[
                 ('Content-Type', 'text/plain'),
             ])
 
 You are expected to implement your own ``self.handle`` method. The
 method receives the whole request body as a single bytestring.  Headers
-may either be passed as a list of tuples or as a dictionary. The body
-content is expected to be a unicode string.
+may either be passed as a list of tuples or as a dictionary. The
+response body content is expected to be a bytestring.
 
 If you need more control over the response, e.g. for implementing long
 polling, use the lower level ``self.send_headers`` and ``self.send_body``
@@ -319,11 +319,11 @@ be explained in detail later::
             # Headers are only sent after the first body event.
             # Set "more_body" to tell the interface server to not
             # finish the response yet:
-            await self.send_body('', more_body=True)
+            await self.send_body(b'', more_body=True)
 
         async def chat_message(self, event):
             # Send JSON and finish the response:
-            await self.send_body(json.dumps(event))
+            await self.send_body(json.dumps(event).encode('utf-8'))
 
 Of course you can also use those primitives to implement a HTTP endpoint for
 `Server-sent events`_::
@@ -339,10 +339,8 @@ Of course you can also use those primitives to implement a HTTP endpoint for
                 ('Transfer-Encoding', 'chunked'),
             ])
             while True:
-                await self.send_body(
-                    'data: %s\n\n' % datetime.now().isoformat(),
-                    more_body=True,
-                )
+                payload = 'data: %s\n\n' % datetime.now().isoformat()
+                await self.send_body(payload.encode('utf-8'), more_body=True)
                 await asyncio.sleep(1)
 
 .. _Server-sent events: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events

--- a/tests/test_generic_http.py
+++ b/tests/test_generic_http.py
@@ -19,7 +19,7 @@ async def test_async_http_consumer():
                 200,
                 json.dumps({
                     "value": data["value"],
-                }),
+                }).encode('utf-8'),
                 headers={
                     "Content-Type": "application/json",
                 },

--- a/tests/test_generic_http.py
+++ b/tests/test_generic_http.py
@@ -1,0 +1,38 @@
+import json
+
+import pytest
+
+from channels.generic.http import AsyncHttpConsumer
+from channels.testing import HttpCommunicator
+
+
+@pytest.mark.asyncio
+async def test_async_http_consumer():
+    """
+    Tests that AsyncHttpConsumer is implemented correctly.
+    """
+
+    class TestConsumer(AsyncHttpConsumer):
+        async def handle(self, body):
+            data = json.loads(body.decode("utf-8"))
+            await self.send_response(
+                200,
+                json.dumps({
+                    "value": data["value"],
+                }),
+                headers={
+                    "Content-Type": "application/json",
+                },
+            )
+
+    # Open a connection
+    communicator = HttpCommunicator(
+        TestConsumer,
+        method="POST",
+        path="/test/",
+        body=json.dumps({"value": 42, "anything": False}).encode("utf-8"),
+    )
+    response = await communicator.get_response()
+    assert response["body"] == b'{"value": 42}'
+    assert response["status"] == 200
+    assert response["headers"] == [("Content-Type", "application/json")]

--- a/tests/test_generic_http.py
+++ b/tests/test_generic_http.py
@@ -19,7 +19,7 @@ async def test_async_http_consumer():
                 200,
                 json.dumps({
                     "value": data["value"],
-                }).encode('utf-8'),
+                }).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
                 },


### PR DESCRIPTION
Refs #841, #524 

This is a very rough initial draft for an asynchronous HTTP consumer. 

I was torn a bit whether I should even add some code. For me, the documentation part is much more interesting and important for now. There certainly are ways to make the functionality more developer-friendly later, so maybe we do not want to decide what the recommended API should be yet.

Also, no synchronous version yet because going completely async is in some horrible way easier to understand for me  😊

TODO:

- [x] Tests
- [x] Default content type / charset