### PR TITLE
Fix deployment via travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ stages:
   - lint
   - test
   - name: release
-    if: branch = master
+    if: tag IS present
 
 jobs:
   include:


### PR DESCRIPTION
The condition `branch = master` skips the release stage for tags, but that's exactly when the stage should run.