### PR TITLE
Fix library reference in client jsdoc

### DIFF
--- a/js_client/src/index.js
+++ b/js_client/src/index.js
@@ -30,7 +30,7 @@ export class WebSocketBridge {
    * @param      {String}  [url]     The url of the websocket. Defaults to
    * `window.location.host`
    * @param      {String[]|String}  [protocols] Optional string or array of protocols.
-   * @param      {Object} options Object of options for [`reconnecting-websocket`](https://github.com/joewalnes/reconnecting-websocket#options-1).
+   * @param      {Object} options Object of options for [`reconnecting-websocket`](https://github.com/pladaria/reconnecting-websocket/tree/v3.0.3#default-options).
    * @example
    * const webSocketBridge = new WebSocketBridge();
    * webSocketBridge.connect();


### PR DESCRIPTION
While debugging why none of my options work, I discovered that the reference for the docs of the underlying `reconnecting-websocket` library is pointing to a different library than the one actually being used.