### PR TITLE
Make it even easier to locally run style checks, compile docs and run tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ __pycache__/
 .tox/
 *.swp
 *.pyc
-.coverage.*
+.coverage*
+.pytest_cache
 TODO
 node_modules
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -28,4 +28,10 @@ Make your change. Add tests for your change. Make the tests pass:
 
     pytest
 
+Make sure your code conforms to the coding style:
+
+    flake8
+    isort --check-only --diff --recursive channels tests
+    unify --check-only --recursive --quote '"' channels tests
+
 Push to your fork and `submit a pull request <https://github.com/django/channels/compare/>`_.


### PR DESCRIPTION
Sorry for the amount of pull requests and related notifications. But anyway, here's a thing I'm using in a few projects of my own. This would have made adapting to " instead of ' easier for me (and maybe for others as well): Using `tox` to run style checks, docs and tests locally.

(Some projects use tox for everything including a local build matrix, but I think this is overkill, I'd rather rely directly on `.travis.yml` there instead of keeping `tox.ini` in sync as well.)