### PR TITLE
Rework HTTP body handling.

### DIFF
--- a/channels/http.py
+++ b/channels/http.py
@@ -118,11 +118,8 @@ class AsgiRequest(http.HttpRequest):
                 pass
         # Body handling
         # TODO: chunked bodies
-
         self._request_body_wrapper = body
-        #         assert isinstance(self._body, bytes), "Body is not bytes"
-        #         # Add a stream-a-like for the body
-        #         self._stream = BytesIO(self._body)
+
         # Other bits
         self.resolver_match = None
 

--- a/channels/http.py
+++ b/channels/http.py
@@ -221,8 +221,8 @@ class AsgiHandler(base.BaseHandler):
         """
         self.send = async_to_sync(send)
 
-        body_stream = AsgiRequestIO(async_to_sync(receive))
-        await self.handle(body_stream)
+        stream = AsgiRequestIO(async_to_sync(receive))
+        await self.handle(stream)
 
     @sync_to_async
     def handle(self, body):

--- a/channels/http.py
+++ b/channels/http.py
@@ -122,22 +122,6 @@ class AsgiRequest(http.HttpRequest):
         # Other bits
         self.resolver_match = None
 
-    @property
-    def body(self):
-        if not hasattr(self, "_body"):
-            # Limit the maximum request data size that will be handled in-memory.
-            if (
-                settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None
-                and self._content_length > settings.DATA_UPLOAD_MAX_MEMORY_SIZE
-            ):
-                raise RequestDataTooBig(
-                    "Request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE."
-                )
-            self._body = self.read()
-            self._stream = BytesIO(self._body)
-
-        return self._body
-
     @cached_property
     def GET(self):
         return http.QueryDict(self.scope.get("query_string", ""))

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -28,10 +28,9 @@ class RequestTests(unittest.TestCase):
         with all optional fields omitted.
         """
 
-        body_stream = AsgiRequestIO(lambda: {})
-
         request = AsgiRequest(
-            {"http_version": "1.1", "method": "GET", "path": "/test/"}, body_stream
+            {"http_version": "1.1", "method": "GET", "path": "/test/"},
+            AsgiRequestIO(lambda: {}),
         )
         self.assertEqual(request.path, "/test/")
         self.assertEqual(request.method, "GET")
@@ -51,8 +50,6 @@ class RequestTests(unittest.TestCase):
         Tests a more fully-featured GET request
         """
 
-        body_stream = AsgiRequestIO(lambda: {})
-
         request = AsgiRequest(
             {
                 "http_version": "1.1",
@@ -66,7 +63,7 @@ class RequestTests(unittest.TestCase):
                 "client": ["10.0.0.1", 1234],
                 "server": ["10.0.0.2", 80],
             },
-            body_stream,
+            AsgiRequestIO(lambda: {}),
         )
         self.assertEqual(request.path, "/test2/")
         self.assertEqual(request.method, "GET")
@@ -91,8 +88,6 @@ class RequestTests(unittest.TestCase):
         def receive():
             return {"type": "http.request", "body": b"djangoponies=are+awesome"}
 
-        body_stream = AsgiRequestIO(receive)
-
         request = AsgiRequest(
             {
                 "http_version": "1.1",
@@ -105,7 +100,7 @@ class RequestTests(unittest.TestCase):
                     "content-length": b"18",
                 },
             },
-            body_stream,
+            AsgiRequestIO(receive),
         )
         self.assertEqual(request.path, "/test2/")
         self.assertEqual(request.method, "POST")
@@ -138,8 +133,6 @@ class RequestTests(unittest.TestCase):
         def receive():
             return {"type": "http.request", "body": body}
 
-        body_stream = AsgiRequestIO(receive)
-
         request = AsgiRequest(
             {
                 "http_version": "1.1",
@@ -150,7 +143,7 @@ class RequestTests(unittest.TestCase):
                     "content-length": str(len(body)).encode("ascii"),
                 },
             },
-            body_stream,
+            AsgiRequestIO(receive),
         )
         self.assertEqual(request.method, "POST")
         self.assertEqual(len(request.body), len(body))
@@ -191,8 +184,6 @@ class RequestTests(unittest.TestCase):
                 "more_body": bool(chunks),
             }
 
-        body_stream = AsgiRequestIO(receive)
-
         request = AsgiRequest(
             {
                 "http_version": "1.1",
@@ -203,7 +194,7 @@ class RequestTests(unittest.TestCase):
                     "content-length": str(len(body)).encode("ascii"),
                 },
             },
-            body_stream,
+            AsgiRequestIO(receive),
         )
 
         self.assertEqual(request.method, "POST")
@@ -222,8 +213,6 @@ class RequestTests(unittest.TestCase):
         def receive():
             return {"type": "http.request", "body": b"onetwothree"}
 
-        body_stream = AsgiRequestIO(receive)
-
         request = AsgiRequest(
             {
                 "http_version": "1.1",
@@ -231,7 +220,7 @@ class RequestTests(unittest.TestCase):
                 "path": "/",
                 "headers": {"host": b"example.com", "content-length": b"11"},
             },
-            body_stream,
+            AsgiRequestIO(receive),
         )
         self.assertEqual(request.method, "PUT")
         self.assertEqual(request.read(3), b"one")
@@ -254,8 +243,6 @@ class RequestTests(unittest.TestCase):
         def receive():
             return {"type": "http.request", "body": b""}
 
-        body_stream = AsgiRequestIO(receive)
-
         with override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=1):
             with pytest.raises(RequestDataTooBig):
                 AsgiRequest(
@@ -265,7 +252,7 @@ class RequestTests(unittest.TestCase):
                         "path": "/",
                         "headers": {"host": b"example.com", "content-length": b"1000"},
                     },
-                    body_stream,
+                    AsgiRequestIO(receive),
                 ).body
 
     def test_size_check_ignores_files(self):


### PR DESCRIPTION
Refs #1240. This is a sketch of working around loading the request body fully-into-memory before instantiating the `AsgiRequest`. 

The idea is to wrap the `receive` callable such that we can later `read()` it when accessing `request.body`. This would (in theory) allow us to mimic Django's behaviour here. 

This approach means we **won't** be able to response to `http.disconnect` events, but, we're not really handling those anyway, and in a traditional single request-response scenario it's not so important. Maybe we _could_ raise a `RequestAborted` or similar, as per @andrewgodwin's https://github.com/django/django/pull/11209?

(Needs squashing etc.)