### PR TITLE
Correct syntax highlighting

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -25,7 +25,7 @@ Make sure the tests pass:
 
 .. code-block:: sh
 
-    pip install -e .[tests]
+    python -m pip install -e .[tests]
     pytest
 
 Make your change. Add tests for your change. Make the tests pass:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,20 +15,28 @@ For more information, please see our `contribution guide <https://channels.readt
 Quick Setup
 -----------
 
-Fork, then clone the repo::
+Fork, then clone the repo:
+
+.. code-block:: sh
 
     git clone git@github.com:your-username/channels.git
 
-Make sure the tests pass::
+Make sure the tests pass:
+
+.. code-block:: sh
 
     pip install -e .[tests]
     pytest
 
-Make your change. Add tests for your change. Make the tests pass::
+Make your change. Add tests for your change. Make the tests pass:
+
+.. code-block:: sh
 
     pytest
 
-Make sure your code conforms to the coding style::
+Make sure your code conforms to the coding style:
+
+.. code-block:: sh
 
     black ./channels ./tests
     isort --check-only --diff --recursive ./channels ./tests

--- a/docs/asgi.rst
+++ b/docs/asgi.rst
@@ -17,7 +17,9 @@ Summary
 -------
 
 An ASGI application is a callable that takes a scope and returns a coroutine
-callable, that takes receive and send methods. It's usually written as a class::
+callable, that takes receive and send methods. It's usually written as a class:
+
+.. code-block:: python
 
     class Application:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,7 +129,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -75,7 +75,7 @@ your environment:
 .. code-block:: sh
 
     cd channels/
-    pip install -e .[tests]
+    python -m pip install -e .[tests]
 
 Note the ``[tests]`` section there; that tells ``pip`` that you want to install
 the ``tests`` extra, which will bring in testing dependencies like

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -59,7 +59,9 @@ get in touch with Andrew directly at andrew@aeracode.org.
 How do I get started and run the tests?
 ---------------------------------------
 
-First, you should first clone the git repository to a local directory::
+First, you should first clone the git repository to a local directory:
+
+.. code-block:: sh
 
     git clone https://github.com/django/channels.git channels
 
@@ -68,7 +70,9 @@ in; you can use either ``virtualenvwrapper``, ``pipenv`` or just plain
 ``virtualenv`` for this.
 
 Then, ``cd`` into the ``channels`` directory and install it editable into
-your environment::
+your environment:
+
+.. code-block:: sh
 
     cd channels/
     pip install -e .[tests]
@@ -77,11 +81,15 @@ Note the ``[tests]`` section there; that tells ``pip`` that you want to install
 the ``tests`` extra, which will bring in testing dependencies like
 ``pytest-django``.
 
-Then, you can run the tests::
+Then, you can run the tests:
+
+.. code-block:: sh
 
     pytest
 
-Also, there is a tox.ini file at the root of the repository. Example commands::
+Also, there is a tox.ini file at the root of the repository. Example commands:
+
+.. code-block:: sh
 
    $ tox -l
    py36-dj11
@@ -95,7 +103,9 @@ Also, there is a tox.ini file at the root of the repository. Example commands::
    $ tox -e py37-dj22 && tox -e py37-djmaster
 
 Note that tox can also forward arguments to pytest. When using pdb with pytest,
-forward the ``-s`` option to pytest as such::
+forward the ``-s`` option to pytest as such:
+
+.. code-block:: sh
 
    tox -e py37-dj22 -- -s
 

--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -18,7 +18,9 @@ Channels what the *root application* of your project is. As discussed in
 (Protocol Type) router.
 
 It should be a dotted path to the instance of the router; this is generally
-going to be in a file like ``myproject/routing.py``::
+going to be in a file like ``myproject/routing.py``:
+
+.. code-block:: python
 
     ASGI_APPLICATION = "myproject.routing.application"
 
@@ -34,7 +36,9 @@ Setting up a channel backend
 Typically a channel backend will connect to one or more central servers that
 serve as the communication layer - for example, the Redis backend connects
 to a Redis server. All this goes into the ``CHANNEL_LAYERS`` setting;
-here's an example for a remote Redis server::
+here's an example for a remote Redis server:
+
+.. code-block:: python
 
     CHANNEL_LAYERS = {
         "default": {
@@ -45,7 +49,9 @@ here's an example for a remote Redis server::
         },
     }
 
-To use the Redis backend you have to install it::
+To use the Redis backend you have to install it:
+
+.. code-block:: sh
 
     pip install -U channels_redis
 
@@ -66,7 +72,9 @@ in, you can't just pass in the same variable as you configured in
 
 In your project directory, you'll already have a file called ``wsgi.py`` that
 does this to present Django as a WSGI application. Make a new file alongside it
-called ``asgi.py`` and put this in it::
+called ``asgi.py`` and put this in it:
+
+.. code-block:: python
 
     """
     ASGI entrypoint. Configures Django and then runs the application
@@ -86,7 +94,9 @@ on application start, or different ways of loading settings, you can do those
 in here as well.
 
 Now you have this file, all you need to do is pass the ``application`` object
-inside it to your protocol server as the application it should run::
+inside it to your protocol server as the application it should run:
+
+.. code-block:: sh
 
     daphne -p 8001 myproject.asgi:application
 
@@ -120,7 +130,9 @@ To run Daphne, it just needs to be supplied with an application, much like
 a WSGI server would need to be. Make sure you have an ``asgi.py`` file as
 outlined above.
 
-Then, you can run Daphne and supply the ASGI application as the argument::
+Then, you can run Daphne and supply the ASGI application as the argument:
+
+.. code-block:: sh
 
     daphne myproject.asgi:application
 
@@ -132,7 +144,9 @@ If you want to bind multiple Daphne instances to the same port on a machine,
 use a process supervisor that can listen on ports and pass the file descriptors
 to launched processes, and then pass the file descriptor with ``--fd NUM``.
 
-You can also specify the port and IP that Daphne binds to::
+You can also specify the port and IP that Daphne binds to:
+
+.. code-block:: sh
 
     daphne -b 0.0.0.0 -p 8001 myproject.asgi:application
 
@@ -169,14 +183,18 @@ Nginx/Supervisor (Ubuntu)
 This example sets up a Django site on an Ubuntu server, using Nginx as the
 main webserver and supervisord to run and manage Daphne.
 
-First, install Nginx and Supervisor::
+First, install Nginx and Supervisor:
+
+.. code-block:: sh
 
     $ sudo apt install nginx supervisor
 
 Now, you will need to create the supervisor configuration file (often located in
 ``/etc/supervisor/conf.d/`` - here, we're making Supervisor listen on the TCP
 port and then handing that socket off to the child processes so they can all
-share the same bound port::
+share the same bound port:
+
+.. code-block:: ini
 
     [fcgi-program:asgi]
     # TCP socket used by Nginx backend upstream
@@ -203,13 +221,17 @@ share the same bound port::
     stdout_logfile=/your/log/asgi.log
     redirect_stderr=true
 
-Have supervisor reread and update its jobs::
+Have supervisor reread and update its jobs:
+
+.. code-block:: sh
 
     $ sudo supervisorctl reread
     $ sudo supervisorctl update
 
 Next, Nginx has to be told to proxy traffic to the running Daphne instances.
-Setup your nginx upstream conf file for your project::
+Setup your nginx upstream conf file for your project:
+
+.. code-block:: text
 
     upstream channels-backend {
         server localhost:8000;
@@ -237,6 +259,8 @@ Setup your nginx upstream conf file for your project::
         ...
     }
 
-Reload nginx to apply the changes::
+Reload nginx to apply the changes:
+
+.. code-block:: sh
 
     $ sudo service nginx reload

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,12 +1,16 @@
 Installation
 ============
 
-Channels is available on PyPI - to install it, just run::
+Channels is available on PyPI - to install it, just run:
 
-    pip install -U channels
+.. code-block:: sh
+
+    python -m pip install -U channels
 
 Once that's done, you should add ``channels`` to your
-``INSTALLED_APPS`` setting::
+``INSTALLED_APPS`` setting:
+
+.. code-block:: python
 
     INSTALLED_APPS = (
         'django.contrib.auth',
@@ -17,7 +21,9 @@ Once that's done, you should add ``channels`` to your
         'channels',
     )
 
-Then, make a default routing in ``myproject/routing.py``::
+Then, make a default routing in ``myproject/routing.py``:
+
+.. code-block:: python
 
     from channels.routing import ProtocolTypeRouter
 
@@ -26,7 +32,9 @@ Then, make a default routing in ``myproject/routing.py``::
     })
 
 And finally, set your ``ASGI_APPLICATION`` setting to point to that routing
-object as your root application::
+object as your root application:
+
+.. code-block:: python
 
     ASGI_APPLICATION = "myproject.routing.application"
 
@@ -48,7 +56,9 @@ Installing the latest development version
 
 To install the latest version of Channels, clone the repo, change to the repo,
 change to the repo directory, and pip install it into your current virtual
-environment::
+environment:
+
+.. code-block:: sh
 
     $ git clone git@github.com:django/channels.git
     $ cd channels

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -120,7 +120,9 @@ also be short-running - after all, HTTP requests can also be served by consumers
 but they're built around the idea of living for a little while (they live for
 the duration of a *scope*, as we described above).
 
-A basic consumer looks like this::
+A basic consumer looks like this:
+
+.. code-block:: python
 
     class ChatConsumer(WebsocketConsumer):
 
@@ -146,7 +148,9 @@ all in parallel.
 
 Underneath, Channels is running on a fully asynchronous event loop, and
 if you write code like above, it will get called in a synchronous thread.
-This means you can safely do blocking operations, like calling the Django ORM::
+This means you can safely do blocking operations, like calling the Django ORM:
+
+.. code-block:: python
 
     class LogConsumer(WebsocketConsumer):
 
@@ -157,7 +161,9 @@ This means you can safely do blocking operations, like calling the Django ORM::
             )
 
 However, if you want more control and you're willing to work only in
-asynchronous functions, you can write fully asynchronous consumers::
+asynchronous functions, you can write fully asynchronous consumers:
+
+.. code-block:: python
 
     class PingConsumer(AsyncConsumer):
         async def websocket_connect(self, message):
@@ -179,7 +185,9 @@ Routing and Multiple Protocols
 ------------------------------
 
 You can combine multiple Consumers (which are, remember, their own ASGI apps)
-into one bigger app that represents your project using routing::
+into one bigger app that represents your project using routing:
+
+.. code-block:: python
 
     application = URLRouter([
         url(r"^chat/admin/$", AdminChatConsumer),
@@ -189,7 +197,9 @@ into one bigger app that represents your project using routing::
 Channels is not just built around the world of HTTP and WebSockets - it also
 allows you to build any protocol into a Django environment, by building a
 server that maps those protocols into a similar set of events. For example,
-you can build a chatbot in a similar style::
+you can build a chatbot in a similar style:
+
+.. code-block:: python
 
     class ChattyBotConsumer(SyncConsumer):
 
@@ -203,7 +213,9 @@ you can build a chatbot in a similar style::
             })
 
 And then use another router to have the one project able to serve both
-WebSockets and chat requests::
+WebSockets and chat requests:
+
+.. code-block:: python
 
     application = ProtocolTypeRouter({
 
@@ -253,7 +265,9 @@ point-to-point and broadcast messaging.
 (insert cross-process example here)
 
 You can also send messages to a dedicated process that's listening on its own,
-fixed channel name::
+fixed channel name:
+
+.. code-block:: python
 
     # In a consumer
     self.channel_layer.send(
@@ -272,7 +286,9 @@ Django Integration
 
 Channels ships with easy drop-in support for common Django features, like
 sessions and authentication. You can combine authentication with your
-WebSocket views by just adding the right middleware around them::
+WebSocket views by just adding the right middleware around them:
+
+.. code-block:: python
 
     application = ProtocolTypeRouter({
         "websocket": AuthMiddlewareStack(

--- a/docs/one-to-two.rst
+++ b/docs/one-to-two.rst
@@ -120,13 +120,17 @@ Function-based consumers and Routing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Channels 1 allowed you to route by event type (e.g. ``websocket.connect``) and
-pass individual functions with routing that looked like this::
+pass individual functions with routing that looked like this:
+
+.. code-block:: python
 
     channel_routing = [
         route("websocket.connect", connect_blog, path=r'^/liveblog/(?P<slug>[^/]+)/stream/$'),
     ]
 
-And function-based consumers that looked like this::
+And function-based consumers that looked like this:
+
+.. code-block:: python
 
     def connect_blog(message, slug):
         ...
@@ -163,7 +167,9 @@ All :doc:`authentication </topics/authentication>` and
 any decorators that handled them, like ``http_session``, ``channel_session_user``
 and so on (in fact, there are no decorators in Channels 2 - it's all middleware).
 
-To get auth now, wrap your URLRouter in an ``AuthMiddlewareStack``::
+To get auth now, wrap your URLRouter in an ``AuthMiddlewareStack``:
+
+.. code-block:: python
 
     from channels.routing import ProtocolTypeRouter, URLRouter
     from channels.auth import AuthMiddlewareStack
@@ -191,7 +197,9 @@ need to provide has changed to be async. Only ``channels_redis``, formerly known
 ``asgi_redis``, has been updated to match so far.
 
 Settings are still similar to before, but there is no longer a ``ROUTING``
-key (the base routing is instead defined with ``ASGI_APPLICATION``)::
+key (the base routing is instead defined with ``ASGI_APPLICATION``):
+
+.. code-block:: python
 
     CHANNEL_LAYERS = {
         "default": {
@@ -216,7 +224,9 @@ Group objects
 
 Group objects no longer exist; instead you should use the ``group_add``,
 ``group_discard``, and ``group_send`` methods on the ``self.channel_layer``
-object inside of a consumer directly. As an example::
+object inside of a consumer directly. As an example:
+
+.. code-block:: python
 
     from asgiref.sync import async_to_sync
 
@@ -233,7 +243,9 @@ Delay server
 ~~~~~~~~~~~~
 
 If you used the delay server before to put things on hold for a few seconds,
-you can now instead use an ``AsyncConsumer`` and ``asyncio.sleep``::
+you can now instead use an ``AsyncConsumer`` and ``asyncio.sleep``:
+
+.. code-block:: python
 
     class PingConsumer(AsyncConsumer):
 

--- a/docs/releases/1.0.0.rst
+++ b/docs/releases/1.0.0.rst
@@ -62,7 +62,9 @@ if you send a message to start another consumer you're guaranteed that the
 sending consumer has finished running by the time it's acted upon.
 
 If you want to send messages immediately rather than at the end of the consumer,
-you can still do that by passing the ``immediately`` argument::
+you can still do that by passing the ``immediately`` argument:
+
+.. code-block:: python
 
     Channel("thumbnailing-tasks").send({"id": 34245}, immediately=True)
 
@@ -179,7 +181,9 @@ Now, instead, you must implement ``group_names(instance)``, which returns the
 groups that can see the instance as it is presented for you; the action
 results will be worked out for you. For example, if you want to only show
 objects marked as "admin_only" to admins, and objects without it to everyone,
-previously you would have done::
+previously you would have done:
+
+.. code-block:: python
 
     def group_names(self, instance, action):
         if instance.admin_only:
@@ -189,7 +193,9 @@ previously you would have done::
 
 Because you did nothing based on the ``action`` (and if you did, you would
 have got incomplete messages, hence this design change), you can just change
-the signature of the method like this::
+the signature of the method like this:
+
+.. code-block:: python
 
     def group_names(self, instance):
         if instance.admin_only:

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -60,7 +60,7 @@ Some sample response templates are below.
 General support request
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+.. code-block:: text
 
     Sorry, but we can't help out with general support requests here - the issue tracker is for reproduceable bugs and
     concrete feature requests only! Please see our support documentation (http://channels.readthedocs.io/en/latest/support.html)
@@ -69,7 +69,7 @@ General support request
 Non-specific bug/"It doesn't work!"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+.. code-block:: text
 
     I'm afraid we can't address issues without either direct steps to reproduce, or that only happen in a production
     environment, as they may not be problems in the project itself. Our support documentation
@@ -83,7 +83,7 @@ Non-specific bug/"It doesn't work!"
 Problem in application code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+.. code-block:: text
 
     It looks like a problem in your application code rather than in Channels itself, so I'm going to close the ticket.
     If you can trace it down to a problem in Channels itself (with exact steps to reproduce on a fresh or small example

--- a/docs/topics/authentication.rst
+++ b/docs/topics/authentication.rst
@@ -19,7 +19,9 @@ requires ``CookieMiddleware``. For convenience, these are also provided
 as a combined callable called ``AuthMiddlewareStack`` that includes all three.
 
 To use the middleware, wrap it around the appropriate level of consumer
-in your ``routing.py``::
+in your ``routing.py``:
+
+.. code-block:: python
 
     from django.conf.urls import url
 
@@ -45,8 +47,9 @@ like in this case the ``URLRouter``.
 Note that the ``AuthMiddleware`` will only work on protocols that provide
 HTTP headers in their ``scope`` - by default, this is HTTP and WebSocket.
 
-To access the user, just use ``self.scope["user"]`` in your consumer code::
+To access the user, just use ``self.scope["user"]`` in your consumer code:
 
+.. code-block:: python
 
     class ChatConsumer(WebsocketConsumer):
 
@@ -67,7 +70,9 @@ on the scope, so all you need to do is override the initial constructor
 that takes a scope, rather than the event-running coroutine.
 
 Here's a simple example of a middleware that just takes a user ID out of the
-query string and uses that::
+query string and uses that:
+
+.. code-block:: python
 
     from django.db import close_old_connections
 
@@ -122,7 +127,9 @@ You can logout a user with the ``logout(scope)`` async function.
 If you are in a WebSocket consumer, or logging-in after the first response
 has been sent in a http consumer, the session is populated
 **but will not be saved automatically** - you must call
-``scope["session"].save()`` after login in your consumer code::
+``scope["session"].save()`` after login in your consumer code:
+
+.. code-block:: python
 
     from channels.auth import login
 
@@ -139,7 +146,9 @@ has been sent in a http consumer, the session is populated
 
 When calling ``login(scope, user)``, ``logout(scope)`` or ``get_user(scope)``
 from a synchronous function you will need to wrap them in ``async_to_sync``,
-as we only provide async versions::
+as we only provide async versions:
+
+.. code-block:: python
 
     from asgiref.sync import async_to_sync
     from channels.auth import login

--- a/docs/topics/channel_layers.rst
+++ b/docs/topics/channel_layers.rst
@@ -48,7 +48,9 @@ package.
 
 .. _`channels_redis`: https://pypi.org/project/channels-redis/
 
-In this example, Redis is running on localhost (127.0.0.1) port 6379::
+In this example, Redis is running on localhost (127.0.0.1) port 6379:
+
+.. code-block:: python
 
     CHANNEL_LAYERS = {
         "default": {
@@ -72,7 +74,9 @@ In-Memory Channel Layer
     multi-instance environment.
 
 Channels also comes packaged with an in-memory Channels Layer. This layer can
-be helpful in for :doc:`/topics/testing` or local-development purposes::
+be helpful in for :doc:`/topics/testing` or local-development purposes:
+
+.. code-block:: python
 
     CHANNEL_LAYERS = {
         "default": {
@@ -86,7 +90,9 @@ Synchronous Functions
 By default the ``send()``, ``group_send()``, ``group_add()`` and other functions
 are async functions, meaning you have to ``await`` them. If you need to call
 them from synchronous code, you'll need to use the handy
-``asgiref.sync.async_to_sync`` wrapper::
+``asgiref.sync.async_to_sync`` wrapper:
+
+.. code-block:: python
 
     from asgiref.sync import async_to_sync
 
@@ -107,7 +113,9 @@ networking to their attached client.
 
 For example, the `multichat example <https://github.com/andrewgodwin/channels-examples/tree/master/multichat>`_
 in Andrew Godwin's ``channels-examples`` repository sends events like this
