### PR TITLE
Fix DatabaseSyncToAsync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 dist: xenial
 
+services:
+  - postgresql
+
 language: python
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   - DJANGO="Django==3.0.*"
 
 install:
-  - pip install -U pip wheel setuptools
+  - pip install -U pip wheel setuptools psycopg2
   - pip install $DJANGO -e .[tests]
   - pip freeze
 

--- a/channels/db.py
+++ b/channels/db.py
@@ -43,11 +43,11 @@ class DatabaseSyncToAsyncForTests(SyncToAsync):
 
     def thread_handler(self, loop, *args, **kwargs):
         self._inherit_main_thread_connections()
-        close_old_connections()
+        self._close_old_connections()
         try:
             return super().thread_handler(loop, *args, **kwargs)
         finally:
-            close_old_connections()
+            self._close_old_connections()
 
 
 # The class is TitleCased, but we want to encourage use as a callable/decorator

--- a/channels/db.py
+++ b/channels/db.py
@@ -1,19 +1,48 @@
-from django.db import close_old_connections
+from concurrent.futures import ThreadPoolExecutor
+
+from django.db import connections
 
 from asgiref.sync import SyncToAsync
+
+main_thread_connections = {name: connections[name] for name in connections}
+
+
+def _inherit_main_thread_connections():
+    """Copy/use DB connections in atomic block from main thread.
+
+    This is required for tests using Django's TestCase.
+    """
+    for name in main_thread_connections:
+        if main_thread_connections[name].in_atomic_block:
+            connections[name] = main_thread_connections[name]
+            connections[name].inc_thread_sharing()
 
 
 class DatabaseSyncToAsync(SyncToAsync):
     """
-    SyncToAsync version that cleans up old database connections when it exits.
+    SyncToAsync version that cleans up old database connections.
     """
 
+    executor = ThreadPoolExecutor(
+        # TODO
+        # max_workers=settings.N_SYNC_DATABASE_CONNECTIONS,
+        thread_name_prefix="our-database-sync-to-async-",
+        initializer=_inherit_main_thread_connections,
+    )
+
+    def _close_old_connections(self):
+        """Like django.db.close_old_connections, but skipping in_atomic_block."""
+        for conn in connections.all():
+            if conn.in_atomic_block:
+                continue
+            conn.close_if_unusable_or_obsolete()
+
     def thread_handler(self, loop, *args, **kwargs):
-        close_old_connections()
+        self._close_old_connections()
         try:
             return super().thread_handler(loop, *args, **kwargs)
         finally:
-            close_old_connections()
+            self._close_old_connections()
 
 
 # The class is TitleCased, but we want to encourage use as a callable/decorator

--- a/channels/db.py
+++ b/channels/db.py
@@ -1,5 +1,4 @@
-from django.db import connections
-from django.db import close_old_connections
+from django.db import close_old_connections, connections
 
 from asgiref.sync import SyncToAsync
 

--- a/channels/db.py
+++ b/channels/db.py
@@ -1,5 +1,3 @@
-from concurrent.futures import ThreadPoolExecutor
-
 from django.db import connections
 
 from asgiref.sync import SyncToAsync
