### PR TITLE
Removed community projects for channels v1

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -3,11 +3,7 @@ Community Projects
 
 These projects from the community are developed on top of Channels:
 
-* Djangobot_, a bi-directional interface server for Slack.
-* knocker_, a generic desktop-notification system.
 * Beatserver_, a periodic task scheduler for django channels.
-* cq_, a simple distributed task system.
-* Debugpannel_, a django Debug Toolbar panel for channels.
 * EventStream_, a library to push data using Server-Sent Events (SSE) protocol.
 * DjangoChannelsRestFramework_, a framework that providers DRF like consumers for channels.
 * ChannelsMultiplexer_, a JsonConsumer Multiplexer for channels.
@@ -15,11 +11,7 @@ These projects from the community are developed on top of Channels:
 
 If you'd like to add your project, please submit a PR with a link and brief description.
 
-.. _Djangobot: https://github.com/djangobot/djangobot
-.. _knocker: https://github.com/nephila/django-knocker
 .. _Beatserver: https://github.com/rajasimon/beatserver
-.. _cq: https://github.com/furious-luke/django-cq
-.. _Debugpannel: https://github.com/Krukov/django-channels-panel
 .. _EventStream: https://github.com/fanout/django-eventstream
 .. _DjangoChannelsRestFramework: https://github.com/hishnash/djangochannelsrestframework
 .. _ChannelsMultiplexer: https://github.com/hishnash/channelsmultiplexer


### PR DESCRIPTION
I ran into an issue while trying to get django-debug-toolbar working and noticed this list.