### PR TITLE
Add 'python_requires' check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
+    python_requires='>=3.5',
     install_requires=[
         'Django>=1.11',
         'asgiref~=2.3',


### PR DESCRIPTION
This should prevent users of Python <3.5 from installing the package