### PR TITLE
'path' was imported instead of 're_path' from django.urls

### DIFF
--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -233,7 +233,7 @@ Put the following code in ``chat/routing.py``:
 .. code-block:: python
 
     # chat/routing.py
-    from django.urls import path
+    from django.urls import re_path
 
     from . import consumers
 


### PR DESCRIPTION
In tutorial 2, `chat/routing.py` snippet never imported the `re_path`. 