### PR TITLE
Fix and improve OriginValidator

### DIFF
--- a/channels/security/websocket.py
+++ b/channels/security/websocket.py
@@ -1,7 +1,9 @@
+import ssl
+from http import client as http_client
 from urllib.parse import urlparse
 
 from django.conf import settings
-from django.http.request import validate_host
+from django.http.request import is_same_domain, validate_host
 
 from ..generic.websocket import AsyncWebsocketConsumer
 
@@ -10,26 +12,38 @@ class OriginValidator:
     """
     Validates that the incoming connection has an Origin header that
     is in an allowed list.
+
+    If full attr is True, any origin from allowed_origins must be scheme://hostname[:port].
+    Port is optional, but recommended.
+    Check_cert works only with full attr.
     """
 
-    def __init__(self, application, allowed_origins):
+    def __init__(self, application, allowed_origins, full=False, check_cert=False):
         self.application = application
         self.allowed_origins = allowed_origins
+        # Check state of variable full
+        self.full = full
+        # Check certificate or not. Works only if full True
+        self.check_cert = check_cert if full else False
 
     def __call__(self, scope):
         # Make sure the scope is of type websocket
         if scope["type"] != "websocket":
             raise ValueError("You cannot use OriginValidator on a non-WebSocket connection")
         # Extract the Origin header
-        origin_host = None
+        origin_hostname = None
+        result_parse = None
         for header_name, header_value in scope.get("headers", []):
             if header_name == b"origin":
                 try:
-                    origin_host = urlparse(header_value.decode("ascii")).hostname
+                    # Set ResultParse and origin hostname
+                    result_parse = urlparse(header_value.decode("ascii"))
+                    origin_hostname = result_parse.hostname
                 except UnicodeDecodeError:
                     pass
-        # Check to see if the origin header is valid
-        if self.valid_origin(origin_host):
+        # Check to see if the origin header is valid. Full or default check
+        valid = self.valid_origin(origin_hostname) if not self.full else self.valid_origin_full(result_parse)
+        if valid:
             # Pass control to the application
             return self.application(scope)
         else:
@@ -40,8 +54,87 @@ class OriginValidator:
         # None is not allowed
         if origin is None:
             return False
+        # Get only hostname all allowed origins
+        # Only if not full: https://domain.example.com:8443 -> domain.example.com
+        #   or //domain.example.com - > domain.example.com
+        #   or .example.com -> .example.com
+        self.allowed_origins = [urlparse(pattern).hostname or urlparse("//" + pattern).hostname
+                                or pattern for pattern in self.allowed_origins]
         # Check against our list
         return validate_host(origin, self.allowed_origins)
+
+    def valid_origin_full(self, origin):
+        # None is not allowed
+        if origin is None:
+            return False
+        # Check against our list
+        return self.validate_host_full(origin)
+
+    def validate_host_full(self, origin):
+        # Return True if valid, False otherwise
+        return any(pattern == "*" or self.is_allowed_origin(origin, pattern)
+                   for pattern in self.allowed_origins)
+
+    def is_allowed_origin(self, origin, pattern):
+        checked_address = 0
+        # Get ResultParse object
+        pattern = urlparse(pattern.lower())
+        # Get check result and origin ports
+        valid, origin_ports = self.check_pattern(origin, pattern)
+        if valid:
+            # Check ssl security certificate
+            if origin.scheme == "https" and self.check_cert:
+                for port in origin_ports:
+                    try:
+                        # Init HTTPSConnection object
+                        client = http_client.HTTPSConnection(origin.hostname, port)
+                        # Requesting a site with get method
+                        client.request("get", origin.hostname + origin.path)
+                        checked_address += 1
+                    # Except error: security certificate is invalid
+                    except (ssl.SSLError, ConnectionRefusedError) as error:
+                        # Check error
+                        if isinstance(error, ConnectionRefusedError):
+                            continue
+                        # Raise ssl.SSLError
+                        raise ssl.SSLError(origin.geturl() + " uses an invalid security certificate.")
+                if not checked_address:
+                    # Raise error, if all addresses are not available
+                    raise ConnectionRefusedError("Can not connect to at least one address.")
+            return True
+        return False
+
+    def get_origin_ports(self, origin):
+        if origin.port is not None:
+            # Return tuple (origin.port, )
+            return origin.port,
+        # if origin.port doesn`t exists
+        if origin.scheme == "http":
+            # Default ports return for http
+            return 80, 8080
+        elif origin.scheme == "https":
+            # Default ports return for https
+            return 443, 8443
+        else:
+            return None
+
+    def check_pattern(self, origin, pattern):
+        # Get origin.port or default ports for origin or None
+        origin_ports = self.get_origin_ports(origin)
+        # Get pattern.port or default ports for pattern or None
+        pattern_ports = self.get_origin_ports(pattern)
+        # Get valid origin ports or empty list
+        if origin_ports and pattern_ports:
+            valid_origin_ports = [origin_ports[i] for i in range(0, len(origin_ports))
+                                  if origin_ports[i] in pattern_ports]
+        else:
+            valid_origin_ports = []
+        # Compares hostname, scheme, ports of pattern and origin
+        # Return tuple. Values: (True/False, valid_origin_ports)
+        return all((pattern.scheme == origin.scheme,
+                    is_same_domain(origin.hostname, pattern.hostname),
+                    len(valid_origin_ports) > 0,
+                    )), valid_origin_ports
 
 
 def AllowedHostsOriginValidator(application):

