### PR TITLE
Use FORCE_SCRIPT_NAME setting on AsgiHandler

### DIFF
--- a/channels/http.py
+++ b/channels/http.py
@@ -196,7 +196,10 @@ class AsgiHandler(base.BaseHandler):
         Synchronous message processing.
         """
         # Set script prefix from message root_path, turning None into empty string
-        set_script_prefix(self.scope.get("root_path", "") or "")
+        script_prefix = self.scope.get("root_path", "") or ""
+        if settings.FORCE_SCRIPT_NAME:
+            script_prefix = settings.FORCE_SCRIPT_NAME
+        set_script_prefix(script_prefix)
         signals.request_started.send(sender=self.__class__, scope=self.scope)
         # Run request through view system
         try:


### PR DESCRIPTION
The 'handle' method on AsgiHandler only veryfies the 'root_path' key of it's
'scope', but it should first verify the FORCE_SCRIPT_NAME parameter from the
project's settings. It defines a prefix that precedes all urls and is used as
the value of the SCRIPT_NAME environment variable.

This parameter is used by the 'runserver' command, but not by the asgi
application, resulting on url's being resolved by django with false
paths.