### PR TITLE
Handle the HTTP request body as a spooled temp file.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,13 @@
 Full release notes, with more details and upgrade information, are available at:
 https://channels.readthedocs.io/en/latest/releases
 
+UNRELEASED
+----------
+
+* Adjusted HTTP body handling to use a spooled file, rather than reading
+  request body into memory. ``AsgiRequest.__init__()`` is adjusted to expected
+  an IO stream, rather than bytes.
+
 2.2.0 (2019-04-14)
 ------------------
 


### PR DESCRIPTION
Continuation of #1345 and #1251 

Here is an excerpt from the changes:

- code containing improvement - replacement with the spooled temporary file (https://github.com/django/channels/pull/1251#issuecomment-503956365)
- the fix for #1240 .