@@ -23,13 +21,6 @@ class DatabaseSyncToAsync(SyncToAsync):
     SyncToAsync version that cleans up old database connections.
     """
 
-    executor = ThreadPoolExecutor(
-        # TODO
-        # max_workers=settings.N_SYNC_DATABASE_CONNECTIONS,
-        thread_name_prefix="our-database-sync-to-async-",
-        initializer=_inherit_main_thread_connections,
-    )
-
     def _close_old_connections(self):
         """Like django.db.close_old_connections, but skipping in_atomic_block."""
         for conn in connections.all():
@@ -38,6 +29,7 @@ class DatabaseSyncToAsync(SyncToAsync):
             conn.close_if_unusable_or_obsolete()
 
     def thread_handler(self, loop, *args, **kwargs):
+        _inherit_main_thread_connections()
         self._close_old_connections()
         try:
             return super().thread_handler(loop, *args, **kwargs)

--- a/channels/db.py
+++ b/channels/db.py
@@ -10,6 +10,7 @@ class DatabaseSyncToAsync(SyncToAsync):
     """
     SyncToAsync version that cleans up old database connections.
     """
+
     def __init__(self, *args, **kwargs):
         self.main_thread_connections = {name: connections[name] for name in connections}
         super().__init__(*args, **kwargs)

--- a/channels/db.py
+++ b/channels/db.py
@@ -1,6 +1,9 @@
-from django.db import close_old_connections, connections
+import django
+from django.db import connections
 
 from asgiref.sync import SyncToAsync
+
+HAS_INC_THREAD_SHARING = django.VERSION >= (2, 2)
 
 
 class DatabaseSyncToAsync(SyncToAsync):
@@ -16,12 +19,17 @@ class DatabaseSyncToAsync(SyncToAsync):
 
         This is required for tests using Django's TestCase.
         """
-        from django.db import connections
+        restore_allow_thread_sharing = []
 
         for name in self.main_thread_connections:
             if self.main_thread_connections[name].in_atomic_block:
                 connections[name] = self.main_thread_connections[name]
