### PR TITLE
allowed setting default message-type handler for consumers

### DIFF
--- a/channels/consumer.py
+++ b/channels/consumer.py
@@ -72,7 +72,11 @@ class AsyncConsumer:
         if handler:
             await handler(message)
         else:
-            raise ValueError("No handler for message type %s" % message["type"])
+            await self.default_handler(message)
+
+    async def default_handler(self, message):
+        """Overrideable handler for messages of un-implemented type."""
+        raise ValueError("No handler for message type %s" % message["type"])
 
     async def send(self, message):
         """
@@ -104,7 +108,11 @@ class SyncConsumer(AsyncConsumer):
         if handler:
             handler(message)
         else:
-            raise ValueError("No handler for message type %s" % message["type"])
+            self.default_handler(message)
+
+    def default_handler(self, message):
+        """Overrideable handler for messages of un-implemented type."""
+        raise ValueError("No handler for message type %s" % message["type"])
 
     def send(self, message):
         """

--- a/docs/topics/channel_layers.rst
+++ b/docs/topics/channel_layers.rst
@@ -119,6 +119,9 @@ connected client, and dispatched to a named method on the consumer. The name
 of the method will be the ``type`` of the event with periods replaced by
 underscores - so, for example, an event coming in over the channel layer
 with a ``type`` of ``chat.join`` will be handled by the method ``chat_join``.
+By default, not handling a message type will raise a ``ValueError``. If you
+want to handle all messages, even of a ``type`` you have not implemented, you
+can override the ``default_handler`` method.
 
 .. note::
 


### PR DESCRIPTION
I have recently stumbled over this problem: it is part of a group that I use to monitor which channels are active. This "admin" channel receives status updates and "admin" type messages. Sending these messages stopped my websocket client without an error message. Here is the offending code:

        async_to_sync(self.channel_layer.group_send)(
            ADMIN_GROUP_NAME,
            {
                'id': self.group_name,
                'type': "admin",
                'msg_type': msg_type,
                'content': content,
            }
        )

After some digging I found out that a consumer that receives a message must handle that message or it will generate a `ValueError`. This ValueError is apparently enough to stop my original consumer.

From the documentation, it was not clear to me that a Consumer must handle all message types it could possibly receive, and raises errors if not.

I have made a change that (a) documents this behaviour and (b) allows developers to override the behaviour by implementing a `default_handler(self, message)` method. This method replicates the current behaviour, so it is backwards compatible. Any message for which no handler was found is passed to this handler. So one could use it to generically handle messages, log unknown message types or simply ignore them.