### PR TITLE
Compatibility with isort v5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       env: DJANGO="Django==2.2.*"
 
     - stage: lint
-      install: pip install -U -e .[tests] black pyflakes 'isort<5'
+      install: pip install -U -e .[tests] black pyflakes isort
       script:
         - pyflakes channels tests
         - black --check --diff channels tests

--- a/channels/hacks.py
+++ b/channels/hacks.py
@@ -7,6 +7,7 @@ def monkeypatch_django():
     from django.contrib.staticfiles.management.commands.runserver import (
         Command as StaticRunserverCommand,
     )
+
     from .management.commands.runserver import Command as RunserverCommand
 
     StaticRunserverCommand.__bases__ = (RunserverCommand,)

--- a/channels/routing.py
+++ b/channels/routing.py
@@ -9,7 +9,6 @@ from django.urls.resolvers import URLResolver
 
 from channels.http import AsgiHandler
 
-
 """
 All Routing instances inside this file are also valid ASGI applications - with
 new Channels routing, whatever you end up with as the top level object is just

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,8 @@ known_third_party = django
 known_first_party = channels,daphne,asgiref
 multi_line_output = 3
 line_length = 88
+force_grid_wrap=0
+use_parentheses=True
 
 [bdist_wheel]
 universal=1

--- a/tox.ini
+++ b/tox.ini
@@ -18,4 +18,4 @@ deps =
 commands =
     pyflakes channels tests
     black --check channels tests
-    isort --check-only --diff --recursive channels tests
+    isort --check-only --diff channels tests


### PR DESCRIPTION
isort v5 seems to be much more stable now, number of issues on their tracker have also reduced significantly from a week ago. 