-                connections[name].inc_thread_sharing()
+                if HAS_INC_THREAD_SHARING:
+                    connections[name].inc_thread_sharing()
+                elif not connections[name].allow_thread_sharing:
+                    restore_allow_thread_sharing.append(name)
+                    connections[name].allow_thread_sharing = True
+        return restore_allow_thread_sharing
 
     def _close_old_connections(self):
         """Like django.db.close_old_connections, but skipping in_atomic_block.
@@ -33,12 +41,14 @@ class DatabaseSyncToAsync(SyncToAsync):
                 conn.close_if_unusable_or_obsolete()
 
     def thread_handler(self, loop, *args, **kwargs):
-        self._inherit_main_thread_connections()
+        restore_allow_thread_sharing = self._inherit_main_thread_connections()
         self._close_old_connections()
         try:
             return super().thread_handler(loop, *args, **kwargs)
         finally:
             self._close_old_connections()
+            for name in restore_allow_thread_sharing:
+                connections[name].allow_thread_sharing = False
 
 
 # The class is TitleCased, but we want to encourage use as a callable/decorator

--- a/channels/db.py
+++ b/channels/db.py
@@ -1,25 +1,38 @@
 from django.db import connections
+from django.db import close_old_connections
 
 from asgiref.sync import SyncToAsync
-
-main_thread_connections = {name: connections[name] for name in connections}
-
-
-def _inherit_main_thread_connections():
-    """Copy/use DB connections in atomic block from main thread.
-
-    This is required for tests using Django's TestCase.
-    """
-    for name in main_thread_connections:
-        if main_thread_connections[name].in_atomic_block:
-            connections[name] = main_thread_connections[name]
-            connections[name].inc_thread_sharing()
 
 
 class DatabaseSyncToAsync(SyncToAsync):
     """
     SyncToAsync version that cleans up old database connections.
     """
+
+    def thread_handler(self, loop, *args, **kwargs):
+        close_old_connections()
+        try:
+            return super().thread_handler(loop, *args, **kwargs)
+        finally:
+            close_old_connections()
+
+
+class DatabaseSyncToAsyncForTests(SyncToAsync):
+    def __init__(self, *args, **kwargs):
+        self.main_thread_connections = {name: connections[name] for name in connections}
+        super().__init__(*args, **kwargs)
+
+    def _inherit_main_thread_connections(self):
+        """Copy/use DB connections in atomic block from main thread.
+
+        This is required for tests using Django's TestCase.
+        """
+        from django.db import connections
+
+        for name in self.main_thread_connections:
+            if self.main_thread_connections[name].in_atomic_block:
+                connections[name] = self.main_thread_connections[name]
+                connections[name].inc_thread_sharing()
 
     def _close_old_connections(self):
         """Like django.db.close_old_connections, but skipping in_atomic_block."""
@@ -29,12 +42,12 @@ class DatabaseSyncToAsync(SyncToAsync):
             conn.close_if_unusable_or_obsolete()
 
     def thread_handler(self, loop, *args, **kwargs):
-        _inherit_main_thread_connections()
-        self._close_old_connections()
+        self._inherit_main_thread_connections()
+        close_old_connections()
         try:
             return super().thread_handler(loop, *args, **kwargs)
         finally:
-            self._close_old_connections()
+            close_old_connections()
 
 
 # The class is TitleCased, but we want to encourage use as a callable/decorator

--- a/channels/signals.py
+++ b/channels/signals.py
@@ -1,8 +1,9 @@
-from django.db import close_old_connections
 from django.dispatch import Signal
+
+from channels.db import _close_old_connections
 
 consumer_started = Signal(providing_args=["environ"])
 consumer_finished = Signal()
 
 # Connect connection closer to consumer finished as well
-consumer_finished.connect(close_old_connections)
+consumer_finished.connect(_close_old_connections)

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,4 @@ universal=1
 
 [tool:pytest]
 testpaths = tests
+addopts = -ra

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,70 @@
+import pytest
+
+pytest_plugins = ["pytester"]
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+@pytest.mark.parametrize("db_engine", (
+    "django.db.backends.sqlite3",
+    "django.db.backends.postgresql",
+))
+@pytest.mark.parametrize("conn_max_age", (0, 600))
+async def test_database_sync_to_async(db_engine, conn_max_age, testdir):
+    testdir.makeconftest(
+        """
+        from django.conf import settings
+
+
+        settings.configure(
+            DATABASES={
+                "default": {
+                    "ENGINE": "%s",
+                    "CONN_MAX_AGE": %d,
+                }
+            },
+            INSTALLED_APPS=[
+                "django.contrib.auth",
+                "django.contrib.contenttypes",
+                "django.contrib.sessions",
+                "django.contrib.admin",
+                "channels",
+            ],
+        )
+        """ % (
+            db_engine,
+            conn_max_age,
+        )
+    )
+    p1 = testdir.makepyfile(
+        """
+        import pytest
+        from channels.db import database_sync_to_async
+
+        @pytest.mark.asyncio
+        @pytest.mark.django_db
+        async def test_inner():
+            from django.contrib.auth.models import User
+            from django.db import connections
+
+            conn = connections["default"]
+            assert conn.in_atomic_block
+
+            assert User.objects.count() == 0
+
+            @database_sync_to_async
+            def create_obj(**kwargs):
+                User.objects.create(**kwargs)
+
+            await create_obj(username="alice")
+            await create_obj(username="bob")
+            assert User.objects.count() == 2
+
+        @pytest.mark.django_db
+        def test_check_rolled_back():
+            from django.contrib.auth.models import User
+            assert User.objects.count() == 0
+        """
+    )
+    result = testdir.runpytest_subprocess(str(p1))
+    assert result.ret == 0

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -10,8 +10,7 @@ pytest_plugins = ["pytester"]
     "django.db.backends.postgresql",
 ))
 @pytest.mark.parametrize("conn_max_age", (0, 600))
-@pytest.mark.parametrize("use_fix", (True, False))
-async def test_database_sync_to_async(db_engine, conn_max_age, use_fix, testdir):
+async def test_database_sync_to_async(db_engine, conn_max_age, testdir):
     if db_engine == "django.db.backends.postgresql":
         pytest.importorskip("psycopg2")
 
@@ -43,11 +42,7 @@ async def test_database_sync_to_async(db_engine, conn_max_age, use_fix, testdir)
     p1 = testdir.makepyfile(
         """
         import pytest
