### PR TITLE
Size limit for request body (#1170)

### DIFF
--- a/channels/http.py
+++ b/channels/http.py
@@ -236,6 +236,8 @@ class AsgiHandler(base.BaseHandler):
         except RequestAborted:
             # Client closed connection on us mid request. Abort!
             return
+        except RequestDataTooBig:
+            response = HttpResponse("413 Payload too large", status=413)
         else:
             response = self.get_response(request)
             # Fix chunk size on file responses

--- a/channels/http.py
+++ b/channels/http.py
@@ -121,7 +121,7 @@ class AsgiRequest(http.HttpRequest):
 
         # Limit the maximum request data size that will be handled in-memory.
         if (settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None and
-                int(self.META.get('CONTENT_LENGTH') or 0) > settings.DATA_UPLOAD_MAX_MEMORY_SIZE):
+                self._content_length > settings.DATA_UPLOAD_MAX_MEMORY_SIZE):
             raise RequestDataTooBig('Request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.')
 
         self._body = body

--- a/channels/http.py
+++ b/channels/http.py
@@ -120,9 +120,13 @@ class AsgiRequest(http.HttpRequest):
         # TODO: chunked bodies
 
         # Limit the maximum request data size that will be handled in-memory.
-        if (settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None and
-                self._content_length > settings.DATA_UPLOAD_MAX_MEMORY_SIZE):
-            raise RequestDataTooBig('Request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.')
+        if (
+            settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None
+            and self._content_length > settings.DATA_UPLOAD_MAX_MEMORY_SIZE
+        ):
+            raise RequestDataTooBig(
+                "Request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE."
+            )
 
         self._body = body
         assert isinstance(self._body, bytes), "Body is not bytes"

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -112,13 +112,13 @@ class RequestTests(unittest.TestCase):
         Tests POSTing files using multipart form data.
         """
         body = (
-                b"--BOUNDARY\r\n"
-                + b'Content-Disposition: form-data; name="title"\r\n\r\n'
-                + b"My First Book\r\n"
-                + b"--BOUNDARY\r\n"
-                + b'Content-Disposition: form-data; name="pdf"; filename="book.pdf"\r\n\r\n'
-                + b"FAKEPDFBYTESGOHERE"
-                + b"--BOUNDARY--"
+            b"--BOUNDARY\r\n"
+            + b'Content-Disposition: form-data; name="title"\r\n\r\n'
+            + b"My First Book\r\n"
+            + b"--BOUNDARY\r\n"
+            + b'Content-Disposition: form-data; name="pdf"; filename="book.pdf"\r\n\r\n'
+            + b"FAKEPDFBYTESGOHERE"
+            + b"--BOUNDARY--"
         )
         request = AsgiRequest(
             {
@@ -320,7 +320,7 @@ class MiddlewareTests(unittest.TestCase):
         self.assertTrue(AsgiHandler._middleware_chain is not None)
 
         with patch(
-                "django.core.handlers.base.BaseHandler.load_middleware"
+            "django.core.handlers.base.BaseHandler.load_middleware"
         ) as super_function:
             AsgiHandler(scope)  # Second Handler
             self.assertFalse(super_function.called)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -5,12 +5,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.core.exceptions import RequestDataTooBig
 from django.http import HttpResponse
-
-from asgiref.testing import ApplicationCommunicator
 from django.test import override_settings
 
+from asgiref.testing import ApplicationCommunicator
 from channels.consumer import AsyncConsumer
-
 from channels.http import AsgiHandler, AsgiRequest
 from channels.sessions import SessionMiddlewareStack
 from channels.testing import HttpCommunicator
@@ -114,13 +112,13 @@ class RequestTests(unittest.TestCase):
         Tests POSTing files using multipart form data.
         """
         body = (
-            b"--BOUNDARY\r\n"
-            + b'Content-Disposition: form-data; name="title"\r\n\r\n'
-            + b"My First Book\r\n"
-            + b"--BOUNDARY\r\n"
-            + b'Content-Disposition: form-data; name="pdf"; filename="book.pdf"\r\n\r\n'
-            + b"FAKEPDFBYTESGOHERE"
-            + b"--BOUNDARY--"
+                b"--BOUNDARY\r\n"
+                + b'Content-Disposition: form-data; name="title"\r\n\r\n'
+                + b"My First Book\r\n"
+                + b"--BOUNDARY\r\n"
+                + b'Content-Disposition: form-data; name="pdf"; filename="book.pdf"\r\n\r\n'
+                + b"FAKEPDFBYTESGOHERE"
+                + b"--BOUNDARY--"
         )
         request = AsgiRequest(
             {
@@ -159,7 +157,6 @@ class RequestTests(unittest.TestCase):
         self.assertEqual(request.read(), b"twothree")
 
     def test_script_name(self):
-
         request = AsgiRequest(
             {
                 "http_version": "1.1",
@@ -184,7 +181,6 @@ class RequestTests(unittest.TestCase):
                     },
                     b"",
                 )
-
 
 
 ### Handler tests
@@ -324,7 +320,7 @@ class MiddlewareTests(unittest.TestCase):
         self.assertTrue(AsgiHandler._middleware_chain is not None)
 
         with patch(
-            "django.core.handlers.base.BaseHandler.load_middleware"
+                "django.core.handlers.base.BaseHandler.load_middleware"
         ) as super_function:
             AsgiHandler(scope)  # Second Handler
             self.assertFalse(super_function.called)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -16,9 +16,6 @@ from channels.sessions import SessionMiddlewareStack
 from channels.testing import HttpCommunicator
 
 
-TOO_MUCH_DATA_MSG = 'Request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.'
-
-
 class RequestTests(unittest.TestCase):
     """
     Tests that ASGI request handling correctly decodes HTTP requests given scope


### PR DESCRIPTION
Hey there, 

currently trying to submit a pr for this issue #1170.

Basically I copied the code from django/http/request.py, which then
throws the RequestDataTooBig. The exception gets caught in the
handle-method of the AsgiHandler. In the end a HttpResponse with a
status code of 413 is returned.

Let me know if I am on the right track. 