### PR TITLE
AsyncHttpConsumer: Do not stop the consumer when exiting `self.handle` already

### DIFF
--- a/channels/generic/http.py
+++ b/channels/generic/http.py
@@ -43,6 +43,9 @@ class AsyncHttpConsumer(AsyncConsumer):
         await self.send(
             {"type": "http.response.body", "body": body, "more_body": more_body}
         )
+        if not more_body:
+            await self.disconnect()
+            raise StopConsumer()
 
     async def send_response(self, status, body, **kwargs):
         """
@@ -78,11 +81,7 @@ class AsyncHttpConsumer(AsyncConsumer):
         if "body" in message:
             self.body.append(message["body"])
         if not message.get("more_body"):
-            try:
-                await self.handle(b"".join(self.body))
-            finally:
-                await self.disconnect()
-                raise StopConsumer()
+            await self.handle(b"".join(self.body))
 
     async def http_disconnect(self, message):
         """


### PR DESCRIPTION
Earlier `self.handle` always disconnected the HTTP client and stopped
the consumer when exiting. This meant that the consumer couldn't receive
any messages from the channel layer at all, making it impossible to send
e.g. messages from workers to connected HTTP clients via long polling or
server-sent events.