-        use_fix = %r
-        if use_fix:
-            from channels.db import DatabaseSyncToAsyncForTests as database_sync_to_async
-        else:
-            from channels.db import database_sync_to_async
+        from channels.db import database_sync_to_async
 
         @pytest.mark.asyncio
         @pytest.mark.django_db
@@ -72,12 +67,7 @@ async def test_database_sync_to_async(db_engine, conn_max_age, use_fix, testdir)
         def test_check_rolled_back():
             from django.contrib.auth.models import User
             assert User.objects.count() == 0
-        """ % (
-            int(use_fix),
-        )
+        """
     )
     result = testdir.runpytest_subprocess(str(p1))
-    if use_fix:
-        assert result.ret == 0
-    else:
-        assert result.ret == 1
+    assert result.ret == 0

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -77,4 +77,7 @@ async def test_database_sync_to_async(db_engine, conn_max_age, use_fix, testdir)
         )
     )
     result = testdir.runpytest_subprocess(str(p1))
-    assert result.ret == 0
+    if use_fix:
+        assert result.ret == 0
+    else:
+        assert result.ret == 1

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -24,6 +24,7 @@ async def test_database_sync_to_async(db_engine, conn_max_age, use_fix, testdir)
                 "default": {
                     "ENGINE": %r,
                     "CONN_MAX_AGE": %d,
+                    "NAME": "channels_tests",
                 }
             },
             INSTALLED_APPS=[

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -11,15 +11,17 @@ pytest_plugins = ["pytester"]
 ))
 @pytest.mark.parametrize("conn_max_age", (0, 600))
 async def test_database_sync_to_async(db_engine, conn_max_age, testdir):
+    if db_engine == "django.db.backends.postgresql":
+        pytest.importorskip("psycopg2")
+
     testdir.makeconftest(
         """
         from django.conf import settings
 
-
         settings.configure(
             DATABASES={
                 "default": {
-                    "ENGINE": "%s",
+                    "ENGINE": %r,
                     "CONN_MAX_AGE": %d,
                 }
             },

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -5,10 +5,9 @@ pytest_plugins = ["pytester"]
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-@pytest.mark.parametrize("db_engine", (
-    "django.db.backends.sqlite3",
-    "django.db.backends.postgresql",
-))
+@pytest.mark.parametrize(
+    "db_engine", ("django.db.backends.sqlite3", "django.db.backends.postgresql")
+)
 @pytest.mark.parametrize("conn_max_age", (0, 600))
 async def test_database_sync_to_async(db_engine, conn_max_age, testdir):
     if db_engine == "django.db.backends.postgresql":
@@ -34,10 +33,8 @@ async def test_database_sync_to_async(db_engine, conn_max_age, testdir):
                 "channels",
             ],
         )
-        """ % (
-            db_engine,
-            conn_max_age,
-        )
+        """
+        % (db_engine, conn_max_age)
     )
     p1 = testdir.makepyfile(
         """

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -39,22 +39,23 @@ async def test_database_sync_to_async(db_engine, conn_max_age, testdir):
     p1 = testdir.makepyfile(
         """
         import pytest
+        from django.contrib.auth.models import User
+
         from channels.db import database_sync_to_async
+
+        @database_sync_to_async
+        def create_obj(**kwargs):
+            User.objects.create(**kwargs)
 
         @pytest.mark.asyncio
         @pytest.mark.django_db
         async def test_inner():
-            from django.contrib.auth.models import User
             from django.db import connections
 
             conn = connections["default"]
             assert conn.in_atomic_block
 
             assert User.objects.count() == 0
-
-            @database_sync_to_async
-            def create_obj(**kwargs):
-                User.objects.create(**kwargs)
 
             await create_obj(username="alice")
             await create_obj(username="bob")


### PR DESCRIPTION
- copy/use connections from the main thread, which are in an atomic
  block (used in tests)
- do not close connections in atomic blocks

Ref: https://github.com/django/channels/issues/1091#issuecomment-489488831