### PR TITLE
Enable tox to pytest arg forward

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -94,6 +94,10 @@ Also, there is a tox.ini file at the root of the repository. Example commands::
    # run the test with Python 3.7, on Django 2.2 and Django master branch
    $ tox -e py37-dj21 && tox -e py37-djmaster
 
+Note that tox can also forward arguments to pytest. When using pdb with pytest,
+forward the ``-s`` option to pytest as such::
+
+   tox -e py37-dj21 -- -s
 
 Can you pay me for my time?
 ---------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ usedevelop = true
 commands =
     pip install -e {toxinidir}[tests]
     pip freeze
-    py.test -v
+    py.test -v {posargs}
 
 deps =
     dj11: Django>=1.11,<2.0


### PR DESCRIPTION
It's now easier to enable pdb support in pytest  (disable default capture).