### PR TITLE
tutorial typo - path should match urlpattern

### DIFF
--- a/docs/tutorial/part_1.rst
+++ b/docs/tutorial/part_1.rst
@@ -149,7 +149,7 @@ Put the following code in ``chat/templates/chat/index.html``::
         
         document.querySelector('#room-name-submit').onclick = function(e) {
             var roomName = document.querySelector('#room-name-input').value;
-            window.location.pathname = '/chat/' + roomName;
+            window.location.pathname = '/chat/' + roomName + '/';
         };
     </script>
     </html>


### PR DESCRIPTION
since the slash is there in r'^(?P<room_name>[^/]+)/$'
the user will get a 404 unless they make this change to the index template.

a tiny issue, but confusing to people doing tutorials

thanks all for your great work!