### PR TITLE
 Make clear how to send an event from a synchronous environment

### DIFF
--- a/docs/topics/worker.rst
+++ b/docs/topics/worker.rst
@@ -40,8 +40,8 @@ type of message is being sent over the channel, as it will turn into an event
 a consumer has to handle.
 
 Also remember that if you are sending the event from a synchronous environment, 
-you have to either ``await`` the above function call or use the ``asgiref.sync.async_to_sync``
-wrapper as specified in :doc:`channel layers </topics/channel_layers>`. 
+you have to use the ``asgiref.sync.async_to_sync`` wrapper as specified in 
+:doc:`channel layers </topics/channel_layers>`. 
 
 Receiving and Consumers
 -----------------------

--- a/docs/topics/worker.rst
+++ b/docs/topics/worker.rst
@@ -39,6 +39,9 @@ Note that the event you send **must** have a ``type`` key, even if only one
 type of message is being sent over the channel, as it will turn into an event
 a consumer has to handle.
 
+Also remember that if you are sending the event from a synchronous environment, 
+you have to either ``await`` the above function call or use the ``asgiref.sync.async_to_sync``
+wrapper as specified in :doc:`channel layers </topics/channel_layers>`. 
 
 Receiving and Consumers
 -----------------------


### PR DESCRIPTION
It probably is obvious to people that are familiar with Django Channels 2 that, since background tasks work with channel_layers you have to send events in the same manner as broadcast messages (using the async_to_sync wrapper from a synchronous environment) but for a first-time developer it might be useful to state it in this section.