### PR TITLE
Pass default args from urlconf entries while matching urls

### DIFF
--- a/channels/routing.py
+++ b/channels/routing.py
@@ -64,7 +64,13 @@ def route_pattern_match(route, path):
     the remaining path and positional and keyword arguments matched.
     """
     if hasattr(route, "pattern"):
-        return route.pattern.match(path)
+        match = route.pattern.match(path)
+        if match:
+            path, args, kwargs = match
+            kwargs.update(route.default_args)
+            return path, args, kwargs
+        return match
+
     # Django<2.0. No converters... :-(
     match = route.regex.search(path)
     if match:
@@ -73,6 +79,8 @@ def route_pattern_match(route, path):
         # positional arguments.
         kwargs = match.groupdict()
         args = () if kwargs else match.groups()
+        if kwargs is not None:
+            kwargs.update(route.default_args)
         return path[match.end():], args, kwargs
     return None
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -58,12 +58,14 @@ def test_url_router():
     """
     posarg_app = MagicMock(return_value=4)
     kwarg_app = MagicMock(return_value=5)
+    defaultkwarg_app = MagicMock(return_value=6)
     router = URLRouter([
         url(r"^$", MagicMock(return_value=1)),
         url(r"^foo/$", MagicMock(return_value=2)),
         url(r"^bar", MagicMock(return_value=3)),
         url(r"^posarg/(\d+)/$", posarg_app),
         url(r"^kwarg/(?P<name>\w+)/$", kwarg_app),
+        url(r"^defaultkwargs/$", defaultkwarg_app, kwargs={"default": 42}),
     ])
     # Valid basic matches
     assert router({"type": "http", "path": "/"}) == 1
@@ -80,6 +82,10 @@ def test_url_router():
     assert kwarg_app.call_args[0][0]["url_route"] == {"args": tuple(), "kwargs": {"name": "hello"}}
     assert router({"type": "http", "path": "/kwarg/hellothere/"}) == 5
     assert kwarg_app.call_args[0][0]["url_route"] == {"args": tuple(), "kwargs": {"name": "hellothere"}}
+    # Valid default keyword arguments
+    assert router({"type": "http", "path": "/defaultkwargs/"}) == 6
+    assert defaultkwarg_app.call_args[0][0]["url_route"] == {"args": tuple(), "kwargs": {"default": 42}}
+
     # Invalid matches
     with pytest.raises(ValueError):
         router({"type": "http", "path": "/nonexistent/"})


### PR DESCRIPTION
Nested URL routers took over the role of `router.resolve()` on the
URLPattern with a custom function. This function forgot to include
any default args given in the `path()`/`url()` with `kwargs={}`.