### PR TITLE
Fix simple typo: reuseable -> reusable

### DIFF
--- a/docs/releases/2.1.0.rst
+++ b/docs/releases/2.1.0.rst
@@ -41,7 +41,7 @@ Nested URL Routing
 ``URLRouter`` instances can now be nested inside each other and, like Django's
 URL handling and ``include``, will strip off the matched part of the URL in the
 outer router and leave only the unmatched portion for the inner router, allowing
-reuseable routing files.
+reusable routing files.
 
 Note that you **cannot** use the Django ``include`` function inside of the
 ``URLRouter`` as it assumes a bit too much about what it is given as its

--- a/docs/topics/channel_layers.rst
+++ b/docs/topics/channel_layers.rst
@@ -67,9 +67,9 @@ In-Memory Channel Layer
 .. warning::
 
     **Not for Production Use.** In-memory channel layers operate each
-    process as a seperate layer, which means no cross-process
+    process as a separate layer, which means no cross-process
     messaging is possible. As the core value of channel layers
-    to provide distributed mesaging, in-memory usage will
+    to provide distributed messaging, in-memory usage will
     result in sub-optimal performance and data-loss in a
     multi-instance environment.
 

--- a/docs/topics/consumers.rst
+++ b/docs/topics/consumers.rst
@@ -245,7 +245,7 @@ just deals with text and binary frames:
 
 You can also raise ``channels.exceptions.AcceptConnection`` or
 ``channels.exceptions.DenyConnection`` from anywhere inside the ``connect``
-method in order to accept or reject a connection, if you want reuseable
+method in order to accept or reject a connection, if you want reusable
 authentication or rate-limiting code that doesn't need to use mixins.
 
 A ``WebsocketConsumer``'s channel will automatically be added to (on connect)


### PR DESCRIPTION
There is a small typo in docs/releases/2.1.0.rst, docs/topics/consumers.rst.
Should read `reusable` rather than `reuseable`.

