### PR TITLE
Updated middleware to ASGI 3

### DIFF
--- a/channels/middleware.py
+++ b/channels/middleware.py
@@ -18,7 +18,7 @@ class BaseMiddleware:
         """
         self.inner = inner
 
-    def __call__(self, scope):
+    async def __call__(self, scope, receive, send):
         """
         ASGI constructor; can insert things into the scope, but not
         run asynchronous code.
@@ -27,15 +27,13 @@ class BaseMiddleware:
         scope = dict(scope)
         # Allow subclasses to change the scope
         self.populate_scope(scope)
-        # Call the inner application's init
-        inner_instance = self.inner(scope)
         # Partially bind it to our coroutine entrypoint along with the scope
-        return partial(self.coroutine_call, inner_instance, scope)
+        return await self.coroutine_call(self.inner, scope, receive, send)
 
-    async def coroutine_call(self, inner_instance, scope, receive, send):
+    async def coroutine_call(self, inner, scope, receive, send):
         """
         ASGI coroutine; where we can resolve items in the scope
         (but you can't modify it at the top level here!)
         """
         await self.resolve_scope(scope)
-        await inner_instance(receive, send)
+        await inner(scope, receive, send)

--- a/channels/middleware.py
+++ b/channels/middleware.py
@@ -1,6 +1,3 @@
-from functools import partial
-
-
 class BaseMiddleware:
     """
     Base class for implementing ASGI middleware. Inherit from this and

--- a/channels/sessions.py
+++ b/channels/sessions.py
@@ -28,7 +28,7 @@ class CookieMiddleware:
     def __init__(self, inner):
         self.inner = inner
 
-    def __call__(self, scope):
+    async def __call__(self, scope, receive, send):
         # Check this actually has headers. They're a required scope key for HTTP and WS.
         if "headers" not in scope:
             raise ValueError(
@@ -44,7 +44,7 @@ class CookieMiddleware:
             # No cookie header found - add an empty default.
             cookies = {}
         # Return inner application
-        return self.inner(dict(scope, cookies=cookies))
+        return await self.inner(dict(scope, cookies=cookies), receive, send)
 
     @classmethod
     def set_cookie(
@@ -141,17 +141,11 @@ class SessionMiddleware:
         self.cookie_name = settings.SESSION_COOKIE_NAME
         self.session_store = import_module(settings.SESSION_ENGINE).SessionStore
 
-    def __call__(self, scope):
-        return SessionMiddlewareInstance(scope, self)
-
-
-class SessionMiddlewareInstance:
-    """
-    Inner class that is instantiated once per scope.
-    """
-
-    def __init__(self, scope, middleware):
-        self.middleware = middleware
+    async def __call__(self, scope, receive, send):
+        """
+        We intercept the send() callable so we can do session saves and
+        add session cookie overrides to send back.
+        """
         self.scope = dict(scope)
         if "session" in self.scope:
             # There's already session middleware of some kind above us, pass that through
@@ -165,22 +159,15 @@ class SessionMiddlewareInstance:
             # Parse the headers in the scope into cookies
             self.scope["session"] = LazyObject()
             self.activated = True
-        # Instantiate our inner application
-        self.inner = self.middleware.inner(self.scope)
 
-    async def __call__(self, receive, send):
-        """
-        We intercept the send() callable so we can do session saves and
-        add session cookie overrides to send back.
-        """
         # Resolve the session now we can do it in a blocking way
-        session_key = self.scope["cookies"].get(self.middleware.cookie_name)
+        session_key = self.scope["cookies"].get(self.cookie_name)
         self.scope["session"]._wrapped = await database_sync_to_async(
-            self.middleware.session_store
+            self.session_store
         )(session_key)
         # Override send
         self.real_send = send
-        return await self.inner(receive, self.send)
+        return await self.inner(self.scope, receive, self.send)
 
     async def send(self, message):
         """
@@ -194,14 +181,14 @@ class SessionMiddlewareInstance:
             # changed data, save it. We also save if it's empty as we might
             # not be able to send a cookie-delete along with this message.
             if (
-                message["type"] in self.middleware.save_message_types
+                message["type"] in self.save_message_types
                 and message.get("status", 200) != 500
                 and (modified or settings.SESSION_SAVE_EVERY_REQUEST)
             ):
                 await database_sync_to_async(self.save_session)()
                 # If this is a message type that can transport cookies back to the
                 # client, then do so.
-                if message["type"] in self.middleware.cookie_response_message_types:
+                if message["type"] in self.cookie_response_message_types:
                     if empty:
                         # Delete cookie if it's set
                         if settings.SESSION_COOKIE_NAME in self.scope["cookies"]:
