### PR TITLE
Replace cookie_date, which is deprecated, with http_date

### DIFF
--- a/channels/sessions.py
+++ b/channels/sessions.py
@@ -10,7 +10,7 @@ from django.http.cookie import SimpleCookie
 from django.utils import timezone
 from django.utils.encoding import force_str
 from django.utils.functional import LazyObject
-from django.utils.http import cookie_date
+from django.utils.http import http_date
 
 from channels.db import database_sync_to_async
 
@@ -87,7 +87,7 @@ class CookieMiddleware:
             cookies[key]["max-age"] = max_age
             # IE requires expires, so set it if hasn't been already.
             if not expires:
-                cookies[key]["expires"] = cookie_date(time.time() + max_age)
+                cookies[key]["expires"] = http_date(time.time() + max_age)
         if path is not None:
             cookies[key]["path"] = path
         if domain is not None:
@@ -215,7 +215,7 @@ class SessionMiddlewareInstance:
                         else:
                             max_age = self.scope["session"].get_expiry_age()
                             expires_time = time.time() + max_age
-                            expires = cookie_date(expires_time)
+                            expires = http_date(expires_time)
                         # Set the cookie
                         CookieMiddleware.set_cookie(
                             message,


### PR DESCRIPTION
Just a small change. I did this because `tox` failed with current Django master. (py37-djmaster)

[The Django document says `cookie_date()` is deprecated since v2.1, and should be replaced with `http_date()`.](https://docs.djangoproject.com/en/2.1/ref/utils/#django.utils.http.cookie_date)