### PR TITLE
Fix exception when validating empty origin

### DIFF
--- a/channels/security/websocket.py
+++ b/channels/security/websocket.py
@@ -95,6 +95,8 @@ class OriginValidator:
 
         # Get ResultParse object
         parsed_pattern = urlparse(pattern.lower(), scheme=None)
+        if parsed_origin.hostname is None:
+            return False
         if parsed_pattern.scheme is None:
             pattern_hostname = urlparse("//" + pattern).hostname or pattern
             return is_same_domain(parsed_origin.hostname, pattern_hostname)

--- a/tests/security/test_websocket.py
+++ b/tests/security/test_websocket.py
@@ -74,3 +74,17 @@ async def test_origin_validator():
     connected, _ = await communicator.connect()
     assert not connected
     await communicator.disconnect()
+    # Test bug with subdomain and empty origin header
+    application = OriginValidator(AsyncWebsocketConsumer, [".allowed-domain.com"])
+    communicator = WebsocketCommunicator(application, "/", headers=[(b"origin", b"")])
+    connected, _ = await communicator.connect()
+    assert not connected
+    await communicator.disconnect()
+    # Test bug with subdomain and invalid origin header
+    application = OriginValidator(AsyncWebsocketConsumer, [".allowed-domain.com"])
+    communicator = WebsocketCommunicator(
+        application, "/", headers=[(b"origin", b"something-invalid")]
+    )
+    connected, _ = await communicator.connect()
+    assert not connected
+    await communicator.disconnect()


### PR DESCRIPTION
When the `Origin` header is set to an empty or invalid value and the allowed origin begins with a dot, then this exception is thrown:

```
AttributeError: 'NoneType' object has no attribute 'endswith'

Traceback:
/var/www/karrot-dev/www/backend/env/lib/python3.5/site-packages/twisted/internet/defer.py:151:maybeDeferred
/var/www/karrot-dev/www/backend/env/src/daphne/daphne/server.py:186:create_application
/var/www/karrot-dev/www/backend/env/lib/python3.5/site-packages/channels/routing.py:56:__call__
/var/www/karrot-dev/www/backend/env/lib/python3.5/site-packages/channels/security/websocket.py:33:__call__
/var/www/karrot-dev/www/backend/env/lib/python3.5/site-packages/channels/security/websocket.py:51:valid_origin
/var/www/karrot-dev/www/backend/env/lib/python3.5/site-packages/channels/security/websocket.py:72:validate_origin
/var/www/karrot-dev/www/backend/env/lib/python3.5/site-packages/channels/security/websocket.py:72:<genexpr>
/var/www/karrot-dev/www/backend/env/lib/python3.5/site-packages/channels/security/websocket.py:95:match_allowed_origin
/var/www/karrot-dev/www/backend/env/lib/python3.5/site-packages/django/utils/http.py:275:is_same_domain
```

It seems that `django.http.request.is_same_domain` expects the hostname to be defined, so we should deny the request before calling `is_same_domain`.

I encountered this exception a few times in our dev-only deployment.