### PR TITLE
Lazy daphne import

### DIFF
--- a/channels/apps.py
+++ b/channels/apps.py
@@ -1,12 +1,5 @@
 from django.apps import AppConfig
 
-# We import this here to ensure the reactor is installed very early on
-# in case other packages accidentally import twisted.internet.reactor
-# (e.g. raven does this).
-import daphne.server
-
-assert daphne.server  # pyflakes doesn't support ignores
-
 
 class ChannelsConfig(AppConfig):
 


### PR DESCRIPTION
Lazy import of daphne to avoid incurring the import overhead of all of twisted in for example unit tests where we don't need it.

The overhead for this entire import graph is 0.35s on my work project. This is 15% of the import time for an app that is 280k lines of python, most of which is actually imported in this test!

There is a workaround for raven in apps.py that I had to remove. I don't think it makes sense for this project to work around bugs in raven. Better to document this and supply the workaround, or try to discover the fault and error out on it (and then point to the workaround).