### PR TITLE
Update tutorials: add migrate command

### DIFF
--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -254,9 +254,28 @@ tutorial.) Then the connection will be given to the ``URLRouter``.
 The ``URLRouter`` will examine the HTTP path of the connection to route it to a
 particular consumer, based on the provided ``url`` patterns.
 
-Let's verify that the consumer for the ``/ws/chat/ROOM_NAME/`` path works. Start the
-Channels development server::
+Let's verify that the consumer for the ``/ws/chat/ROOM_NAME/`` path works. Run migrations to
+apply database changes(we need database to manage session) and then start the Channels development
+server::
 
+    $ python manage.py migrate
+    Operations to perform:
+      Apply all migrations: admin, auth, contenttypes, sessions
+    Running migrations:
+      Applying contenttypes.0001_initial... OK
+      Applying auth.0001_initial... OK
+      Applying admin.0001_initial... OK
+      Applying admin.0002_logentry_remove_auto_add... OK
+      Applying contenttypes.0002_remove_content_type_name... OK
+      Applying auth.0002_alter_permission_name_max_length... OK
+      Applying auth.0003_alter_user_email_max_length... OK
+      Applying auth.0004_alter_user_username_opts... OK
+      Applying auth.0005_alter_user_last_login_null... OK
+      Applying auth.0006_require_contenttypes_0002... OK
+      Applying auth.0007_alter_validators_add_error_messages... OK
+      Applying auth.0008_alter_user_username_max_length... OK
+      Applying auth.0009_alter_user_last_name_max_length... OK
+      Applying sessions.0001_initial... OK
     $ python3 manage.py runserver
 
 Go to the room page at http://127.0.0.1:8000/chat/lobby/ which now displays an

--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -255,8 +255,8 @@ The ``URLRouter`` will examine the HTTP path of the connection to route it to a
 particular consumer, based on the provided ``url`` patterns.
 
 Let's verify that the consumer for the ``/ws/chat/ROOM_NAME/`` path works. Run migrations to
-apply database changes(we need database to manage session) and then start the Channels development
-server::
+apply database changes (Django's session framework needs the database) and then start the
+Channels development server::
 
     $ python manage.py migrate
     Operations to perform:


### PR DESCRIPTION
In Tutorial Part 2: Implement a Chat Server / Enable a channel layer, I found that if you didn't apply migrations yet, you will get an error like this when you have two websocket connections:

```
$ python manage.py runserver
Performing system checks...

System check identified no issues (0 silenced).

You have 14 unapplied migration(s). Your project may not work properly until you apply the migrations for app(s): admin
, auth, contenttypes, sessions.
Run 'python manage.py migrate' to apply them.

August 15, 2018 - 11:05:53
Django version 2.0, using settings 'chatwithme.settings'
Starting ASGI/Channels version 2.1.1 development server at http://127.0.0.1:8000/
Quit the server with CONTROL-C.
2018-08-15 11:05:53,975 - INFO - server - HTTP/2 support not enabled (install the http2 and tls Twisted extras)
2018-08-15 11:05:53,975 - INFO - server - Configuring endpoint tcp:port=8000:interface=127.0.0.1
2018-08-15 11:05:53,976 - INFO - server - Listening on TCP address 127.0.0.1:8000
[2018/08/15 11:05:57] HTTP GET /chat/qq/ 200 [0.02, 127.0.0.1:65390]
[2018/08/15 11:05:57] WebSocket HANDSHAKING /ws/chat/qq/ [127.0.0.1:65396]
[2018/08/15 11:05:57] WebSocket CONNECT /ws/chat/qq/ [127.0.0.1:65396]
[2018/08/15 11:06:00] HTTP GET /chat/qq/ 200 [0.00, 127.0.0.1:65413]
2018-08-15 11:06:00,459 - ERROR - ws_protocol - [Failure instance: Traceback: <class 'django.db.utils.OperationalError'
>: no such table: django_session
```

From previous section we never apply migrations, because there is a warning in every code snippet in tutorial part 1:
```
You have 13 unapplied migration(s). Your project may not work properly until you apply the migrations for app(s): admin, auth, contenttypes, sessions.
Run 'python manage.py migrate' to apply them.
```