### PR TITLE
fix(consumer): get_handler_name

### DIFF
--- a/channels/consumer.py
+++ b/channels/consumer.py
@@ -17,10 +17,11 @@ def get_handler_name(message):
     # Check message looks OK
     if "type" not in message:
         raise ValueError("Incoming message has no 'type' attribute")
-    if message["type"].startswith("_"):
-        raise ValueError("Malformed type in message (leading underscore)")
     # Extract type and replace . with _
-    return message["type"].replace(".", "_")
+    handler_name = message["type"].replace(".", "_")
+    if handler_name.startswith("_"):
+        raise ValueError("Malformed type in message (leading underscore)")
+    return handler_name
 
 
 class AsyncConsumer:


### PR DESCRIPTION
Perform check after replace into get_handler_name to avoid class private members call.

Close #1430