### PR TITLE
Improved group_name and channel_name validation error messages.

### DIFF
--- a/channels/layers.py
+++ b/channels/layers.py
@@ -98,6 +98,8 @@ class BaseChannelLayer:
     common functionality.
     """
 
+    MAX_NAME_LENGTH = 100
+
     def __init__(self, expiry=60, capacity=100, channel_capacity=None):
         self.expiry = expiry
         self.capacity = capacity
@@ -131,7 +133,7 @@ class BaseChannelLayer:
         return self.capacity
 
     def match_type_and_length(self, name):
-        if isinstance(name, str) and (len(name) < 100):
+        if isinstance(name, str) and (len(name) < self.MAX_NAME_LENGTH):
             return True
         return False
 
@@ -140,8 +142,10 @@ class BaseChannelLayer:
     channel_name_regex = re.compile(r"^[a-zA-Z\d\-_.]+(\![\d\w\-_.]*)?$")
     group_name_regex = re.compile(r"^[a-zA-Z\d\-_.]+$")
     invalid_name_error = (
-        "{} name must be a valid unicode string containing only ASCII "
-        + "alphanumerics, hyphens, underscores, or periods."
+        "{} name must be a valid unicode string "
+        + "with length < {} ".format(MAX_NAME_LENGTH)
+        + "containing only ASCII alphanumerics, hyphens, underscores, or periods, "
+        + "not {}"
     )
 
     def valid_channel_name(self, name, receive=False):
@@ -153,13 +157,13 @@ class BaseChannelLayer:
                         "Specific channel names in receive() must end at the !"
                     )
                 return True
-        raise TypeError(self.invalid_name_error("Channel"))
+        raise TypeError(self.invalid_name_error.format("Channel", name))
 
     def valid_group_name(self, name):
         if self.match_type_and_length(name):
             if bool(self.group_name_regex.match(name)):
                 return True
-        raise TypeError(self.invalid_name_error("Group"))
+        raise TypeError(self.invalid_name_error.format("Group", name))
 
     def valid_channel_names(self, names, receive=False):
         _non_empty_list = True if names else False

--- a/docs/topics/channel_layers.rst
+++ b/docs/topics/channel_layers.rst
@@ -253,6 +253,11 @@ during disconnection, illustrated here on the WebSocket generic consumer:
         def disconnect(self, close_code):
             async_to_sync(self.channel_layer.group_discard)("chat", self.channel_name)
 
+.. note::
+
+    Group names are restricted to ASCII alphanumerics, hyphens, and periods
+    only and are limited to a maximum length of 100 in the default backend.
+
 Then, to send to a group, use ``group_send``, like in this small example
 which broadcasts chat messages to every connected socket when combined with
 the code above:

--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -492,9 +492,10 @@ Several parts of the new ``ChatConsumer`` code deserve further explanation:
       synchronous WebsocketConsumer but it is calling an asynchronous channel
       layer method. (All channel layer methods are asynchronous.)
     * Group names are restricted to ASCII alphanumerics, hyphens, and periods
-      only. Since this code constructs a group name directly from the room name,
+      only and are limited to a maximum length of 100 in the default backend.
+      Since this code constructs a group name directly from the room name,
       it will fail if the room name contains any characters that aren't valid in
-      a group name.
+      a group name or exceeds the length limit.
 
 * ``self.accept()``
     * Accepts the WebSocket connection.

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -5,7 +5,12 @@ from django.test import override_settings
 
 from channels import DEFAULT_CHANNEL_LAYER
 from channels.exceptions import InvalidChannelLayerError
-from channels.layers import InMemoryChannelLayer, channel_layers, get_channel_layer
+from channels.layers import (
+    BaseChannelLayer,
+    InMemoryChannelLayer,
+    channel_layers,
+    get_channel_layer,
+)
 
 
 class TestChannelLayerManager(unittest.TestCase):
@@ -63,3 +68,19 @@ async def test_send_receive():
     message = {"type": "test.message"}
     await layer.send("test.channel", message)
     assert message == await layer.receive("test.channel")
+
+
+@pytest.mark.parametrize(
+    "method",
+    [BaseChannelLayer().valid_channel_name, BaseChannelLayer().valid_group_name],
+)
+@pytest.mark.parametrize(
+    "channel_name,expected_valid",
+    [("¯\\_(ツ)_/¯", False), ("chat", True), ("chat" * 100, False)],
+)
+def test_channel_and_group_name_validation(method, channel_name, expected_valid):
+    if expected_valid:
+        method(channel_name)
+    else:
+        with pytest.raises(TypeError):
+            method(channel_name)


### PR DESCRIPTION
This is to include the maximum length in the error message when validating group and channels names.
Also found that `invalid_name_error` is defined but never used. This PR also utilizes that to format error messages.
Some tests were added. 

Closes #1229.