### PR TITLE
Prevent hitting AttributeError when later importing daphne.server past django.setup().

### DIFF
--- a/channels/apps.py
+++ b/channels/apps.py
@@ -5,6 +5,8 @@ from django.apps import AppConfig
 # (e.g. raven does this).
 import daphne.server
 
+assert daphne.server  # pyflakes doesn't support ignores
+
 
 class ChannelsConfig(AppConfig):
 

--- a/channels/apps.py
+++ b/channels/apps.py
@@ -5,8 +5,6 @@ from django.apps import AppConfig
 # (e.g. raven does this).
 import daphne.server
 
-del daphne.server
-
 
 class ChannelsConfig(AppConfig):
 


### PR DESCRIPTION
The `daphne` namespace it still kept around, but without `.server`, causing `AttributeError` since an update to `channels`. This alleviates that.