### PR TITLE
re_path import fixed and $ sign socket error fixed

### DIFF
--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -233,12 +233,12 @@ Put the following code in ``chat/routing.py``:
 .. code-block:: python
 
     # chat/routing.py
-    from django.urls import path
+    from django.urls import re_path
 
     from . import consumers
 
     websocket_urlpatterns = [
-        re_path(r'ws/chat/(?P<room_name>\w+)/$', consumers.ChatConsumer),
+        re_path(r'ws/chat/(?P<room_name>\w+)/', consumers.ChatConsumer),
     ]
 
 (Note we use ``re_path()`` due to limitations in :ref:`URLRouter <urlrouter>`.)


### PR DESCRIPTION
instead of importing "re_path" ,path was imported which was giving import error and ,in url patterns regex if we use "url" then $ sign is required otherwise not. This $ sign was giving socket closed error. So,It should be removed.