### PR TITLE
Run tests against Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,14 @@ script:
 
 jobs:
   include:
+    - python: "3.7"
+      env: DJANGO="Django>=2.0,<2.1"
+      dist: xenial
+      sudo: required
+    - python: "3.7"
+      env: DJANGO="Django>=2.1,<2.2"
+      dist: xenial
+      sudo: required
     #- stage: test_js
     #  script: cd js_client && npm install --progress=false && npm test && cd ..
     - stage: release


### PR DESCRIPTION
According to https://docs.djangoproject.com/en/2.1/releases/1.11/, Django 1.11 does not support Python 3.7.  Therefore I skipped the combination of Django 1.11 and Python 3.7.