### PR TITLE
Use raw strings as url() routes

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -182,8 +182,8 @@ You can combine multiple Consumers (which are, remember, their own ASGI apps)
 into one bigger app that represents your project using routing::
 
     application = URLRouter([
-        url("^chat/admin/$", AdminChatConsumer),
-        url("^chat/$", PublicChatConsumer),
+        url(r"^chat/admin/$", AdminChatConsumer),
+        url(r"^chat/$", PublicChatConsumer),
     ])
 
 Channels is not just built around the world of HTTP and WebSockets - it also
@@ -208,8 +208,8 @@ WebSockets and chat requests::
     application = ProtocolTypeRouter({
 
         "websocket": URLRouter([
-            url("^chat/admin/$", AdminChatConsumer),
-            url("^chat/$", PublicChatConsumer),
+            url(r"^chat/admin/$", AdminChatConsumer),
+            url(r"^chat/$", PublicChatConsumer),
         ]),
 
         "telegram": ChattyBotConsumer,
@@ -277,7 +277,7 @@ WebSocket views by just adding the right middleware around them::
     application = ProtocolTypeRouter({
         "websocket": AuthMiddlewareStack(
             URLRouter([
-                url("^front(end)/$", consumers.AsyncChatConsumer),
+                url(r"^front(end)/$", consumers.AsyncChatConsumer),
             ])
         ),
     })

--- a/docs/topics/authentication.rst
+++ b/docs/topics/authentication.rst
@@ -32,7 +32,7 @@ in your ``routing.py``::
 
         "websocket": AuthMiddlewareStack(
             URLRouter([
-                url("^front(end)/$", consumers.AsyncChatConsumer),
+                url(r"^front(end)/$", consumers.AsyncChatConsumer),
             ])
         ),
 

--- a/docs/topics/routing.rst
+++ b/docs/topics/routing.rst
@@ -43,8 +43,8 @@ Here's an example of what that ``routing.py`` might look like::
         # WebSocket chat handler
         "websocket": AuthMiddlewareStack(
             URLRouter([
-                url("^chat/admin/$", AdminChatConsumer),
-                url("^chat/$", PublicChatConsumer),
+                url(r"^chat/admin/$", AdminChatConsumer),
+                url(r"^chat/$", PublicChatConsumer),
             ])
         ),
 
@@ -97,9 +97,9 @@ Routes ``http`` or ``websocket`` type connections via their HTTP path. Takes
 a single argument, a list of Django URL objects (either ``path()`` or ``url()``)::
 
     URLRouter([
-        url("^longpoll/$", LongPollConsumer),
-        url("^notifications/(?P<stream>\w+)/$", LongPollConsumer),
-        url("", AsgiHandler),
+        url(r"^longpoll/$", LongPollConsumer),
+        url(r"^notifications/(?P<stream>\w+)/$", LongPollConsumer),
+        url(r"", AsgiHandler),
     ])
 
 Any captured groups will be provided in ``scope`` as the key ``url_route``, a

--- a/docs/topics/sessions.rst
+++ b/docs/topics/sessions.rst
@@ -30,7 +30,7 @@ in your ``routing.py``::
 
         "websocket": SessionMiddlewareStack(
             URLRouter([
-                url("^front(end)/$", consumers.AsyncChatConsumer),
+                url(r"^front(end)/$", consumers.AsyncChatConsumer),
             ])
         ),
 


### PR DESCRIPTION
Does not fix any bugs (right now), but follows Django's documentation which also seems to prefer raw strings as arguments to `url()` resp. `re_path()`