### PR TITLE
Add support for nested URLRouter instances

### DIFF
--- a/channels/routing.py
+++ b/channels/routing.py
@@ -99,11 +99,10 @@ class URLRouter:
                     new_path, args, kwargs = match
                     # Shallow copy of scope.
                     scope = dict(scope)
-                    outer = scope.get("url_route", {})
                     # Only pass on the rest of the path
                     scope["path_remaining"] = new_path
-                    # scope["path"] = scope["path"][match.end():]
                     # Add args or kwargs into the scope
+                    outer = scope.get("url_route", {})
                     scope["url_route"] = {
                         "args": outer.get("args", ()) + args,
                         "kwargs": {**outer.get("kwargs", {}), **kwargs},

--- a/channels/routing.py
+++ b/channels/routing.py
@@ -67,7 +67,7 @@ class URLRouter:
 
     def __call__(self, scope):
         # Get the path
-        path = scope.get("path", None)
+        path = scope.get("path_remaining", scope.get("path", None))
         if path is None:
             raise ValueError("No 'path' key in connection scope, cannot route URLs")
         # Remove leading / to match Django's handling
@@ -82,7 +82,7 @@ class URLRouter:
                     scope = dict(scope)
                     outer = scope.get("url_route", {})
                     # Only pass on the rest of the path
-                    scope["path"] = new_path
+                    scope["path_remaining"] = new_path
                     # scope["path"] = scope["path"][match.end():]
                     # Add args or kwargs into the scope
                     scope["url_route"] = {

--- a/channels/routing.py
+++ b/channels/routing.py
@@ -81,8 +81,14 @@ class URLRouter:
     url() or path().
     """
 
+    extensions = {"path_routing"}
+
     def __init__(self, routes):
         self.routes = routes
+        if self.routes and hasattr(self.routes[0], "pattern"):
+            for route in self.routes:
+                if "path_routing" in getattr(route.callback, "extensions", set()):
+                    route.pattern._is_endpoint = False
 
     def __call__(self, scope):
         # Get the path

--- a/docs/topics/routing.rst
+++ b/docs/topics/routing.rst
@@ -103,13 +103,18 @@ a single argument, a list of Django URL objects (either ``path()`` or ``url()``)
     ])
 
 Any captured groups will be provided in ``scope`` as the key ``url_route``, a
-dict with an ``args`` key containing a list of positional regex groups and a
-``kwargs`` key with a dict of the named regex groups.
+dict with a ``kwargs`` key containing a dict of the named regex groups and
+an ``args`` key with a list of positional regex groups. Note that named
+and unnamed groups cannot be mixed: Positional groups are discarded as soon
+as a single named group is matched.
 
 For example, to pull out the named group ``stream`` in the example above, you
 would do this::
 
     stream = self.scope["url_route"]["kwargs"]["stream"]
+
+Please note that ``URLRouter`` nesting will not work properly with
+``path()`` routes if inner routers are wrapped by additional middleware.
 
 
 ChannelNameRouter

--- a/docs/topics/routing.rst
+++ b/docs/topics/routing.rst
@@ -111,13 +111,6 @@ would do this::
 
     stream = self.scope["url_route"]["kwargs"]["stream"]
 
-.. note::
-    ``URLRouter`` instances may be nested. Outer ``URLRouter`` instances
-    should not use ``path()`` but ``re_path()`` (respectively
-    ``url()``), because ``path()`` wrongly translates the route into a
-    regex ending with a ``$`` because it assumes that the ASGI app is a
-    view.
-
 
 ChannelNameRouter
 -----------------

--- a/docs/topics/routing.rst
+++ b/docs/topics/routing.rst
@@ -111,6 +111,13 @@ would do this::
 
     stream = self.scope["url_route"]["kwargs"]["stream"]
 
+.. note::
+    ``URLRouter`` instances may be nested. Outer ``URLRouter`` instances
+    should not use ``path()`` but ``re_path()`` (respectively
+    ``url()``), because ``path()`` wrongly translates the route into a
+    regex ending with a ``$`` because it assumes that the ASGI app is a
+    view.
+
 
 ChannelNameRouter
 -----------------

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -84,22 +84,22 @@ def test_url_router():
         router({"type": "http", "path": "/nonexistent/"})
 
 
-@pytest.mark.xfail
+# @pytest.mark.xfail
 def test_url_router_nesting():
     """
     Tests that nested URLRouters add their keyword captures together.
     """
     test_app = MagicMock(return_value=1)
     inner_router = URLRouter([
-        url(r"^book/(?P<book>[\w\-]+)/page/(\d+)/$", test_app),
+        url(r"^book/(?P<book>[\w\-]+)/page/(?P<page>\d+)/$", test_app),
     ])
     outer_router = URLRouter([
-        url(r"^universe/(\d+)/author/(?P<author>\w+)/$", inner_router),
+        url(r"^universe/(?P<universe>\d+)/author/(?P<author>\w+)/", inner_router),
     ])
     assert outer_router({"type": "http", "path": "/universe/42/author/andrewgodwin/book/channels-guide/page/10/"}) == 1
     assert test_app.call_args[0][0]["url_route"] == {
-        "args": ("42", "10"),
-        "kwargs": {"book": "channels-guide", "author": "andrewgodwin"},
+        "args": (),
+        "kwargs": {"book": "channels-guide", "author": "andrewgodwin", "page": "10", "universe": "42"},
     }
 
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -126,7 +126,7 @@ def test_url_router_nesting_path():
         # Some middleware which hides the fact that we have an inner URLRouter
         def app(scope):
             return inner(scope)
-        app.extensions = {"path_routing"}
+        app._path_routing = True
         return app
 
     outer_router = URLRouter([
@@ -141,6 +141,8 @@ def test_url_router_nesting_path():
     }
     with pytest.raises(ValueError):
         assert outer_router({"type": "http", "path": "/number/42/test/3/bla/"})
+    with pytest.raises(ValueError):
+        assert outer_router({"type": "http", "path": "/number/42/blub/"})
 
 
 @pytest.mark.skipif(django.VERSION[0] < 2, reason="Needs Django 2.x")


### PR DESCRIPTION
Refs #870

Instead of modifying `scope["path"]` I introduced a new scope variable `"path_remaining"` for inner URLRouter instances, which -- if present -- is preferred by URLRouter to `"path"`.

The `test_url_router_nesting` test is modified to not expect positional AND keyword arguments, because Django also ignores all positional arguments as soon as there are any keyword arguments in URLconfs.