### PR TITLE
Allow None if '*' is in allowed_origins. Fixes #1115

### DIFF
--- a/channels/security/websocket.py
+++ b/channels/security/websocket.py
@@ -45,8 +45,8 @@ class OriginValidator:
 
         Returns ``True`` if validation function was successful, ``False`` otherwise.
         """
-        # None is not allowed
-        if parsed_origin is None:
+        # None is not allowed unless all hosts are allowed
+        if parsed_origin is None and "*" not in self.allowed_origins:
             return False
         return self.validate_origin(parsed_origin)
 
@@ -85,9 +85,12 @@ class OriginValidator:
         ``http://exapmple.com``). After the domain there must be a port,
         but it can be omitted.
 
-        Note. This function assumes that the given origin has a schema, domain and port,
-        or only domain. Port is optional.
+        Note. This function assumes that the given origin is None, has a schema,
+        domain and port, or only domain. Port is optional.
         """
+        if parsed_origin is None:
+            return False
+
         # Get ResultParse object
         parsed_pattern = urlparse(pattern.lower(), scheme=None)
         if parsed_pattern.scheme is None:

--- a/channels/security/websocket.py
+++ b/channels/security/websocket.py
@@ -85,8 +85,8 @@ class OriginValidator:
         ``http://exapmple.com``). After the domain there must be a port,
         but it can be omitted.
 
-        Note. This function assumes that the given origin is None, has a schema,
-        domain and port, or only domain. Port is optional.
+        Note. This function assumes that the given origin is either None, a
+        schema-domain-port string, or just a domain string
         """
         if parsed_origin is None:
             return False

--- a/tests/security/test_websocket.py
+++ b/tests/security/test_websocket.py
@@ -48,3 +48,17 @@ async def test_origin_validator():
     connected, _ = await communicator.connect()
     assert not connected
     await communicator.disconnect()
+    # Make our test application, with all hosts allowed
+    application = OriginValidator(AsyncWebsocketConsumer, ["*"])
+    # Test a connection without any headers
+    communicator = WebsocketCommunicator(application, "/", headers=[])
+    connected, _ = await communicator.connect()
+    assert connected
+    await communicator.disconnect()
+    # Make our test application, with no hosts allowed
+    application = OriginValidator(AsyncWebsocketConsumer, [])
+    # Test a connection without any headers
+    communicator = WebsocketCommunicator(application, "/", headers=[])
+    connected, _ = await communicator.connect()
+    assert not connected
+    await communicator.disconnect()


### PR DESCRIPTION
Allow None as parsed_origin only if '*' is in allowed_origins. This does require a None check in `match_allowed_origin()`.