@@ -223,7 +210,7 @@ class SessionMiddlewareInstance:
                         # Set the cookie
                         CookieMiddleware.set_cookie(
                             message,
-                            self.middleware.cookie_name,
+                            self.cookie_name,
                             self.scope["session"].session_key,
                             max_age=max_age,
                             expires=expires,

--- a/tests/security/test_auth.py
+++ b/tests/security/test_auth.py
@@ -247,24 +247,3 @@ async def test_logout_not_logged_in(session):
 
     assert "user" not in scope
     assert isinstance(await get_user(scope), AnonymousUser)
-
-
-@pytest.mark.django_db(transaction=True)
-@pytest.mark.asyncio
-async def test_scope_user_error_message(session):
-    """
-    Tests that the correct error message is thrown when scope user is accessed before it's ready
-    """
-
-    class TestConsumer(WebsocketConsumer):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            if "user" in self.scope:
-                # access scope user before it's ready
-                getattr(self.scope["user"], "test")
-
-    with pytest.raises(ValueError, match="Accessing scope user before it is ready."):
-        scope = {"session": session}
-        app = guarantee_single_callable(TestConsumer)
-        auth = AuthMiddleware(app)
-        await auth(scope, lambda e: None, lambda e: None)

--- a/tests/security/test_auth.py
+++ b/tests/security/test_auth.py
@@ -14,6 +14,7 @@ from django.contrib.auth import (
 from django.contrib.auth.models import AnonymousUser
 
 from asgiref.sync import sync_to_async
+from asgiref.compatibility import guarantee_single_callable
 from channels.auth import AuthMiddleware, get_user, login, logout
 from channels.db import database_sync_to_async
 from channels.generic.websocket import WebsocketConsumer
@@ -264,5 +265,6 @@ async def test_scope_user_error_message(session):
 
     with pytest.raises(ValueError, match="Accessing scope user before it is ready."):
         scope = {"session": session}
-        auth = AuthMiddleware(TestConsumer)
-        auth(scope)
+        app = guarantee_single_callable(TestConsumer)
+        auth = AuthMiddleware(app)
+        await auth(scope, lambda e: None, lambda e: None)

--- a/tests/security/test_auth.py
+++ b/tests/security/test_auth.py
@@ -14,10 +14,8 @@ from django.contrib.auth import (
 from django.contrib.auth.models import AnonymousUser
 
 from asgiref.sync import sync_to_async
-from asgiref.compatibility import guarantee_single_callable
-from channels.auth import AuthMiddleware, get_user, login, logout
+from channels.auth import get_user, login, logout
 from channels.db import database_sync_to_async
-from channels.generic.websocket import WebsocketConsumer
 
 
 class CatchSignal:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -9,6 +9,7 @@ from django.http import HttpResponse, RawPostDataException
 from django.test import override_settings
 
 from asgiref.testing import ApplicationCommunicator
+from asgiref.compatibility import guarantee_single_callable
 from channels.consumer import AsyncConsumer
 from channels.db import database_sync_to_async
 from channels.http import AsgiHandler, AsgiRequest
@@ -344,8 +345,10 @@ async def test_sessions():
             )
             await self.send({"type": "http.response.body", "body": b"test response"})
 
+    app = guarantee_single_callable(SimpleHttpApp)
+
     communicator = HttpCommunicator(
-        SessionMiddlewareStack(SimpleHttpApp), "GET", "/test/"
+        SessionMiddlewareStack(app), "GET", "/test/"
     )
     response = await communicator.get_response()
     headers = response.get("headers", [])

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -8,8 +8,8 @@ from django.core.exceptions import RequestDataTooBig
 from django.http import HttpResponse, RawPostDataException
 from django.test import override_settings
 
-from asgiref.testing import ApplicationCommunicator
 from asgiref.compatibility import guarantee_single_callable
+from asgiref.testing import ApplicationCommunicator
 from channels.consumer import AsyncConsumer
 from channels.db import database_sync_to_async
 from channels.http import AsgiHandler, AsgiRequest
@@ -347,9 +347,7 @@ async def test_sessions():
 
     app = guarantee_single_callable(SimpleHttpApp)
 
-    communicator = HttpCommunicator(
-        SessionMiddlewareStack(app), "GET", "/test/"
-    )
+    communicator = HttpCommunicator(SessionMiddlewareStack(app), "GET", "/test/")
     response = await communicator.get_response()
     headers = response.get("headers", [])
 


### PR DESCRIPTION
This PR updates `BaseMiddleware`, `SessionMiddleware`, `CookieMiddleware`, and `AuthMiddleware` to use ASGI 3 single callables, which should fix #1316.

A few questions:
- Since we're not maintaining ASGI 2 compatibility, should these middlewares log a warning or raise an exception when a user tries to initialize them with a legacy double-callable application?
- Do we need to maintain a distinction between https://github.com/jaydenwindle/channels/blob/76c9510c625a1fb8557d71bf872109f197c05486/channels/middleware.py#L21 and https://github.com/jaydenwindle/channels/blob/76c9510c625a1fb8557d71bf872109f197c05486/channels/middleware.py#L33 in `BaseMiddleware` now that inner apps aren't initialized before being called? Or can we call both `populate_scope` and `resolve_scope` in the `BaseMiddleware` callable prior to awaiting the inner app?
- There's currently one failing test (`test_scope_user_error_message`) that ensures that an exception is thrown when an application tries to access the user scope before `AuthMiddleware` has initialized it. It looks to me like middleware scopes will always be initialized before the inner application has access to them under the single callable model. Is this test still necessary?

This is my first time contributing to Channels, so I would love any and all feedback :)