-over the channel layer::
+over the channel layer:
+
+.. code-block:: python
 
     await self.channel_layer.group_send(
         room.group_name,
@@ -120,7 +128,9 @@ over the channel layer::
     )
 
 And then the consumers define a handling function to receive those events
-and turn them into WebSocket frames::
+and turn them into WebSocket frames:
+
+.. code-block:: python
 
     async def chat_message(self, event):
         """
@@ -170,7 +180,9 @@ to them and run code just like they would events from their client connection.
 
 The channel name is available on a consumer as ``self.channel_name``. Here's
 an example of writing the channel name into a database upon connection,
-and then specifying a handler method for events on it::
+and then specifying a handler method for events on it:
+
+.. code-block:: python
 
     class ChatConsumer(WebsocketConsumer):
 
@@ -193,7 +205,9 @@ clash. It's recommended you prefix type names (like we did here with ``chat.``)
 to avoid clashes.
 
 To send to a single channel, just find its channel name (for the example above,
-we could crawl the database), and use ``channel_layer.send``::
+we could crawl the database), and use ``channel_layer.send``:
+
+.. code-block:: python
 
     from channels.layers import get_channel_layer
 
@@ -231,7 +245,9 @@ is connected, you should build your own system or use a suitable third-party
 one.
 
 You use groups by adding a channel to them during connection, and removing it
-during disconnection, illustrated here on the WebSocket generic consumer::
+during disconnection, illustrated here on the WebSocket generic consumer:
+
+.. code-block:: python
 
     # This example uses WebSocket consumer, which is synchronous, and so
     # needs the async channel layer functions to be converted.
@@ -247,7 +263,9 @@ during disconnection, illustrated here on the WebSocket generic consumer::
 
 Then, to send to a group, use ``group_send``, like in this small example
 which broadcasts chat messages to every connected socket when combined with
-the code above::
+the code above:
+
+.. code-block:: python
 
     class ChatConsumer(WebsocketConsumer):
 
@@ -271,14 +289,18 @@ Using Outside Of Consumers
 
 You'll often want to send to the channel layer from outside of the scope of
 a consumer, and so you won't have ``self.channel_layer``. In this case, you
-should use the ``get_channel_layer`` function to retrieve it::
+should use the ``get_channel_layer`` function to retrieve it:
+
+.. code-block:: python
 
     from channels.layers import get_channel_layer
     channel_layer = get_channel_layer()
 
 Then, once you have it, you can just call methods on it. Remember that
 **channel layers only support async methods**, so you can either call it
-from your own asynchronous context::
+from your own asynchronous context:
+
+.. code-block:: python
 
     for chat_name in chats:
         await channel_layer.group_send(
@@ -286,7 +308,9 @@ from your own asynchronous context::
             {"type": "chat.system_message", "text": announcement_text},
         )
 
-Or you'll need to use async_to_sync::
+Or you'll need to use async_to_sync:
+
+.. code-block:: python
 
     from asgiref.sync import async_to_sync
 

--- a/docs/topics/consumers.rst
+++ b/docs/topics/consumers.rst
@@ -29,7 +29,9 @@ A consumer is a subclass of either ``channels.consumer.AsyncConsumer`` or
 you to write async-capable code, while the other will run your code
 synchronously in a threadpool for you.
 
-Let's look at a basic example of a ``SyncConsumer``::
+Let's look at a basic example of a ``SyncConsumer``:
+
+.. code-block:: python
 
     from channels.consumer import SyncConsumer
 
@@ -68,7 +70,9 @@ protocol - if you read the WebSocket protocol, you'll see that the dict we
 send above is how you send a text frame to the client.
 
 The ``AsyncConsumer`` is laid out very similarly, but all the handler methods
-must be coroutines, and ``self.send`` is a coroutine::
+must be coroutines, and ``self.send`` is a coroutine:
+
+.. code-block:: python
 
     from channels.consumer import AsyncConsumer
 
@@ -149,7 +153,9 @@ Consumers will use the channel layer ``default`` unless
 the ``channel_layer_alias`` attribute is set when subclassing any
 of the provided ``Consumer`` classes.
 
-To use the channel layer ``echo_alias`` we would set it like so::
+To use the channel layer ``echo_alias`` we would set it like so:
+
+.. code-block:: python
 
     from channels.consumer import SyncConsumer
 
@@ -203,7 +209,9 @@ WebsocketConsumer
 
 Available as ``channels.generic.websocket.WebsocketConsumer``, this
 wraps the verbose plain-ASGI message sending and receiving into handling that
-just deals with text and binary frames::
+just deals with text and binary frames:
+
+.. code-block:: python
 
     from channels.generic.websocket import WebsocketConsumer
 
@@ -256,7 +264,9 @@ AsyncWebsocketConsumer
 
 Available as ``channels.generic.websocket.AsyncWebsocketConsumer``, this has
 the exact same methods and signature as ``WebsocketConsumer`` but everything
-is async, and the functions you need to write have to be as well::
+is async, and the functions you need to write have to be as well:
+
+.. code-block:: python
 
     from channels.generic.websocket import AsyncWebsocketConsumer
 
@@ -320,7 +330,9 @@ AsyncHttpConsumer
 ~~~~~~~~~~~~~~~~~
 
 Available as ``channels.generic.http.AsyncHttpConsumer``, this offers basic
-primitives to implement a HTTP endpoint::
+primitives to implement a HTTP endpoint:
+
+.. code-block:: python
 
     from channels.generic.http import AsyncHttpConsumer
 
@@ -344,7 +356,9 @@ finished running cleanly.
 If you need more control over the response, e.g. for implementing long
 polling, use the lower level ``self.send_headers`` and ``self.send_body``
 methods instead. This example already mentions channel layers which will
-be explained in detail later::
+be explained in detail later:
+
+.. code-block:: python
 
     import json
     from channels.generic.http import AsyncHttpConsumer
@@ -364,7 +378,9 @@ be explained in detail later::
             await self.send_body(json.dumps(event).encode("utf-8"))
 
 Of course you can also use those primitives to implement a HTTP endpoint for
-`Server-sent events <https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events>`_::
+`Server-sent events <https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events>`_:
+
+.. code-block:: python
 
     from datetime import datetime
     from channels.generic.http import AsyncHttpConsumer

--- a/docs/topics/databases.rst
+++ b/docs/topics/databases.rst
@@ -31,7 +31,9 @@ database_sync_to_async
 that also cleans up database connections on exit.
 
 To use it, write your ORM queries in a separate function or method, and then
-call it with ``database_sync_to_async`` like so::
+call it with ``database_sync_to_async`` like so:
+
+.. code-block:: python
 
     from channels.db import database_sync_to_async
 
@@ -41,7 +43,9 @@ call it with ``database_sync_to_async`` like so::
     def get_name(self):
         return User.objects.all()[0].name
 
-You can also use it as a decorator::
+You can also use it as a decorator:
+
+.. code-block:: python
 
     from channels.db import database_sync_to_async
 

--- a/docs/topics/routing.rst
+++ b/docs/topics/routing.rst
@@ -28,7 +28,9 @@ but we recommend putting them in a project-level file called ``routing.py``,
 next to ``urls.py``. You can read more about deploying Channels projects and
 settings in :doc:`/deploying`.
 
-Here's an example of what that ``routing.py`` might look like::
+Here's an example of what that ``routing.py`` might look like:
+
+.. code-block:: python
 
     from django.conf.urls import url
 
@@ -71,7 +73,9 @@ value that their scope contains, so you can use this to distinguish between
 incoming connection types.
 
 It takes a single argument - a dictionary mapping type names to ASGI
-applications that serve them::
+applications that serve them:
+
+.. code-block:: python
 
     ProtocolTypeRouter({
         "http": some_app,
@@ -94,7 +98,9 @@ URLRouter
 ``channels.routing.URLRouter``
 
 Routes ``http`` or ``websocket`` type connections via their HTTP path. Takes
-a single argument, a list of Django URL objects (either ``path()`` or ``url()``)::
+a single argument, a list of Django URL objects (either ``path()`` or ``url()``):
+
+.. code-block:: python
 
     URLRouter([
         url(r"^longpoll/$", LongPollConsumer),
@@ -109,7 +115,9 @@ and unnamed groups cannot be mixed: Positional groups are discarded as soon
 as a single named group is matched.
 
 For example, to pull out the named group ``stream`` in the example above, you
-would do this::
+would do this:
+
+.. code-block:: python
 
     stream = self.scope["url_route"]["kwargs"]["stream"]
 
@@ -126,7 +134,9 @@ Routes ``channel`` type scopes based on the value of the ``channel`` key in
 their scope. Intended for use with the :doc:`/topics/worker`.
 
 It takes a single argument - a dictionary mapping channel names to ASGI
-applications that serve them::
+applications that serve them:
+
+.. code-block:: python
 
     ChannelNameRouter({
         "thumbnails-generate": some_app,

--- a/docs/topics/security.rst
+++ b/docs/topics/security.rst
@@ -27,7 +27,9 @@ header that is sent with every WebSocket to say where it comes from. Just wrap
 it around your WebSocket application code like this, and pass it a list of
 valid domains as the second argument. You can pass only a single domain (for example,
 ``.allowed-domain.com``) or a full origin, in the format ``scheme://domain[:port]``
-(for example, ``http://allowed-domain.com:80``). Port is optional, but recommended::
+(for example, ``http://allowed-domain.com:80``). Port is optional, but recommended:
+
+.. code-block:: python
 
     from channels.security.websocket import OriginValidator
 
@@ -49,7 +51,9 @@ Note: If you want to resolve any domain, then use the origin ``*``.
 Often, the set of domains you want to restrict to is the same as the Django
 ``ALLOWED_HOSTS`` setting, which performs a similar security check for the
 ``Host`` header, and so ``AllowedHostsOriginValidator`` lets you use this
-setting without having to re-declare the list::
+setting without having to re-declare the list:
+
+.. code-block:: python
 
     from channels.security.websocket import AllowedHostsOriginValidator
 

--- a/docs/topics/sessions.rst
+++ b/docs/topics/sessions.rst
@@ -19,7 +19,9 @@ For convenience, these are also provided as a combined callable called
 ``channels.session``.
 
 To use the middleware, wrap it around the appropriate level of consumer
-in your ``routing.py``::
+in your ``routing.py``:
+
+.. code-block:: python
 
     from channels.routing import ProtocolTypeRouter, URLRouter
     from channels.sessions import SessionMiddlewareStack
@@ -39,7 +41,9 @@ in your ``routing.py``::
 ``SessionMiddleware`` will only work on protocols that provide
 HTTP headers in their ``scope`` - by default, this is HTTP and WebSocket.
 
-To access the session, use ``self.scope["session"]`` in your consumer code::
+To access the session, use ``self.scope["session"]`` in your consumer code:
+
+.. code-block:: python
 
     class ChatConsumer(WebsocketConsumer):
 

--- a/docs/topics/testing.rst
+++ b/docs/topics/testing.rst
@@ -18,14 +18,18 @@ Setting Up Async Tests
 
 Firstly, you need to get ``py.test`` set up with async test support, and
 presumably Django test support as well. You can do this by installing the
-``pytest-django`` and ``pytest-asyncio`` packages::
+``pytest-django`` and ``pytest-asyncio`` packages:
+
+.. code-block:: sh
 
     pip install -U pytest-django pytest-asyncio
 
 Then, you need to decorate the tests you want to run async with
 ``pytest.mark.asyncio``. Note that you can't mix this with ``unittest.TestCase``
 subclasses; you have to write async tests as top-level test functions in the
-native ``py.test`` style::
+native ``py.test`` style:
+
+.. code-block:: python
 
     import pytest
     from channels.testing import HttpCommunicator
@@ -60,7 +64,9 @@ responses or long-polling, which aren't supported in ``HttpCommunicator`` yet.
     ``ApplicationCommunicator`` is actually provided by the base ``asgiref``
     package, but we let you import it from ``channels.testing`` for convenience.
 
-To construct it, pass it an application and a scope::
+To construct it, pass it an application and a scope:
+
+.. code-block:: python
 
     from channels.testing import ApplicationCommunicator
     communicator = ApplicationCommunicator(MyConsumer, {"type": "http", ...})
@@ -68,7 +74,9 @@ To construct it, pass it an application and a scope::
 send_input
 ~~~~~~~~~~
 
-Call it to send an event to the application::
+Call it to send an event to the application:
+
+.. code-block:: python
 
     await communicator.send_input({
         "type": "http.request",
@@ -78,7 +86,9 @@ Call it to send an event to the application::
 receive_output
 ~~~~~~~~~~~~~~
 
-Call it to receive an event from the application::
+Call it to receive an event from the application:
+
+.. code-block:: python
 
     event = await communicator.receive_output(timeout=1)
     assert event["type"] == "http.response.start"
@@ -89,7 +99,9 @@ receive_nothing
 ~~~~~~~~~~~~~~~
 
 Call it to check that there is no event waiting to be received from the
-application::
+application:
+
+.. code-block:: python
 
     assert await communicator.receive_nothing(timeout=0.1, interval=0.01) is False
     # Receive the rest of the http request from above
@@ -115,12 +127,16 @@ wait
 ~~~~
 
 Call it to wait for an application to exit (you'll need to either do this or wait for
-it to send you output before you can see what it did using mocks or inspection)::
+it to send you output before you can see what it did using mocks or inspection):
+
+.. code-block:: python
 
     await communicator.wait(timeout=1)
 
 If you're expecting your application to raise an exception, use ``pytest.raises``
-around ``wait``::
+around ``wait``:
+
+.. code-block:: python
 
     with pytest.raises(ValueError):
         await communicator.wait()
@@ -131,12 +147,16 @@ HttpCommunicator
 
 ``HttpCommunicator`` is a subclass of ``ApplicationCommunicator`` specifically
 tailored for HTTP requests. You need only instantiate it with your desired
-options::
+options:
+
+.. code-block:: python
 
     from channels.testing import HttpCommunicator
     communicator = HttpCommunicator(MyHttpConsumer, "GET", "/test/")
 
-And then wait for its response::
+And then wait for its response:
+
+.. code-block:: python
 
     response = await communicator.get_response()
     assert response["body"] == b"test response"
@@ -148,7 +168,7 @@ You can pass the following arguments to the constructor:
 * ``body``: HTTP body (bytestring, optional)
 
 The response from the ``get_response`` method will be a dict with the following
-keys::
+keys:
 
 * ``status``: HTTP status code (integer)
 * ``headers``: List of headers as (name, value) tuples (both bytestrings)
@@ -160,7 +180,9 @@ WebsocketCommunicator
 
 ``WebsocketCommunicator`` allows you to more easily test WebSocket consumers.
 It provides several convenience methods for interacting with a WebSocket
-application, as shown in this example::
+application, as shown in this example:
+
+.. code-block:: python
 
     from channels.testing import WebsocketCommunicator
     communicator = WebsocketCommunicator(SimpleWebsocketApp, "/testws/")
@@ -190,7 +212,9 @@ application, as shown in this example::
 
 You can also pass an ``application`` built with ``URLRouter`` instead of the
 plain consumer class. This lets you test applications that require positional
-or keyword arguments in the ``scope``::
+or keyword arguments in the ``scope``:
+
+.. code-block:: python
 
     from channels.testing import WebsocketCommunicator
     application = URLRouter([
@@ -227,7 +251,9 @@ send_to
 ~~~~~~~
 
 Sends a data frame to the application. Takes exactly one of ``bytes_data``
-or ``text_data`` as parameters, and returns nothing::
+or ``text_data`` as parameters, and returns nothing:
+
+.. code-block:: python
 
     await communicator.send_to(bytes_data=b"hi\0")
 
@@ -238,7 +264,9 @@ send_json_to
 ~~~~~~~~~~~~
 
 Sends a JSON payload to the application as a text frame. Call it with
-an object and it will JSON-encode it for you, and return nothing::
+an object and it will JSON-encode it for you, and return nothing:
+
+.. code-block:: python
 
     await communicator.send_json_to({"hello": "world"})
 
@@ -246,7 +274,9 @@ receive_from
 ~~~~~~~~~~~~
 
 Receives a frame from the application and gives you either ``bytes`` or
-``text`` back depending on the frame type::
+``text`` back depending on the frame type:
+
+.. code-block:: python
 
     response = await communicator.receive_from()
 
@@ -258,7 +288,9 @@ frames contain binary data.
 receive_json_from
 ~~~~~~~~~~~~~~~~~
 
-Receives a text frame from the application and decodes it for you::
+Receives a text frame from the application and decodes it for you:
+
+.. code-block:: python
 
     response = await communicator.receive_json_from()
     assert response == {"hello": "world"}
@@ -289,7 +321,9 @@ ChannelsLiveServerTestCase
 If you just want to run standard Selenium or other tests that require a
 webserver to be running for external programs, you can use
 ``ChannelsLiveServerTestCase``, which is a drop-in replacement for the
-standard Django ``LiveServerTestCase``::
+standard Django ``LiveServerTestCase``:
+
+.. code-block:: python
 
     from channels.testing import ChannelsLiveServerTestCase
 
@@ -302,7 +336,9 @@ standard Django ``LiveServerTestCase``::
 
     You can't use an in-memory database for your live tests. Therefore
     include a test database file name in your settings to tell Django to
-    use a file database if you use SQLite::
+    use a file database if you use SQLite:
+
+    .. code-block:: python
 
         DATABASES = {
             "default": {

--- a/docs/topics/testing.rst
+++ b/docs/topics/testing.rst
@@ -22,7 +22,7 @@ presumably Django test support as well. You can do this by installing the
 
 .. code-block:: sh
 
-    pip install -U pytest-django pytest-asyncio
+    python -m pip install -U pytest-django pytest-asyncio
 
 Then, you need to decorate the tests you want to run async with
 ``pytest.mark.asyncio``. Note that you can't mix this with ``unittest.TestCase``

--- a/docs/topics/worker.rst
+++ b/docs/topics/worker.rst
@@ -24,7 +24,9 @@ Sending
 -------
 
 To send an event, just send it to a fixed channel name. For example, let's say
-we want a background process that pre-caches thumbnails::
+we want a background process that pre-caches thumbnails:
+
+.. code-block:: python
 
     # Inside a consumer
     self.channel_layer.send(
@@ -39,9 +41,9 @@ Note that the event you send **must** have a ``type`` key, even if only one
 type of message is being sent over the channel, as it will turn into an event
 a consumer has to handle.
 
-Also remember that if you are sending the event from a synchronous environment, 
-you have to use the ``asgiref.sync.async_to_sync`` wrapper as specified in 
-:doc:`channel layers </topics/channel_layers>`. 
+Also remember that if you are sending the event from a synchronous environment,
+you have to use the ``asgiref.sync.async_to_sync`` wrapper as specified in
+:doc:`channel layers </topics/channel_layers>`.
 
 Receiving and Consumers
 -----------------------
@@ -49,7 +51,9 @@ Receiving and Consumers
 Channels will present incoming worker tasks to you as events inside a scope
 with a ``type`` of ``channel``, and a ``channel`` key matching the channel
 name. We recommend you use ProtocolTypeRouter and ChannelNameRouter (see
-:doc:`/topics/routing` for more) to arrange your consumers::
+:doc:`/topics/routing` for more) to arrange your consumers:
+
+.. code-block:: python
 
     application = ProtocolTypeRouter({
         ...
@@ -63,7 +67,9 @@ You'll be specifying the ``type`` values of the individual events yourself
 when you send them, so decide what your names are going to be and write
 consumers to match. For example, here's a basic consumer that expects to
 receive an event with ``type`` ``test.print``, and a ``text`` value containing
-the text to print::
+the text to print:
+
+.. code-block:: python
 
     class PrintConsumer(SyncConsumer):
         def test_print(self, message):
@@ -72,9 +78,11 @@ the text to print::
 Once you've hooked up the consumers, all you need to do is run a process that
 will handle them. In lieu of a protocol server - as there are no connections
 involved here - Channels instead provides you this with the ``runworker``
-command::
+command:
 
-    ./manage.py runworker thumbnails-generate thumbnails-delete
+.. code-block:: text
+
+    python manage.py runworker thumbnails-generate thumbnails-delete
 
 Note that ``runworker`` will only listen to the channels you pass it on the
 command line. If you do not include a channel, or forget to run the worker,

--- a/docs/tutorial/part_1.rst
+++ b/docs/tutorial/part_1.rst
@@ -10,17 +10,21 @@ The room view will use a WebSocket to communicate with the Django server and
 listen for any messages that are posted.
 
 We assume that you are familiar with basic concepts for building a Django site.
-If not we recommend you complete `the Django tutorial`_ first and then come back 
+If not we recommend you complete `the Django tutorial`_ first and then come back
 to this tutorial.
 
 We assume that you have `Django installed`_ already. You can tell Django is
 installed and which version by running the following command in a shell prompt
-(indicated by the ``$`` prefix)::
+(indicated by the ``$`` prefix):
+
+.. code-block:: sh
 
     $ python3 -m django --version
 
 We also assume that you have :doc:`Channels installed </installation>` already. You can tell
-Channels is installed by running the following command::
+Channels is installed by running the following command:
+
+.. code-block:: sh
 
     $ python3 -c 'import channels; print(channels.__version__)'
 
@@ -53,12 +57,16 @@ Creating a project
 If you don't already have a Django project, you will need to create one.
 
 From the command line, ``cd`` into a directory where you'd like to store your
-code, then run the following command::
+code, then run the following command:
+
+.. code-block:: sh
 
     $ django-admin startproject mysite
 
-This will create a ``mysite`` directory in your current directory with the 
-following contents::
+This will create a ``mysite`` directory in your current directory with the
+following contents:
+
+.. code-block:: text
 
     mysite/
         manage.py
@@ -73,11 +81,15 @@ Creating the Chat app
 
 We will put the code for the chat server in its own app.
 
-Make sure you're in the same directory as ``manage.py`` and type this command::
+Make sure you're in the same directory as ``manage.py`` and type this command:
+
+.. code-block:: sh
 
     $ python3 manage.py startapp chat
 
-That'll create a directory ``chat``, which is laid out like this::
+That'll create a directory ``chat``, which is laid out like this:
+
+.. code-block:: text
 
     chat/
         __init__.py
@@ -89,10 +101,12 @@ That'll create a directory ``chat``, which is laid out like this::
         tests.py
         views.py
 
-For the purposes of this tutorial, we will only be working with ``chat/views.py`` 
+For the purposes of this tutorial, we will only be working with ``chat/views.py``
 and ``chat/__init__.py``. So remove all other files from the ``chat`` directory.
 
-After removing unnecessary files, the ``chat`` directory should look like::
+After removing unnecessary files, the ``chat`` directory should look like:
+
+.. code-block:: text
 
     chat/
         __init__.py
@@ -100,7 +114,9 @@ After removing unnecessary files, the ``chat`` directory should look like::
 
 We need to tell our project that the ``chat`` app is installed. Edit the
 ``mysite/settings.py`` file and add ``'chat'`` to the **INSTALLED_APPS** setting.
-It'll look like this::
+It'll look like this:
+
+.. code-block:: python
 
     # mysite/settings.py
     INSTALLED_APPS = [
@@ -124,7 +140,9 @@ Create a ``templates`` directory in your ``chat`` directory. Within the
 ``chat``, and within that create a file called ``index.html`` to hold the
 template for the index view.
 
-Your chat directory should now look like::
+Your chat directory should now look like:
+
+.. code-block:: text
 
     chat/
         __init__.py
@@ -133,7 +151,9 @@ Your chat directory should now look like::
                 index.html
         views.py
 
-Put the following code in ``chat/templates/chat/index.html``::
+Put the following code in ``chat/templates/chat/index.html``:
+
+.. code-block:: html
 
     <!-- chat/templates/chat/index.html -->
     <!DOCTYPE html>
@@ -146,7 +166,7 @@ Put the following code in ``chat/templates/chat/index.html``::
         What chat room would you like to enter?<br/>
         <input id="room-name-input" type="text" size="100"/><br/>
         <input id="room-name-submit" type="button" value="Enter"/>
-        
+
         <script>
             document.querySelector('#room-name-input').focus();
             document.querySelector('#room-name-input').onkeyup = function(e) {
@@ -164,18 +184,22 @@ Put the following code in ``chat/templates/chat/index.html``::
     </html>
 
 Create the view function for the room view.
-Put the following code in ``chat/views.py``::
+Put the following code in ``chat/views.py``:
+
+.. code-block:: python
 
     # chat/views.py
     from django.shortcuts import render
-    
+
     def index(request):
         return render(request, 'chat/index.html', {})
 
 To call the view, we need to map it to a URL - and for this we need a URLconf.
 
 To create a URLconf in the chat directory, create a file called ``urls.py``.
-Your app directory should now look like::
+Your app directory should now look like:
+
+.. code-block:: text
 
     chat/
         __init__.py
@@ -185,36 +209,44 @@ Your app directory should now look like::
         urls.py
         views.py
 
-In the ``chat/urls.py`` file include the following code::
+In the ``chat/urls.py`` file include the following code:
+
+.. code-block:: python
 
     # chat/urls.py
     from django.urls import path
-    
+
     from . import views
-    
+
     urlpatterns = [
         path('', views.index, name='index'),
     ]
 
 The next step is to point the root URLconf at the **chat.urls** module.
 In ``mysite/urls.py``, add an import for **django.conf.urls.include** and
-insert an **include()** in the **urlpatterns** list, so you have::
+insert an **include()** in the **urlpatterns** list, so you have:
+
+.. code-block:: python
 
     # mysite/urls.py
     from django.conf.urls import include
     from django.urls import path
     from django.contrib import admin
-    
+
     urlpatterns = [
         path('chat/', include('chat.urls')),
         path('admin/', admin.site.urls),
     ]
 
-Let's verify that the index view works. Run the following command::
+Let's verify that the index view works. Run the following command:
+
+.. code-block:: sh
 
     $ python3 manage.py runserver
 
-You'll see the following output on the command line::
+You'll see the following output on the command line:
+
+.. code-block:: text
 
     Performing system checks...
 
@@ -250,7 +282,9 @@ Let's start by creating a root routing configuration for Channels. A Channels
 what code to run when an HTTP request is received by the Channels server.
 
 We'll start with an empty routing configuration.
-Create a file ``mysite/routing.py`` and include the following code::
+Create a file ``mysite/routing.py`` and include the following code:
+
+.. code-block:: python
 
     # mysite/routing.py
     from channels.routing import ProtocolTypeRouter
@@ -261,7 +295,9 @@ Create a file ``mysite/routing.py`` and include the following code::
 
 Now add the Channels library to the list of installed apps.
 Edit the ``mysite/settings.py`` file and add ``'channels'`` to the
-``INSTALLED_APPS`` setting. It'll look like this::
+``INSTALLED_APPS`` setting. It'll look like this:
+
+.. code-block:: python
 
     # mysite/settings.py
     INSTALLED_APPS = [
@@ -277,7 +313,9 @@ Edit the ``mysite/settings.py`` file and add ``'channels'`` to the
 
 You'll also need to point Channels at the root routing configuration.
 Edit the ``mysite/settings.py`` file again and add the following to the bottom
-of it::
+of it:
+
+.. code-block:: python
 
     # mysite/settings.py
     # Channels
@@ -298,19 +336,23 @@ the Channels development server.
 .. _whitenoise: https://github.com/evansd/whitenoise
 
 Let's ensure that the Channels development server is working correctly.
-Run the following command::
+Run the following command:
+
+.. code-block:: sh
 
     $ python3 manage.py runserver
 
-You'll see the following output on the command line::
+You'll see the following output on the command line:
+
+.. code-block:: text
 
     Performing system checks...
-    
+
     System check identified no issues (0 silenced).
-    
+
     You have 13 unapplied migration(s). Your project may not work properly until you apply the migrations for app(s): admin, auth, contenttypes, sessions.
     Run 'python manage.py migrate' to apply them.
-    
+
     February 18, 2018 - 22:16:23
     Django version 1.11.10, using settings 'mysite.settings'
     Starting ASGI/Channels development server at http://127.0.0.1:8000/
@@ -323,8 +365,8 @@ You'll see the following output on the command line::
     Ignore the warning about unapplied database migrations.
     We won't be using a database in this tutorial.
 
-Notice the line beginning with 
-``Starting ASGI/Channels development server at http://127.0.0.1:8000/``. 
+Notice the line beginning with
+``Starting ASGI/Channels development server at http://127.0.0.1:8000/``.
 This indicates that the Channels development server has taken over from the
 Django development server.
 

--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -352,7 +352,7 @@ Redis. Run the following command:
 
 .. code-block:: sh
 
-    $ pip3 install channels_redis
+    $ python3 -m pip install channels_redis
 
 Before we can use a channel layer, we must configure it. Edit the
 ``mysite/settings.py`` file and add a ``CHANNEL_LAYERS`` setting to the bottom.

--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -12,7 +12,9 @@ We will now create the second view, a room view that lets you see messages
 posted in a particular chat room.
 
 Create a new file ``chat/templates/chat/room.html``.
-Your app directory should now look like::
+Your app directory should now look like:
+
+.. code-block:: text
 
     chat/
         __init__.py
@@ -23,7 +25,9 @@ Your app directory should now look like::
         urls.py
         views.py
 
-Create the view template for the room view in ``chat/templates/chat/room.html``::
+Create the view template for the room view in ``chat/templates/chat/room.html``:
+
+.. code-block:: html
 
     <!-- chat/templates/chat/room.html -->
     <!DOCTYPE html>
@@ -73,7 +77,9 @@ Create the view template for the room view in ``chat/templates/chat/room.html``:
     </script>
     </html>
 
-Create the view function for the room view in ``chat/views.py``::
+Create the view function for the room view in ``chat/views.py``:
+
+.. code-block:: python
 
     # chat/views.py
     from django.shortcuts import render
@@ -86,7 +92,9 @@ Create the view function for the room view in ``chat/views.py``::
             'room_name': room_name
         })
 
-Create the route for the room view in ``chat/urls.py``::
+Create the route for the room view in ``chat/urls.py``:
+
+.. code-block:: python
 
     # chat/urls.py
     from django.urls import path
@@ -98,7 +106,9 @@ Create the route for the room view in ``chat/urls.py``::
         path('<str:room_name>/', views.room, name='room'),
     ]
 
-Start the Channels development server::
+Start the Channels development server:
+
+.. code-block:: sh
 
     $ python3 manage.py runserver
 
@@ -114,7 +124,9 @@ message does not appear in the chat log. Why?
 The room view is trying to open a WebSocket to the URL
 ``ws://127.0.0.1:8000/ws/chat/lobby/`` but we haven't created a consumer that
 accepts WebSocket connections yet. If you open your browser's JavaScript
-console, you should see an error that looks like::
+console, you should see an error that looks like:
+
+.. code-block:: text
 
     WebSocket connection to 'ws://127.0.0.1:8000/ws/chat/lobby/' failed: Unexpected response code: 500
 
@@ -148,7 +160,9 @@ echos it back to the same WebSocket.
     separate WSGI server. In this deployment configuration no common path prefix
     like ``/ws/`` is necessary.
 
-Create a new file ``chat/consumers.py``. Your app directory should now look like::
+Create a new file ``chat/consumers.py``. Your app directory should now look like:
+
+.. code-block:: text
 
     chat/
         __init__.py
@@ -160,7 +174,9 @@ Create a new file ``chat/consumers.py``. Your app directory should now look like
         urls.py
         views.py
 
-Put the following code in ``chat/consumers.py``::
+Put the following code in ``chat/consumers.py``:
+
+.. code-block:: python
 
     # chat/consumers.py
     from channels.generic.websocket import WebsocketConsumer
@@ -194,7 +210,9 @@ now it does not broadcast messages to other clients in the same room.
 
 We need to create a routing configuration for the ``chat`` app that has a route to
 the consumer. Create a new file ``chat/routing.py``. Your app directory should now
-look like::
+look like:
+
+.. code-block:: text
 
     chat/
         __init__.py
@@ -207,7 +225,9 @@ look like::
         urls.py
         views.py
 
-Put the following code in ``chat/routing.py``::
+Put the following code in ``chat/routing.py``:
+
+.. code-block:: python
 
     # chat/routing.py
     from django.urls import re_path
@@ -221,7 +241,9 @@ Put the following code in ``chat/routing.py``::
 The next step is to point the root routing configuration at the **chat.routing**
 module. In ``mysite/routing.py``, import ``AuthMiddlewareStack``, ``URLRouter``,
 and ``chat.routing``; and insert a ``'websocket'`` key in the
-``ProtocolTypeRouter`` list in the following format::
+``ProtocolTypeRouter`` list in the following format:
+
+.. code-block:: python
 
     # mysite/routing.py
     from channels.auth import AuthMiddlewareStack
@@ -253,7 +275,9 @@ particular consumer, based on the provided ``url`` patterns.
 
 Let's verify that the consumer for the ``/ws/chat/ROOM_NAME/`` path works. Run migrations to
 apply database changes (Django's session framework needs the database) and then start the
-Channels development server::
+Channels development server:
+
+.. code-block:: sh
 
     $ python manage.py migrate
     Operations to perform:
@@ -317,18 +341,24 @@ That will allow ChatConsumers to transmit messages to all other ChatConsumers in
 the same room.
 
 We will use a channel layer that uses Redis as its backing store. To start a
-Redis server on port 6379, run the following command::
+Redis server on port 6379, run the following command:
+
+.. code-block:: sh
 
     $ docker run -p 6379:6379 -d redis:2.8
 
 We need to install channels_redis so that Channels knows how to interface with
-Redis. Run the following command::
+Redis. Run the following command:
+
+.. code-block:: sh
 
     $ pip3 install channels_redis
 
 Before we can use a channel layer, we must configure it. Edit the
 ``mysite/settings.py`` file and add a ``CHANNEL_LAYERS`` setting to the bottom.
-It should look like::
+It should look like:
+
+.. code-block:: python
 
     # mysite/settings.py
     # Channels
@@ -347,7 +377,9 @@ It should look like::
     However most projects will just use a single ``'default'`` channel layer.
 
 Let's make sure that the channel layer can communicate with Redis. Open a Django
-shell and run the following commands::
+shell and run the following commands:
+
+.. code-block:: pycon
 
     $ python3 manage.py shell
     >>> import channels.layers
@@ -360,7 +392,9 @@ shell and run the following commands::
 Type Control-D to exit the Django shell.
 
 Now that we have a channel layer, let's use it in ``ChatConsumer``. Put the
-following code in ``chat/consumers.py``, replacing the old code::
+following code in ``chat/consumers.py``, replacing the old code:
+
+.. code-block:: python
 
     # chat/consumers.py
     from asgiref.sync import async_to_sync
@@ -419,21 +453,21 @@ appended to the chat log.
 
 Several parts of the new ``ChatConsumer`` code deserve further explanation:
 
-* self.scope['url_route']['kwargs']['room_name']
+* ``self.scope['url_route']['kwargs']['room_name']``
     * Obtains the ``'room_name'`` parameter from the URL route in ``chat/routing.py``
       that opened the WebSocket connection to the consumer.
     * Every consumer has a :ref:`scope <scope>` that contains information about its connection,
       including in particular any positional or keyword arguments from the URL
       route and the currently authenticated user if any.
 
-* self.room_group_name = 'chat_%s' % self.room_name
+* ``self.room_group_name = 'chat_%s' % self.room_name``
     * Constructs a Channels group name directly from the user-specified room
       name, without any quoting or escaping.
     * Group names may only contain letters, digits, hyphens, and periods.
       Therefore this example code will fail on room names that have other
       characters.
 
-* async_to_sync(self.channel_layer.group_add)(...)
+* ``async_to_sync(self.channel_layer.group_add)(...)``
     * Joins a group.
     * The async_to_sync(...) wrapper is required because ChatConsumer is a
       synchronous WebsocketConsumer but it is calling an asynchronous channel
@@ -443,7 +477,7 @@ Several parts of the new ``ChatConsumer`` code deserve further explanation:
       it will fail if the room name contains any characters that aren't valid in
       a group name.
 
-* self.accept()
+* ``self.accept()``
     * Accepts the WebSocket connection.
     * If you do not call accept() within the connect() method then the
       connection will be rejected and closed. You might want to reject a connection
@@ -452,16 +486,18 @@ Several parts of the new ``ChatConsumer`` code deserve further explanation:
     * It is recommended that accept() be called as the *last* action in connect()
       if you choose to accept the connection.
 
-* async_to_sync(self.channel_layer.group_discard)(...)
+* ``async_to_sync(self.channel_layer.group_discard)(...)``
     * Leaves a group.
 
-* async_to_sync(self.channel_layer.group_send)
+* ``async_to_sync(self.channel_layer.group_send)``
     * Sends an event to a group.
     * An event has a special ``'type'`` key corresponding to the name of the method
       that should be invoked on consumers that receive the event.
 
 Let's verify that the new consumer for the ``/ws/chat/ROOM_NAME/`` path works.
-To start the Channels development server, run the following command::
+To start the Channels development server, run the following command:
+
+.. code-block:: sh
 
     $ python3 manage.py runserver
 

--- a/docs/tutorial/part_3.rst
+++ b/docs/tutorial/part_3.rst
@@ -27,37 +27,39 @@ be rewritten to be asynchronous without complications.
     gains however would be less than if it only used async-native libraries.
 
 Let's rewrite ``ChatConsumer`` to be asynchronous.
-Put the following code in ``chat/consumers.py``::
+Put the following code in ``chat/consumers.py``:
+
+.. code-block:: python
 
     # chat/consumers.py
     from channels.generic.websocket import AsyncWebsocketConsumer
     import json
-    
+
     class ChatConsumer(AsyncWebsocketConsumer):
         async def connect(self):
             self.room_name = self.scope['url_route']['kwargs']['room_name']
             self.room_group_name = 'chat_%s' % self.room_name
-            
+
             # Join room group
             await self.channel_layer.group_add(
                 self.room_group_name,
                 self.channel_name
             )
-            
+
             await self.accept()
-        
+
         async def disconnect(self, close_code):
             # Leave room group
             await self.channel_layer.group_discard(
                 self.room_group_name,
                 self.channel_name
             )
-        
+
         # Receive message from WebSocket
         async def receive(self, text_data):
             text_data_json = json.loads(text_data)
             message = text_data_json['message']
-            
+
             # Send message to room group
             await self.channel_layer.group_send(
                 self.room_group_name,
@@ -66,11 +68,11 @@ Put the following code in ``chat/consumers.py``::
                     'message': message
                 }
             )
-        
+
         # Receive message from room group
         async def chat_message(self, event):
             message = event['message']
-            
+
             # Send message to WebSocket
             await self.send(text_data=json.dumps({
                 'message': message
@@ -85,7 +87,9 @@ This new code is for ChatConsumer is very similar to the original code, with the
 * ``async_to_sync`` is no longer needed when calling methods on the channel layer.
 
 Let's verify that the consumer for the ``/ws/chat/ROOM_NAME/`` path still works.
-To start the Channels development server, run the following command::
+To start the Channels development server, run the following command:
+
+.. code-block:: sh
 
     $ python3 manage.py runserver
 
@@ -99,6 +103,3 @@ first browser tab.
 Now your chat server is fully asynchronous!
 
 This tutorial continues in :doc:`Tutorial 4 </tutorial/part_4>`.
-
-
-

--- a/docs/tutorial/part_4.rst
+++ b/docs/tutorial/part_4.rst
@@ -19,14 +19,18 @@ browser. These tests will ensure that:
 
 `Install chromedriver`_.
 
-Install Selenium. Run the following command::
+Install Selenium. Run the following command:
+
+.. code-block:: sh
 
     $ pip3 install selenium
 
 .. _Install the Chrome web browser: https://www.google.com/chrome/
 .. _Install chromedriver: https://sites.google.com/a/chromium.org/chromedriver/getting-started
 
-Create a new file ``chat/tests.py``. Your app directory should now look like::
+Create a new file ``chat/tests.py``. Your app directory should now look like:
+
+.. code-block:: text
 
     chat/
         __init__.py
@@ -40,7 +44,9 @@ Create a new file ``chat/tests.py``. Your app directory should now look like::
         urls.py
         views.py
 
-Put the following code in ``chat/tests.py``::
+Put the following code in ``chat/tests.py``:
+
+.. code-block:: python
 
     # chat/tests.py
     from channels.testing import ChannelsLiveServerTestCase
@@ -144,7 +150,9 @@ will work inside the suite.
 
 We are using ``sqlite3``, which for testing, is run as an in-memory database, and therefore, the tests will not run correctly.
 We need to tell our project that the ``sqlite3`` database need not to be in memory for run the tests. Edit the
-``mysite/settings.py`` file and add the ``TEST`` argument to the **DATABASES** setting::
+``mysite/settings.py`` file and add the ``TEST`` argument to the **DATABASES** setting:
+
+.. code-block:: python
 
     # mysite/settings.py
     DATABASES = {
@@ -157,12 +165,15 @@ We need to tell our project that the ``sqlite3`` database need not to be in memo
         }
     }
 
+To run the tests, run the following command:
 
-To run the tests, run the following command::
+.. code-block:: sh
 
     $ python3 manage.py test chat.tests
 
-You should see output that looks like::
+You should see output that looks like:
+
+.. code-block:: text
 
     Creating test database for alias 'default'...
     System check identified no issues (0 silenced).

--- a/docs/tutorial/part_4.rst
+++ b/docs/tutorial/part_4.rst
@@ -23,7 +23,7 @@ Install Selenium. Run the following command:
 
 .. code-block:: sh
 
-    $ pip3 install selenium
+    $ python3 -m pip install selenium
 
 .. _Install the Chrome web browser: https://www.google.com/chrome/
 .. _Install chromedriver: https://sites.google.com/a/chromium.org/chromedriver/getting-started


### PR DESCRIPTION
Use the explicit `.. code-block` reStructuredText directive throughout, and highlight all blocks with the correct pygments lexer. The `::` syntax uses the default Python lexer which causes mishighlighting when it's not Python.

Also:

* sneak in a change from `pip install` to `python -m pip install` as per my [blog post today](https://adamj.eu/tech/2020/02/25/use-python-m-pip-everywhere/).
* Fix 'WARNING: html_static_path entry '_static' does not exist' by commenting out '_static' entry