--- a/channels/security/websocket.py
+++ b/channels/security/websocket.py
@@ -55,7 +55,7 @@ class OriginValidator:
         Validate the given origin for this site.
 
         Check than the origin looks valid and matches the origin pattern in
-        specified list `` allowed_origins``. Any pattern begins with a scheme.
+        specified list ``allowed_origins``. Any pattern begins with a scheme.
         After the scheme there must be a domain. Any domain beginning with a period
         corresponds to the domain and all its subdomains (for example, ``http://.example.com``
         ``http://example.com`` and any subdomain). After the domain there must be a port,
@@ -65,7 +65,7 @@ class OriginValidator:
         Note. This function assumes that the given origin has a schema, domain and port,
         but port is optional.
 
-        Returns `` True`` for a valid host, `` False`` otherwise.
+        Returns ``True`` for a valid host, ``False`` otherwise.
         """
         return any(
             pattern == "*" or self.match_allowed_origin(parsed_origin, pattern)
@@ -113,10 +113,10 @@ class OriginValidator:
             return origin.port
         # if origin.port doesn`t exists
         if origin.scheme == "http" or origin.scheme == "ws":
-            # Default port return for http
+            # Default port return for http, ws
             return 80
         elif origin.scheme == "https" or origin.scheme == "wss":
-            # Default port return for https
+            # Default port return for https, wss
             return 443
         else:
             return None

--- a/docs/topics/security.rst
+++ b/docs/topics/security.rst
@@ -37,9 +37,38 @@ valid domains as the second argument::
                     ...
                 ])
             ),
-            ["goodsite.com", "*.goodsite.com"],
+            [".goodsite.com", "*"],
         ),
     })
+
+Note: If you want to resolve any domains, just add ``["*"]`` as second argument.
+
+``OriginValidator`` also has a ``full`` option. If this option is enabled,
+``OriginValidator`` checks the domain schema and port of each ``Origin`` header.
+To do this, pass the list of valid domains as the second argument:
+``scheme://domain[:port]``. The port is an optional parameter, but recommended.
+And just pass ``full=True`` as the third argument::
+
+    application = ProtocolTypeRouter({
+
+        "websocket": OriginValidator(
+            AuthMiddlewareStack(
+                URLRouter([
+                    ...
+                ])
+            ),
+            ["http://.goodsite.com", "https://domain.goodsite.com:443",
+            "http://.goodsite.com:80"],
+            full=True,
+        ),
+    })
+
+Note: If you want to resolve any domains, just add ``["*"]`` as second argument.
+
+``OriginValidator`` can accept the ``check_cert`` as fourth argument.
+Works only when the ``full`` option is enabled. If the argument is specified,
+then for ``https`` verifies the certificate. Just pass
+``check_cert=True`` as fourth argument.
 
 Often, the set of domains you want to restrict to is the same as the Django
 ``ALLOWED_HOSTS`` setting, which performs a similar security check for the

--- a/docs/topics/security.rst
+++ b/docs/topics/security.rst
@@ -25,8 +25,8 @@ ASGI middlewares it contains, ``OriginValidator`` and
 ``OriginValidator`` lets you restrict the valid options for the ``Origin``
 header that is sent with every WebSocket to say where it comes from. Just wrap
 it around your WebSocket application code like this, and pass it a list of
-valid domains as the second argument. You can pass only domain (for example,
-``.allowed-domain.com``) and full origin, than must be scheme://domain[:port]
+valid domains as the second argument. You can pass only a single domain (for example,
+``.allowed-domain.com``) or a full origin, in the format ``scheme://domain[:port]``
 (for example, ``http://allowed-domain.com:80``). Port is optional, but recommended::
 
     from channels.security.websocket import OriginValidator
@@ -43,12 +43,8 @@ valid domains as the second argument. You can pass only domain (for example,
         ),
     })
 
-Note: If you want to resolve any domains, just add ``["*"]`` as second argument.
+Note: If you want to resolve any domain, then use the origin ``*``.
 
-``OriginValidator`` can accept the ``check_cert`` as fourth argument.
-Works only when the ``full`` option is enabled. If the argument is specified,
-then for ``https`` verifies the certificate. Just pass
-``check_cert=True`` as fourth argument.
 
 Often, the set of domains you want to restrict to is the same as the Django
 ``ALLOWED_HOSTS`` setting, which performs a similar security check for the

--- a/docs/topics/security.rst
+++ b/docs/topics/security.rst
@@ -25,7 +25,9 @@ ASGI middlewares it contains, ``OriginValidator`` and
 ``OriginValidator`` lets you restrict the valid options for the ``Origin``
 header that is sent with every WebSocket to say where it comes from. Just wrap
 it around your WebSocket application code like this, and pass it a list of
-valid domains as the second argument::
+valid domains as the second argument. You can pass only domain (for example,
+``.allowed-domain.com``) and full origin, than must be scheme://domain[:port]
+(for example, ``http://allowed-domain.com:80``). Port is optional, but recommended::
 
     from channels.security.websocket import OriginValidator
 
@@ -37,29 +39,7 @@ valid domains as the second argument::
                     ...
                 ])
             ),
-            [".goodsite.com", "*"],
-        ),
-    })
-
-Note: If you want to resolve any domains, just add ``["*"]`` as second argument.
-
-``OriginValidator`` also has a ``full`` option. If this option is enabled,
-``OriginValidator`` checks the domain schema and port of each ``Origin`` header.
-To do this, pass the list of valid domains as the second argument:
-``scheme://domain[:port]``. The port is an optional parameter, but recommended.
-And just pass ``full=True`` as the third argument::
-
-    application = ProtocolTypeRouter({
-
-        "websocket": OriginValidator(
-            AuthMiddlewareStack(
-                URLRouter([
-                    ...
-                ])
-            ),
-            ["http://.goodsite.com", "https://domain.goodsite.com:443",
-            "http://.goodsite.com:80"],
-            full=True,
+            [".goodsite.com", "http://.goodsite.com:80", "http://other.site.com"],
         ),
     })
 

--- a/tests/security/test_websocket.py
+++ b/tests/security/test_websocket.py
@@ -21,3 +21,39 @@ async def test_origin_validator():
     communicator = WebsocketCommunicator(application, "/", headers=[(b"origin", b"http://bad-domain.com")])
     connected, _ = await communicator.connect()
     assert not connected
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_origin_validator_full():
+    """
+    Tests that OriginValidator correctly allows/denies connections with full option.
+    Allowed-domain: scheme://allowed-domain[:port]. Port is optional, but recommended.
+    """
+    # Make our test application
+    application = OriginValidator(AsyncWebsocketConsumer, ["http://allowed-domain.com:8080",
+                                                           "https://allowed-domain.com:8443"],
+                                  full=True, check_cert=False)
+    # Test a normal connection
+    communicator = WebsocketCommunicator(application, "/", headers=[(b"origin", b"http://allowed-domain.com")])
+    connected, _ = await communicator.connect()
+    assert connected
+    await communicator.disconnect()
+    # Test a normal connection. With port
+    communicator = WebsocketCommunicator(application, "/", headers=[(b"origin", b"https://allowed-domain.com:8443")])
+    connected, _ = await communicator.connect()
+    assert connected
+    # Test a bad connection. Without scheme
+    communicator = WebsocketCommunicator(application, "/", headers=[(b"origin", b".bad-domain.com")])
+    connected, _ = await communicator.connect()
+    assert not connected
+    # Test a bad connection. Invalid port
+    communicator = WebsocketCommunicator(application, "/", headers=[(b"origin", b"https://bad-domain.com:8445")])
+    connected, _ = await communicator.connect()
+    assert not connected
+    await communicator.disconnect()
+    # Test a bad connection
+    communicator = WebsocketCommunicator(application, "/", headers=[(b"origin", b".bad-domain.com")])
+    connected, _ = await communicator.connect()
+    assert not connected
+    await communicator.disconnect()

--- a/tests/security/test_websocket.py
+++ b/tests/security/test_websocket.py
@@ -34,4 +34,3 @@ async def test_origin_validator():
     connected, _ = await communicator.connect()
     assert not connected
     await communicator.disconnect()
-

--- a/tests/security/test_websocket.py
+++ b/tests/security/test_websocket.py
@@ -22,6 +22,20 @@ async def test_origin_validator():
     connected, _ = await communicator.connect()
     assert not connected
     await communicator.disconnect()
+    # Make our test application, bad pattern
+    application = OriginValidator(AsyncWebsocketConsumer, ["*.allowed-domain.com"])
+    # Test a bad connection
+    communicator = WebsocketCommunicator(application, "/", headers=[(b"origin", b"http://allowed-domain.com")])
+    connected, _ = await communicator.connect()
+    assert not connected
+    await communicator.disconnect()
+    # Make our test application, good pattern
+    application = OriginValidator(AsyncWebsocketConsumer, [".allowed-domain.com"])
+    # Test a normal connection
+    communicator = WebsocketCommunicator(application, "/", headers=[(b"origin", b"http://www.allowed-domain.com")])
+    connected, _ = await communicator.connect()
+    assert connected
+    await communicator.disconnect()
     # Make our test application, with scheme://domain[:port] for http
     application = OriginValidator(AsyncWebsocketConsumer, ["http://allowed-domain.com"])
     # Test a normal connection

--- a/tests/security/test_websocket.py
+++ b/tests/security/test_websocket.py
@@ -22,38 +22,16 @@ async def test_origin_validator():
     connected, _ = await communicator.connect()
     assert not connected
     await communicator.disconnect()
-
-
-@pytest.mark.asyncio
-async def test_origin_validator_full():
-    """
-    Tests that OriginValidator correctly allows/denies connections with full option.
-    Allowed-domain: scheme://allowed-domain[:port]. Port is optional, but recommended.
-    """
-    # Make our test application
-    application = OriginValidator(AsyncWebsocketConsumer, ["http://allowed-domain.com:8080",
-                                                           "https://allowed-domain.com:8443"],
-                                  full=True, check_cert=False)
+    # Make our test application, with scheme://domain[:port] for http
+    application = OriginValidator(AsyncWebsocketConsumer, ["http://allowed-domain.com"])
     # Test a normal connection
     communicator = WebsocketCommunicator(application, "/", headers=[(b"origin", b"http://allowed-domain.com")])
     connected, _ = await communicator.connect()
     assert connected
     await communicator.disconnect()
-    # Test a normal connection. With port
-    communicator = WebsocketCommunicator(application, "/", headers=[(b"origin", b"https://allowed-domain.com:8443")])
-    connected, _ = await communicator.connect()
-    assert connected
-    # Test a bad connection. Without scheme
-    communicator = WebsocketCommunicator(application, "/", headers=[(b"origin", b".bad-domain.com")])
-    connected, _ = await communicator.connect()
-    assert not connected
-    # Test a bad connection. Invalid port
-    communicator = WebsocketCommunicator(application, "/", headers=[(b"origin", b"https://bad-domain.com:8445")])
-    connected, _ = await communicator.connect()
-    assert not connected
-    await communicator.disconnect()
     # Test a bad connection
-    communicator = WebsocketCommunicator(application, "/", headers=[(b"origin", b".bad-domain.com")])
+    communicator = WebsocketCommunicator(application, "/", headers=[(b"origin", b"https://bad-domain.com:443")])
     connected, _ = await communicator.connect()
     assert not connected
     await communicator.disconnect()
+


### PR DESCRIPTION
See issue  #929 

Added: 
* methods
    * `self.valid_origin_full(self, origin)` 
    * `self.validate_host_full(self, origin)`
    * `self.is_allowed_origin(self, origin, pattern)`
    * `self.get_origin_ports(self, origin)`
    * `self.check_pattern(self, origin, pattern)`
* attributes
    * `self.full`
    * `self.check_cert`


The ability to check only domains (by default) or to check the entire source is added. You can add both complete and incomplete sources to the list of allowed domains, but for complete verification, at least a schema and domain are required. You can also check the ssl certificate.

Also included are tests and an update for the documentation.