### PR TITLE
Create shallow copies of "scope" instead of modifying it in place when calling the next ASGI app

### DIFF
--- a/channels/auth.py
+++ b/channels/auth.py
@@ -137,6 +137,7 @@ class AuthMiddleware:
         if "session" not in scope:
             raise ValueError("AuthMiddleware cannot find session in scope. SessionMiddleware must be above it.")
         # Add it to the scope if it's not there already
+        scope = dict(scope)
         if "user" not in scope:
             scope["user"] = SimpleLazyObject(lambda: async_to_sync(get_user)(scope))
         # Pass control to inner application

--- a/channels/staticfiles.py
+++ b/channels/staticfiles.py
@@ -36,8 +36,7 @@ class StaticFilesWrapper:
         # Only even look at HTTP requests
         if scope["type"] == "http" and self._should_handle(scope["path"]):
             # Serve static content
-            scope["static_base_url"] = self.base_url
-            return StaticFilesHandler(scope)
+            return StaticFilesHandler(dict(scope, static_base_url=self.base_url))
         # Hand off to the main app
         return self.application(scope)
 

--- a/docs/topics/authentication.rst
+++ b/docs/topics/authentication.rst
@@ -81,9 +81,9 @@ query string and uses that::
         def __call__(self, scope):
             # Look up user from query string (you should also do things like
             # check it's a valid user ID, or if scope["user"] is already populated)
-            scope["user"] = User.objects.get(id=int(scope["query_string"]))
+            user = User.objects.get(id=int(scope["query_string"]))
             # Return the inner application directly and let it run everything else
-            return self.inner(scope)
+            return self.inner(dict(scope, user=user))
 
 The same principles can be applied to authenticate over non-HTTP protocols;
 for example, you might want to use someone's chat username from a chat protocol

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -170,3 +170,20 @@ def test_url_router_path():
     # Invalid matches
     with pytest.raises(ValueError):
         router({"type": "http", "path": "/nonexistent/"})
+
+
+# @pytest.mark.xfail
+def test_path_remaining():
+    inner_router = URLRouter([
+        url(r'^no-match/$', MagicMock(return_value=1)),
+    ])
+    test_app = MagicMock(return_value=2)
+    outer_router = URLRouter([
+        url(r'^prefix/', inner_router),
+        url(r'^prefix/stuff/$', test_app),
+    ])
+    outermost_router = URLRouter([
+        url(r'', outer_router),
+    ])
+
+    assert outermost_router({"type": "http", "path": "/prefix/stuff/"}) == 2


### PR DESCRIPTION
Maybe it makes more sense to continue the discussion here instead of on the closed pull request for URLRouter nesting (https://github.com/django/channels/pull/946)

I know that the decision whether scope should be copied or not hasn't been made yet. As mentioned [here](https://github.com/django/channels/pull/946#issuecomment-372929152) I think that copying is the right thing to do. 

This pull request includes

- a test for nested URLRouter instances which fails with current master
- scope copying in middleware and routers, no scope copying in utility functions such as `login` and `logout` (since scope is passed as an argument, and supposed to be modified in-place)