### PR TITLE
Refs #962 -- Removed tutorial note that tests didn't run on macOS.

### DIFF
--- a/docs/tutorial/part_4.rst
+++ b/docs/tutorial/part_4.rst
@@ -4,16 +4,6 @@ Tutorial Part 4: Automated Testing
 This tutorial begins where :doc:`Tutorial 3 </tutorial/part_3>` left off.
 We've built a simple chat server and now we'll create some automated tests for it.
 
-.. note::
-    The ChannelsLiveServerTestCase used in this tutorial hangs on macOS due to
-    a `known issue`_.
-    
-    If you want to complete this tutorial on macOS, please downgrade Channels
-    to version 2.0.2 using ``pip3 install channels==2.0.2`` until the issue
-    is fixed.
-
-.. _known issue: https://github.com/django/channels/issues/962
-
 Testing the views
 -----------------
 
@@ -57,10 +47,10 @@ Put the following code in ``chat/tests.py``::
     from selenium import webdriver
     from selenium.webdriver.common.action_chains import ActionChains
     from selenium.webdriver.support.wait import WebDriverWait
-    
+
     class ChatTests(ChannelsLiveServerTestCase):
         serve_static = True  # emulate StaticLiveServerTestCase
-        
+
         @classmethod
         def setUpClass(cls):
             super().setUpClass()
@@ -70,19 +60,19 @@ Put the following code in ``chat/tests.py``::
             except:
                 super().tearDownClass()
                 raise
-        
+
         @classmethod
         def tearDownClass(cls):
             cls.driver.quit()
             super().tearDownClass()
-        
+
         def test_when_chat_message_posted_then_seen_by_everyone_in_same_room(self):
             try:
                 self._enter_chat_room('room_1')
-                
+
                 self._open_new_window()
                 self._enter_chat_room('room_1')
-                
+
                 self._switch_to_window(0)
                 self._post_message('hello')
                 WebDriverWait(self.driver, 2).until(lambda _:
@@ -94,20 +84,20 @@ Put the following code in ``chat/tests.py``::
                     'Message was not received by window 2 from window 1')
             finally:
                 self._close_all_new_windows()
-        
+
         def test_when_chat_message_posted_then_not_seen_by_anyone_in_different_room(self):
             try:
                 self._enter_chat_room('room_1')
-                
+
                 self._open_new_window()
                 self._enter_chat_room('room_2')
-                
+
                 self._switch_to_window(0)
                 self._post_message('hello')
                 WebDriverWait(self.driver, 2).until(lambda _:
                     'hello' in self._chat_log_value,
                     'Message was not received by window 1 from window 1')
-                
+
                 self._switch_to_window(1)
                 self._post_message('world')
                 WebDriverWait(self.driver, 2).until(lambda _:
@@ -117,32 +107,32 @@ Put the following code in ``chat/tests.py``::
                     'Message was improperly received by window 2 from window 1')
             finally:
                 self._close_all_new_windows()
-        
+
         # === Utility ===
-        
+
         def _enter_chat_room(self, room_name):
             self.driver.get(self.live_server_url + '/chat/')
             ActionChains(self.driver).send_keys(room_name + '\n').perform()
             WebDriverWait(self.driver, 2).until(lambda _:
                 room_name in self.driver.current_url)
-        
+
         def _open_new_window(self):
             self.driver.execute_script('window.open("about:blank", "_blank");')
             self.driver.switch_to_window(self.driver.window_handles[-1])
-        
+
         def _close_all_new_windows(self):
             while len(self.driver.window_handles) > 1:
                 self.driver.switch_to_window(self.driver.window_handles[-1])
                 self.driver.execute_script('window.close();')
             if len(self.driver.window_handles) == 1:
                 self.driver.switch_to_window(self.driver.window_handles[0])
-        
+
         def _switch_to_window(self, window_index):
             self.driver.switch_to_window(self.driver.window_handles[window_index])
-        
+
         def _post_message(self, message):
             ActionChains(self.driver).send_keys(message + '\n').perform()
-        
+
         @property
         def _chat_log_value(self):
             return self.driver.find_element_by_css_selector('#chat-log').get_property('value')
@@ -179,7 +169,7 @@ You should see output that looks like::
     ..
     ----------------------------------------------------------------------
     Ran 2 tests in 5.014s
-    
+
     OK
     Destroying test database for alias 'default'...
 


### PR DESCRIPTION
Fixed by https://github.com/django/daphne/pull/247.

@kuratowski's PR solves the "Daphne tests hanging on macOS" issue and allows @dgilge's tests from https://github.com/dgilge/channels-tests to pass, so removing @davidfstr's note, to the effect that they don't work. 

Thanks everyone for the effort! 