### PR TITLE
Added extra error for when bytes_data is revieved

### DIFF
--- a/channels/generic/websocket.py
+++ b/channels/generic/websocket.py
@@ -123,6 +123,8 @@ class JsonWebsocketConsumer(WebsocketConsumer):
     def receive(self, text_data=None, bytes_data=None, **kwargs):
         if text_data:
             self.receive_json(self.decode_json(text_data), **kwargs)
+        elif not text_data and bytes_data:
+            raise ValueError("No text section for incoming WebSocket frame! There is a bytes section, however. Did you mean for it to be the text section?")
         else:
             raise ValueError("No text section for incoming WebSocket frame!")
 
@@ -257,6 +259,8 @@ class AsyncJsonWebsocketConsumer(AsyncWebsocketConsumer):
     async def receive(self, text_data=None, bytes_data=None, **kwargs):
         if text_data:
             await self.receive_json(await self.decode_json(text_data), **kwargs)
+        elif not text_data and bytes_data:
+            raise ValueError("No text section for incoming WebSocket frame! There is a bytes section, however. Did you mean for it to be the text section?")
         else:
             raise ValueError("No text section for incoming WebSocket frame!")
 


### PR DESCRIPTION
I'm trying to set up a connection from Godot to Django Channels. I'm learning about how the websocket handshake and transfer protocol needs to work, and found that an error I was getting wasn't very explicit. This PR adds some more information in the case where bytes_data is received, but not text_data.

If I need to clean up this PR at all, I'll be more than happy to!