### PR TITLE
[FIX] channel layer's one tutorial command is wrong.

### DIFF
--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -337,7 +337,7 @@ shell and run the following commands::
     >>> import channels.layers
     >>> channel_layer = channels.layers.get_channel_layer()
     >>> from asgiref.sync import async_to_sync
-    >>> async_to_sync(channel_layer.send)('test_channel', {type: 'hello'})
+    >>> async_to_sync(channel_layer.send)('test_channel', {'type': 'hello'})
     >>> async_to_sync(channel_layer.receive)('test_channel')
     {'type': 'hello'}
 


### PR DESCRIPTION
python version 3.5.x
django version 2.0.3
channels version 2.0.2

```
async_to_sync(channel_layer.send)('test_channel', {type: 'hello'})
``` 
command keeps throwing  `TypeError: can't serialize <class 'type'>`. 

```
async_to_sync(channel_layer.send)('test_channel', {'type': 'hello'})
``` 
works well.