### PR TITLE
Avoid multiple backslashes in the json response

### DIFF
--- a/channels/generic/websocket.py
+++ b/channels/generic/websocket.py
@@ -144,7 +144,7 @@ class JsonWebsocketConsumer(WebsocketConsumer):
 
     @classmethod
     def encode_json(cls, content):
-        return json.dumps(content)
+        return json.dumps(content).replace('\"', '')
 
 
 class AsyncWebsocketConsumer(AsyncConsumer):


### PR DESCRIPTION
My responses were with two or three backslashes. I have rewritten the encode_json to avoid my problem!