### PR TITLE
Add subprotocol support to generic consumers (#930)

### DIFF
--- a/channels/generic/websocket.py
+++ b/channels/generic/websocket.py
@@ -38,11 +38,11 @@ class WebsocketConsumer(SyncConsumer):
     def connect(self):
         self.accept()
 
-    def accept(self):
+    def accept(self, subprotocol=None):
         """
         Accepts an incoming socket
         """
-        super().send({"type": "websocket.accept"})
+        super().send({"type": "websocket.accept", "subprotocol": subprotocol})
 
     def websocket_receive(self, message):
         """
@@ -179,11 +179,11 @@ class AsyncWebsocketConsumer(AsyncConsumer):
     async def connect(self):
         await self.accept()
 
-    async def accept(self):
+    async def accept(self, subprotocol=None):
         """
         Accepts an incoming socket
         """
-        await super().send({"type": "websocket.accept"})
+        await super().send({"type": "websocket.accept", "subprotocol": subprotocol})
 
     async def websocket_receive(self, message):
         """

--- a/docs/topics/consumers.rst
+++ b/docs/topics/consumers.rst
@@ -192,9 +192,14 @@ just deals with text and binary frames::
         groups = ["broadcast"]
 
         def connect(self):
-            # Called on connection. Either call
+            # Called on connection. 
+            # To accept the connection call:
             self.accept()
-            # Or to reject the connection, call
+            # Or accept the connection and specify a chosen subprotocol.
+            # A list of subprotocols specified by the connecting client 
+            # will be available in self.scope['subprotocols']
+            self.accept("subprotocol")
+            # To reject the connection, call:
             self.close()
 
         def receive(self, text_data=None, bytes_data=None):
@@ -240,9 +245,14 @@ is async, and the functions you need to write have to be as well::
         groups = ["broadcast"]
 
         async def connect(self):
-            # Called on connection. Either call
+            # Called on connection. 
+            # To accept the connection call:
             await self.accept()
-            # Or to reject the connection, call
+            # Or accept the connection and specify a chosen subprotocol.
+            # A list of subprotocols specified by the connecting client 
+            # will be available in self.scope['subprotocols']
+            await self.accept("subprotocol")
+            # To reject the connection, call:
             await self.close()
 
         async def receive(self, text_data=None, bytes_data=None):

--- a/tests/test_generic_websocket.py
+++ b/tests/test_generic_websocket.py
@@ -48,6 +48,23 @@ async def test_websocket_consumer():
 
 
 @pytest.mark.asyncio
+async def test_websocket_consumer_subprotocol():
+    """
+    Tests that WebsocketConsumer correctly handles subprotocols.
+    """
+    class TestConsumer(WebsocketConsumer):
+        def connect(self):
+            assert self.scope["subprotocols"] == ["subprotocol1", "subprotocol2"]
+            self.accept("subprotocol2")
+
+    # Test a normal connection with subprotocols
+    communicator = WebsocketCommunicator(TestConsumer, "/testws/", subprotocols=["subprotocol1", "subprotocol2"])
+    connected, subprotocol = await communicator.connect()
+    assert connected
+    assert subprotocol == "subprotocol2"
+
+
+@pytest.mark.asyncio
 async def test_websocket_consumer_groups():
     """
     Tests that WebsocketConsumer adds and removes channels from groups.
@@ -119,6 +136,23 @@ async def test_async_websocket_consumer():
     # Close out
     await communicator.disconnect()
     assert "disconnected" in results
+
+
+@pytest.mark.asyncio
+async def test_async_websocket_consumer_subprotocol():
+    """
+    Tests that AsyncWebsocketConsumer correctly handles subprotocols.
+    """
+    class TestConsumer(AsyncWebsocketConsumer):
+        async def connect(self):
+            assert self.scope["subprotocols"] == ["subprotocol1", "subprotocol2"]
+            await self.accept("subprotocol2")
+
+    # Test a normal connection with subprotocols
+    communicator = WebsocketCommunicator(TestConsumer, "/testws/", subprotocols=["subprotocol1", "subprotocol2"])
+    connected, subprotocol = await communicator.connect()
+    assert connected
+    assert subprotocol == "subprotocol2"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
@andrewgodwin Let me know if you would like any other changes. I see that if AcceptConnection is thrown during a connection, accept is also called. I have left it being called without a subprotocol argument, unless you think it should behave in some other way?