### PR TITLE
Remove leading white spaces in cookie value 

### DIFF
--- a/channels/http.py
+++ b/channels/http.py
@@ -273,7 +273,7 @@ class AsgiHandler(base.BaseHandler):
             response_headers.append(
                 (
                     b"Set-Cookie",
-                    c.output(header="").encode("ascii"),
+                    c.output(header="").encode("ascii").strip(),
                 )
             )
         # Make initial response message


### PR DESCRIPTION
MorselCoockie.output() adds a leading whitespace at the cookie-value, see https://github.com/python/cpython/blob/3.7/Lib/http/cookies.py#L371

At least [uvicon](https://www.uvicorn.org/) with [h11](https://h11.readthedocs.io/en/latest/) has a problem with that whitespace. So it has to be stripped.