### PR TITLE
ci: run linting after tests, output diff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ script:
   - pytest
 
 stages:
-  - lint
   - test
+  - lint
   - name: release
     if: tag IS present
 
@@ -36,7 +36,7 @@ jobs:
       install: pip install -U -e .[tests] black pyflakes isort
       script:
         - pyflakes channels tests
-        - black --check channels tests
+        - black --check --diff channels tests
         - isort --check-only --diff --recursive channels tests
 
     - stage: release


### PR DESCRIPTION
It is not very useful to get a failure because of style issues, without
any feedback on the actual tests.  Also black should display what it
would change (`--diff`).