### PR TITLE
Enforced data size in channels 2.1.7 prevent large file uploads

### DIFF
--- a/channels/http.py
+++ b/channels/http.py
@@ -120,8 +120,11 @@ class AsgiRequest(http.HttpRequest):
         # TODO: chunked bodies
 
         # Limit the maximum request data size that will be handled in-memory.
+        # but only for non-multipart requests, because files are handled
+        # differently by django, see #1240
         if (
-            settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None
+            self.content_type != "multipart/form-data"
+            and settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None
             and self._content_length > settings.DATA_UPLOAD_MAX_MEMORY_SIZE
         ):
             raise RequestDataTooBig(

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -182,6 +182,30 @@ class RequestTests(unittest.TestCase):
                     b"",
                 )
 
+    def test_size_check_ignore_files(self):
+        body = (
+            b"--BOUNDARY\r\n"
+            + b'Content-Disposition: form-data; name="title"\r\n\r\n'
+            + b"My First Book\r\n"
+            + b"--BOUNDARY\r\n"
+            + b'Content-Disposition: form-data; name="pdf"; filename="book.pdf"\r\n\r\n'
+            + b"FAKEPDFBYTESGOHERE"
+            + b"--BOUNDARY--"
+        )
+        with override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=10):
+            AsgiRequest(
+                {
+                    "http_version": "1.1",
+                    "method": "POST",
+                    "path": "/test/",
+                    "headers": {
+                        "content-type": b"multipart/form-data; boundary=BOUNDARY",
+                        "content-length": str(len(body)).encode("ascii"),
+                    },
+                },
+                body,
+            )
+
 
 ### Handler tests
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -189,22 +189,49 @@ class RequestTests(unittest.TestCase):
             + b"My First Book\r\n"
             + b"--BOUNDARY\r\n"
             + b'Content-Disposition: form-data; name="pdf"; filename="book.pdf"\r\n\r\n'
-            + b"FAKEPDFBYTESGOHERE"
+            + b"FAKEPDFBYTESGOHERETHISISREALLYLONGBUTNOTUSEDTOCOMPUTETHESIZEOFTHEREQUEST"
             + b"--BOUNDARY--"
         )
-        with override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=10):
-            AsgiRequest(
-                {
-                    "http_version": "1.1",
-                    "method": "POST",
-                    "path": "/test/",
-                    "headers": {
-                        "content-type": b"multipart/form-data; boundary=BOUNDARY",
-                        "content-length": str(len(body)).encode("ascii"),
-                    },
+        request = AsgiRequest(
+            {
+                "http_version": "1.1",
+                "method": "POST",
+                "path": "/test/",
+                "headers": {
+                    "content-type": b"multipart/form-data; boundary=BOUNDARY",
+                    "content-length": str(len(body)).encode("ascii"),
                 },
-                body,
-            )
+            },
+            body,
+        )
+        with override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=60):
+            request.POST
+
+    def test_size_check_ignore_files_but_honor_other_post_data(self):
+        body = (
+            b"--BOUNDARY\r\n"
+            + b'Content-Disposition: form-data; name="title"\r\n\r\n'
+            + b"My First Book\r\n"
+            + b"--BOUNDARY\r\n"
+            + b'Content-Disposition: form-data; name="pdf"; filename="book.pdf"\r\n\r\n'
+            + b"FAKEPDFBYTESGOHERETHISISREALLYLONGBUTNOTUSEDTOCOMPUTETHESIZEOFTHEREQUEST"
+            + b"--BOUNDARY--"
+        )
+        request = AsgiRequest(
+            {
+                "http_version": "1.1",
+                "method": "POST",
+                "path": "/test/",
+                "headers": {
+                    "content-type": b"multipart/form-data; boundary=BOUNDARY",
+                    "content-length": str(len(body)).encode("ascii"),
+                },
+            },
+            body,
+        )
+        with override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=1):
+            with pytest.raises(RequestDataTooBig):
+                request.POST
 
 
 ### Handler tests


### PR DESCRIPTION
Fix #1240 

Todo:

- [x] Test case to reproduce the issue
- [x] Fix :D 

I think the actual fix will be a bit tricky because right now, we rely on the `Content-Length` header value to accept or refuse the request. Mimicking [Django's implementation](https://github.com/django/django/blob/77d25dbd0f20d6a907c805ffae8aaadd87edbacf/django/http/multipartparser.py#L169) would probably be a better option:

- If the request CONTENT_TYPE is multipart, then we need to check things when we lazily read the body
- Else, we can use the CONTENT_LENGHT to accept or refuse the request upfront

If that looks good to you, then I can start working on a fix :)

cc @Zarathustra2 @carltongibson 