### PR TITLE
Remove old Django compat code

### DIFF
--- a/channels/routing.py
+++ b/channels/routing.py
@@ -101,15 +101,13 @@ class URLRouter:
 
     def __init__(self, routes):
         self.routes = routes
-        # Django 2 introduced path(); older routes have no "pattern" attribute
-        if self.routes and hasattr(self.routes[0], "pattern"):
-            for route in self.routes:
-                # The inner ASGI app wants to do additional routing, route
-                # must not be an endpoint
-                if getattr(route.callback, "_path_routing", False) is True:
-                    route.pattern._is_endpoint = False
 
         for route in self.routes:
+            # The inner ASGI app wants to do additional routing, route
+            # must not be an endpoint
+            if getattr(route.callback, "_path_routing", False) is True:
+                route.pattern._is_endpoint = False
+
             if not route.callback and isinstance(route, URLResolver):
                 raise ImproperlyConfigured(
                     "%s: include() is not supported in URLRouter. Use nested"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock
 
-import django
 import pytest
 from django.conf.urls import url
 from django.core.exceptions import ImproperlyConfigured
@@ -141,7 +140,6 @@ def test_url_router_nesting():
     assert test_app.call_args[0][0]["url_route"] == {"args": ("foo", "3"), "kwargs": {}}
 
 
-@pytest.mark.skipif(django.VERSION[0] < 2, reason="Needs Django 2.x")
 def test_url_router_nesting_path():
     """
     Tests that nested URLRouters add their keyword captures together when used
@@ -176,7 +174,6 @@ def test_url_router_nesting_path():
         assert outer_router({"type": "http", "path": "/number/42/blub/"})
 
 
-@pytest.mark.skipif(django.VERSION[0] < 2, reason="Needs Django 2.x")
 def test_url_router_path():
     """
     Tests that URLRouter also works with path()


### PR DESCRIPTION
PR #1389 moved minimum supported Django to 2.2 so these old code paths can be removed.