### PR TITLE
[bug fix] fix the bug about chat room not found

### DIFF
--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -98,7 +98,7 @@ Create the route for the room view in ``chat/urls.py``::
     
     urlpatterns = [
         url(r'^$', views.index, name='index'),
-        url(r'^(?P<room_name>[^/]+)/$', views.room, name='room'),
+        url(r'^chat/(?P<room_name>[^/]+)/$', views.room, name='room'),
     ]
 
 Start the Channels development server::


### PR DESCRIPTION
Fix the bug that chat room may not be found in the tutorial.
The path in the html file is "window.location.pathname = '/chat/' + roomName + '/';"
And the path in the python file is "^/(?P<room_name>[^/]+)/$" , missing "chat".