### PR TITLE
Update to use ASGI v3 single-callable interface. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ Pipfile.lock
 # IDE and Tooling files
 .idea/*
 *~
+.vscode
 
 # macOS
 .DS_Store

--- a/channels/consumer.py
+++ b/channels/consumer.py
@@ -34,13 +34,12 @@ class AsyncConsumer:
     _sync = False
     channel_layer_alias = DEFAULT_CHANNEL_LAYER
 
-    def __init__(self, scope):
-        self.scope = scope
-
-    async def __call__(self, receive, send):
+    async def __call__(self, scope, receive, send):
         """
         Dispatches incoming messages to type-based handlers asynchronously.
         """
+        self.scope = scope
+
         # Initialize channel layer
         self.channel_layer = get_channel_layer(self.channel_layer_alias)
         if self.channel_layer is not None:

--- a/channels/generic/http.py
+++ b/channels/generic/http.py
@@ -10,7 +10,6 @@ class AsyncHttpConsumer(AsyncConsumer):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
         self.body = []
 
     async def send_headers(self, *, status=200, headers=None):

--- a/channels/http.py
+++ b/channels/http.py
@@ -168,21 +168,21 @@ class AsgiHandler(base.BaseHandler):
     # Size to chunk response bodies into for multiple response messages
     chunk_size = 512 * 1024
 
-    def __init__(self, scope):
+    def __init__(self):
+        super(AsgiHandler, self).__init__()
+        self.load_middleware()
+
+    async def __call__(self, scope, receive, send):
+        """
+        Async entrypoint - uses the sync_to_async wrapper to run things in a
+        threadpool.
+        """
         if scope["type"] != "http":
             raise ValueError(
                 "The AsgiHandler can only handle HTTP connections, not %s"
                 % scope["type"]
             )
-        super(AsgiHandler, self).__init__()
         self.scope = scope
-        self.load_middleware()
-
-    async def __call__(self, receive, send):
-        """
-        Async entrypoint - uses the sync_to_async wrapper to run things in a
-        threadpool.
-        """
         self.send = async_to_sync(send)
 
         # Receive the HTTP request body as a stream object.

--- a/channels/management/commands/runserver.py
+++ b/channels/management/commands/runserver.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import sys
 
+from daphne.cli import ASGI3Middleware
 from daphne.endpoints import build_endpoint_description_strings
 from daphne.server import Server
 from django.apps import apps
@@ -104,7 +105,7 @@ class Command(RunserverCommand):
         endpoints = build_endpoint_description_strings(host=self.addr, port=self.port)
         try:
             self.server_cls(
-                application=self.get_application(options),
+                application=ASGI3Middleware(self.get_application(options)),
                 endpoints=endpoints,
                 signal_handlers=not options["use_reloader"],
                 action_logger=self.log_action,

--- a/channels/middleware.py
+++ b/channels/middleware.py
@@ -1,6 +1,3 @@
-from functools import partial
-
-
 class BaseMiddleware:
     """
     Base class for implementing ASGI middleware. Inherit from this and
@@ -18,7 +15,7 @@ class BaseMiddleware:
         """
         self.inner = inner
 
-    def __call__(self, scope):
+    async def __call__(self, scope, receive, send):
         """
         ASGI constructor; can insert things into the scope, but not
         run asynchronous code.
@@ -27,15 +24,13 @@ class BaseMiddleware:
         scope = dict(scope)
         # Allow subclasses to change the scope
         self.populate_scope(scope)
-        # Call the inner application's init
-        inner_instance = self.inner(scope)
         # Partially bind it to our coroutine entrypoint along with the scope
-        return partial(self.coroutine_call, inner_instance, scope)
+        return await self.coroutine_call(self.inner, scope, receive, send)
 
-    async def coroutine_call(self, inner_instance, scope, receive, send):
+    async def coroutine_call(self, inner, scope, receive, send):
         """
         ASGI coroutine; where we can resolve items in the scope
         (but you can't modify it at the top level here!)
         """
         await self.resolve_scope(scope)
-        await inner_instance(receive, send)
+        await inner(scope, receive, send)

--- a/channels/routing.py
+++ b/channels/routing.py
@@ -47,7 +47,7 @@ class ProtocolTypeRouter:
     def __init__(self, application_mapping):
         self.application_mapping = application_mapping
         if "http" not in self.application_mapping:
-            self.application_mapping["http"] = AsgiHandler
+            self.application_mapping["http"] = AsgiHandler()
 
     async def __call__(self, scope, receive, send):
         if scope["type"] in self.application_mapping:

--- a/channels/security/websocket.py
+++ b/channels/security/websocket.py
@@ -16,7 +16,7 @@ class OriginValidator:
         self.application = application
         self.allowed_origins = allowed_origins
 
-    def __call__(self, scope):
+    async def __call__(self, scope, send, receive):
         # Make sure the scope is of type websocket
         if scope["type"] != "websocket":
             raise ValueError(
@@ -34,10 +34,11 @@ class OriginValidator:
         # Check to see if the origin header is valid
         if self.valid_origin(parsed_origin):
             # Pass control to the application
-            return self.application(scope)
+            return await self.application(scope, send, receive)
         else:
             # Deny the connection
-            return WebsocketDenier(scope)
+            denier = WebsocketDenier()
+            return await denier(scope, send, receive)
 
     def valid_origin(self, parsed_origin):
         """

--- a/channels/staticfiles.py
+++ b/channels/staticfiles.py
@@ -32,19 +32,23 @@ class StaticFilesWrapper:
         """
         return path.startswith(self.base_url[2]) and not self.base_url[1]
 
-    def __call__(self, scope):
+    def __call__(self, scope, receive, send):
         # Only even look at HTTP requests
         if scope["type"] == "http" and self._should_handle(scope["path"]):
             # Serve static content
-            return StaticFilesHandler(dict(scope, static_base_url=self.base_url))
+            return StaticFilesHandler()(
+                dict(scope, static_base_url=self.base_url), receive, send
+            )
         # Hand off to the main app
-        return self.application(scope)
+        return self.application(scope, receive, send)
 
 
 class StaticFilesHandler(AsgiHandler):
     """
     Subclass of AsgiHandler that serves directly from its get_response.
     """
+
+    # TODO: Review hierarchy here. Do we NEED to inherit BaseHandler, AsgiHandler?
 
     def file_path(self, url):
         """

--- a/tests/security/test_auth.py
+++ b/tests/security/test_auth.py
@@ -14,9 +14,8 @@ from django.contrib.auth import (
 )
 from django.contrib.auth.models import AnonymousUser
 
-from channels.auth import AuthMiddleware, get_user, login, logout
+from channels.auth import get_user, login, logout
 from channels.db import database_sync_to_async
-from channels.generic.websocket import WebsocketConsumer
 
 
 class CatchSignal:
@@ -251,24 +250,3 @@ async def test_logout_not_logged_in(session):
 
     assert "user" not in scope
     assert isinstance(await get_user(scope), AnonymousUser)
-
-
-@pytest.mark.django_db(transaction=True)
-@pytest.mark.asyncio
-async def test_scope_user_error_message(session):
-    """
-    Tests that the correct error message is thrown when scope user is accessed
-    before it's ready
-    """
-
-    class TestConsumer(WebsocketConsumer):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            if "user" in self.scope:
-                # access scope user before it's ready
-                getattr(self.scope["user"], "test")
-
-    with pytest.raises(ValueError, match="Accessing scope user before it is ready."):
-        scope = {"session": session}
-        auth = AuthMiddleware(TestConsumer)
-        auth(scope)

--- a/tests/security/test_websocket.py
+++ b/tests/security/test_websocket.py
@@ -11,7 +11,7 @@ async def test_origin_validator():
     Tests that OriginValidator correctly allows/denies connections.
     """
     # Make our test application
-    application = OriginValidator(AsyncWebsocketConsumer, ["allowed-domain.com"])
+    application = OriginValidator(AsyncWebsocketConsumer(), ["allowed-domain.com"])
     # Test a normal connection
     communicator = WebsocketCommunicator(
         application, "/", headers=[(b"origin", b"http://allowed-domain.com")]
@@ -27,7 +27,7 @@ async def test_origin_validator():
     assert not connected
     await communicator.disconnect()
     # Make our test application, bad pattern
-    application = OriginValidator(AsyncWebsocketConsumer, ["*.allowed-domain.com"])
+    application = OriginValidator(AsyncWebsocketConsumer(), ["*.allowed-domain.com"])
     # Test a bad connection
     communicator = WebsocketCommunicator(
         application, "/", headers=[(b"origin", b"http://allowed-domain.com")]
@@ -36,7 +36,7 @@ async def test_origin_validator():
     assert not connected
     await communicator.disconnect()
     # Make our test application, good pattern
-    application = OriginValidator(AsyncWebsocketConsumer, [".allowed-domain.com"])
+    application = OriginValidator(AsyncWebsocketConsumer(), [".allowed-domain.com"])
     # Test a normal connection
     communicator = WebsocketCommunicator(
         application, "/", headers=[(b"origin", b"http://www.allowed-domain.com")]
@@ -45,7 +45,9 @@ async def test_origin_validator():
     assert connected
     await communicator.disconnect()
     # Make our test application, with scheme://domain[:port] for http
-    application = OriginValidator(AsyncWebsocketConsumer, ["http://allowed-domain.com"])
+    application = OriginValidator(
+        AsyncWebsocketConsumer(), ["http://allowed-domain.com"]
+    )
     # Test a normal connection
     communicator = WebsocketCommunicator(
         application, "/", headers=[(b"origin", b"http://allowed-domain.com")]
@@ -61,27 +63,27 @@ async def test_origin_validator():
     assert not connected
     await communicator.disconnect()
     # Make our test application, with all hosts allowed
-    application = OriginValidator(AsyncWebsocketConsumer, ["*"])
+    application = OriginValidator(AsyncWebsocketConsumer(), ["*"])
     # Test a connection without any headers
     communicator = WebsocketCommunicator(application, "/", headers=[])
     connected, _ = await communicator.connect()
     assert connected
     await communicator.disconnect()
     # Make our test application, with no hosts allowed
-    application = OriginValidator(AsyncWebsocketConsumer, [])
+    application = OriginValidator(AsyncWebsocketConsumer(), [])
     # Test a connection without any headers
     communicator = WebsocketCommunicator(application, "/", headers=[])
     connected, _ = await communicator.connect()
     assert not connected
     await communicator.disconnect()
     # Test bug with subdomain and empty origin header
-    application = OriginValidator(AsyncWebsocketConsumer, [".allowed-domain.com"])
+    application = OriginValidator(AsyncWebsocketConsumer(), [".allowed-domain.com"])
     communicator = WebsocketCommunicator(application, "/", headers=[(b"origin", b"")])
     connected, _ = await communicator.connect()
     assert not connected
     await communicator.disconnect()
     # Test bug with subdomain and invalid origin header
-    application = OriginValidator(AsyncWebsocketConsumer, [".allowed-domain.com"])
+    application = OriginValidator(AsyncWebsocketConsumer(), [".allowed-domain.com"])
     communicator = WebsocketCommunicator(
         application, "/", headers=[(b"origin", b"something-invalid")]
     )

--- a/tests/test_generic_http.py
+++ b/tests/test_generic_http.py
@@ -21,9 +21,11 @@ async def test_async_http_consumer():
                 headers={b"Content-Type": b"application/json"},
             )
 
+    app = TestConsumer()
+
     # Open a connection
     communicator = HttpCommunicator(
-        TestConsumer,
+        app,
         method="POST",
         path="/test/",
         body=json.dumps({"value": 42, "anything": False}).encode("utf-8"),

--- a/tests/test_generic_websocket.py
+++ b/tests/test_generic_websocket.py
@@ -31,8 +31,10 @@ async def test_websocket_consumer():
         def disconnect(self, code):
             results["disconnected"] = code
 
+    app = TestConsumer()
+
     # Test a normal connection
-    communicator = WebsocketCommunicator(TestConsumer, "/testws/")
+    communicator = WebsocketCommunicator(app, "/testws/")
     connected, _ = await communicator.connect()
     assert connected
     assert "connected" in results
@@ -63,9 +65,11 @@ async def test_websocket_consumer_subprotocol():
             assert self.scope["subprotocols"] == ["subprotocol1", "subprotocol2"]
             self.accept("subprotocol2")
 
+    app = TestConsumer()
+
     # Test a normal connection with subprotocols
     communicator = WebsocketCommunicator(
-        TestConsumer, "/testws/", subprotocols=["subprotocol1", "subprotocol2"]
+        app, "/testws/", subprotocols=["subprotocol1", "subprotocol2"]
     )
     connected, subprotocol = await communicator.connect()
     assert connected
@@ -87,11 +91,13 @@ async def test_websocket_consumer_groups():
             results["received"] = (text_data, bytes_data)
             self.send(text_data=text_data, bytes_data=bytes_data)
 
+    app = TestConsumer()
+
     channel_layers_setting = {
         "default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}
     }
     with override_settings(CHANNEL_LAYERS=channel_layers_setting):
-        communicator = WebsocketCommunicator(TestConsumer, "/testws/")
+        communicator = WebsocketCommunicator(app, "/testws/")
         await communicator.connect()
 
         channel_layer = get_channel_layer()
@@ -125,8 +131,10 @@ async def test_async_websocket_consumer():
         async def disconnect(self, code):
             results["disconnected"] = code
 
+    app = TestConsumer()
+
     # Test a normal connection
-    communicator = WebsocketCommunicator(TestConsumer, "/testws/")
+    communicator = WebsocketCommunicator(app, "/testws/")
     connected, _ = await communicator.connect()
     assert connected
     assert "connected" in results
@@ -156,9 +164,11 @@ async def test_async_websocket_consumer_subprotocol():
             assert self.scope["subprotocols"] == ["subprotocol1", "subprotocol2"]
             await self.accept("subprotocol2")
 
+    app = TestConsumer()
+
     # Test a normal connection with subprotocols
     communicator = WebsocketCommunicator(
-        TestConsumer, "/testws/", subprotocols=["subprotocol1", "subprotocol2"]
+        app, "/testws/", subprotocols=["subprotocol1", "subprotocol2"]
     )
     connected, subprotocol = await communicator.connect()
     assert connected
@@ -179,11 +189,13 @@ async def test_async_websocket_consumer_groups():
             results["received"] = (text_data, bytes_data)
             await self.send(text_data=text_data, bytes_data=bytes_data)
 
+    app = TestConsumer()
+
     channel_layers_setting = {
         "default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}
     }
     with override_settings(CHANNEL_LAYERS=channel_layers_setting):
-        communicator = WebsocketCommunicator(TestConsumer, "/testws/")
+        communicator = WebsocketCommunicator(app, "/testws/")
         await communicator.connect()
 
         channel_layer = get_channel_layer()
@@ -213,11 +225,13 @@ async def test_async_websocket_consumer_specific_channel_layer():
             results["received"] = (text_data, bytes_data)
             await self.send(text_data=text_data, bytes_data=bytes_data)
 
+    app = TestConsumer()
+
     channel_layers_setting = {
         "testlayer": {"BACKEND": "channels.layers.InMemoryChannelLayer"}
     }
     with override_settings(CHANNEL_LAYERS=channel_layers_setting):
-        communicator = WebsocketCommunicator(TestConsumer, "/testws/")
+        communicator = WebsocketCommunicator(app, "/testws/")
         await communicator.connect()
 
         channel_layer = get_channel_layer("testlayer")
@@ -250,8 +264,10 @@ async def test_json_websocket_consumer():
             results["received"] = data
             self.send_json(data)
 
+    app = TestConsumer()
+
     # Open a connection
-    communicator = WebsocketCommunicator(TestConsumer, "/testws/")
+    communicator = WebsocketCommunicator(app, "/testws/")
     connected, _ = await communicator.connect()
     assert connected
     # Test sending
@@ -280,8 +296,10 @@ async def test_async_json_websocket_consumer():
             results["received"] = data
             await self.send_json(data)
 
+    app = TestConsumer()
+
     # Open a connection
-    communicator = WebsocketCommunicator(TestConsumer, "/testws/")
+    communicator = WebsocketCommunicator(app, "/testws/")
     connected, _ = await communicator.connect()
     assert connected
     # Test sending
@@ -307,11 +325,13 @@ async def test_block_underscored_type_function_call():
         async def _my_private_handler(self, _):
             await self.send(text_data="should never be called")
 
+    app = TestConsumer()
+
     channel_layers_setting = {
         "testlayer": {"BACKEND": "channels.layers.InMemoryChannelLayer"}
     }
     with override_settings(CHANNEL_LAYERS=channel_layers_setting):
-        communicator = WebsocketCommunicator(TestConsumer, "/testws/")
+        communicator = WebsocketCommunicator(app, "/testws/")
         await communicator.connect()
 
         channel_layer = get_channel_layer("testlayer")
@@ -340,11 +360,13 @@ async def test_block_leading_dot_type_function_call():
         async def _my_private_handler(self, _):
             await self.send(text_data="should never be called")
 
+    app = TestConsumer()
+
     channel_layers_setting = {
         "testlayer": {"BACKEND": "channels.layers.InMemoryChannelLayer"}
     }
     with override_settings(CHANNEL_LAYERS=channel_layers_setting):
-        communicator = WebsocketCommunicator(TestConsumer, "/testws/")
+        communicator = WebsocketCommunicator(app, "/testws/")
         await communicator.connect()
 
         channel_layer = get_channel_layer("testlayer")

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -9,7 +9,6 @@ from django.core.exceptions import RequestDataTooBig
 from django.http import HttpResponse, RawPostDataException
 from django.test import override_settings
 
-from asgiref.testing import ApplicationCommunicator
 from channels.consumer import AsyncConsumer
 from channels.db import database_sync_to_async
 from channels.http import AsgiHandler, AsgiRequest

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -9,7 +9,6 @@ from django.core.exceptions import RequestDataTooBig
 from django.http import HttpResponse, RawPostDataException
 from django.test import override_settings
 
-from asgiref.compatibility import guarantee_single_callable
 from asgiref.testing import ApplicationCommunicator
 from channels.consumer import AsyncConsumer
 from channels.db import database_sync_to_async
@@ -350,7 +349,7 @@ async def test_sessions():
             )
             await self.send({"type": "http.response.body", "body": b"test response"})
 
-    app = guarantee_single_callable(SimpleHttpApp)
+    app = SimpleHttpApp()
 
     communicator = HttpCommunicator(SessionMiddlewareStack(app), "GET", "/test/")
     response = await communicator.get_response()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -264,7 +264,7 @@ async def test_handler_basic():
     Tests very basic request handling, no body.
     """
     scope = {"type": "http", "http_version": "1.1", "method": "GET", "path": "/test/"}
-    handler = ApplicationCommunicator(MockHandler, scope)
+    handler = ApplicationCommunicator(MockHandler(), scope)
     await handler.send_input({"type": "http.request"})
     await handler.receive_output(1)  # response start
     await handler.receive_output(1)  # response body
@@ -280,7 +280,7 @@ async def test_handler_body_single():
     Tests request handling with a single-part body
     """
     scope = {"type": "http", "http_version": "1.1", "method": "GET", "path": "/test/"}
-    handler = ApplicationCommunicator(MockHandler, scope)
+    handler = ApplicationCommunicator(MockHandler(), scope)
     await handler.send_input(
         {"type": "http.request", "body": b"chunk one \x01 chunk two"}
     )
@@ -298,7 +298,7 @@ async def test_handler_body_multiple():
     Tests request handling with a multi-part body
     """
     scope = {"type": "http", "http_version": "1.1", "method": "GET", "path": "/test/"}
-    handler = ApplicationCommunicator(MockHandler, scope)
+    handler = ApplicationCommunicator(MockHandler(), scope)
     await handler.send_input(
         {"type": "http.request", "body": b"chunk one", "more_body": True}
     )
@@ -320,7 +320,7 @@ async def test_handler_body_ignore_extra():
     Tests request handling ignores anything after more_body: False
     """
     scope = {"type": "http", "http_version": "1.1", "method": "GET", "path": "/test/"}
-    handler = ApplicationCommunicator(MockHandler, scope)
+    handler = ApplicationCommunicator(MockHandler(), scope)
     await handler.send_input(
         {"type": "http.request", "body": b"chunk one", "more_body": False}
     )
@@ -378,20 +378,12 @@ class MiddlewareTests(unittest.TestCase):
         Tests that middleware is only loaded once
         and is successfully cached on the AsgiHandler class.
         """
-
-        scope = {
-            "type": "http",
-            "http_version": "1.1",
-            "method": "GET",
-            "path": "/test/",
-        }
-
-        AsgiHandler(scope)  # First Handler
+        AsgiHandler()  # First Handler
 
         self.assertTrue(AsgiHandler._middleware_chain is not None)
 
         with patch(
             "django.core.handlers.base.BaseHandler.load_middleware"
         ) as super_function:
-            AsgiHandler(scope)  # Second Handler
+            AsgiHandler()  # Second Handler
             self.assertFalse(super_function.called)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -9,6 +9,8 @@ from django.core.exceptions import RequestDataTooBig
 from django.http import HttpResponse, RawPostDataException
 from django.test import override_settings
 
+from asgiref.compatibility import guarantee_single_callable
+from asgiref.testing import ApplicationCommunicator
 from channels.consumer import AsyncConsumer
 from channels.db import database_sync_to_async
 from channels.http import AsgiHandler, AsgiRequest
@@ -348,9 +350,9 @@ async def test_sessions():
             )
             await self.send({"type": "http.response.body", "body": b"test response"})
 
-    communicator = HttpCommunicator(
-        SessionMiddlewareStack(SimpleHttpApp), "GET", "/test/"
-    )
+    app = guarantee_single_callable(SimpleHttpApp)
+
+    communicator = HttpCommunicator(SessionMiddlewareStack(app), "GET", "/test/")
     response = await communicator.get_response()
     headers = response.get("headers", [])
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import path, re_path
@@ -8,88 +6,107 @@ from channels.http import AsgiHandler
 from channels.routing import ChannelNameRouter, ProtocolTypeRouter, URLRouter
 
 
-def test_protocol_type_router():
+class MockApplication:
+
+    call_args = None
+
+    def __init__(self, return_value):
+        self.return_value = return_value
+        super().__init__()
+
+    async def __call__(self, scope, receive, send):
+        self.call_args = ((scope, receive, send), None)
+        return self.return_value
+
+
+@pytest.mark.asyncio
+async def test_protocol_type_router():
     """
     Tests the ProtocolTypeRouter
     """
     # Test basic operation
     router = ProtocolTypeRouter(
         {
-            "websocket": MagicMock(return_value="ws"),
-            "http": MagicMock(return_value="http"),
+            "websocket": MockApplication(return_value="ws"),
+            "http": MockApplication(return_value="http"),
         }
     )
-    assert router({"type": "websocket"}) == "ws"
-    assert router({"type": "http"}) == "http"
+    assert await router({"type": "websocket"}, None, None) == "ws"
+    assert await router({"type": "http"}, None, None) == "http"
     # Test defaulting to AsgiHandler
-    router = ProtocolTypeRouter({"websocket": MagicMock(return_value="ws")})
-    assert isinstance(router({"type": "http"}), AsgiHandler)
+    router = ProtocolTypeRouter({"websocket": MockApplication(return_value="ws")})
+    assert router.application_mapping["http"] == AsgiHandler
     # Test an unmatched type
     with pytest.raises(ValueError):
-        router({"type": "aprs"})
+        await router({"type": "aprs"}, None, None)
     # Test a scope with no type
     with pytest.raises(KeyError):
-        router({"tyyyype": "http"})
+        await router({"tyyyype": "http"}, None, None)
 
 
-def test_channel_name_router():
+@pytest.mark.asyncio
+async def test_channel_name_router():
     """
     Tests the ChannelNameRouter
     """
     # Test basic operation
     router = ChannelNameRouter(
-        {"test": MagicMock(return_value=1), "other_test": MagicMock(return_value=2)}
+        {
+            "test": MockApplication(return_value=1),
+            "other_test": MockApplication(return_value=2),
+        }
     )
-    assert router({"channel": "test"}) == 1
-    assert router({"channel": "other_test"}) == 2
+    assert await router({"channel": "test"}, None, None) == 1
+    assert await router({"channel": "other_test"}, None, None) == 2
     # Test an unmatched channel
     with pytest.raises(ValueError):
-        router({"channel": "chat"})
+        await router({"channel": "chat"}, None, None)
     # Test a scope with no channel
     with pytest.raises(ValueError):
-        router({"type": "http"})
+        await router({"type": "http"}, None, None)
 
 
-def test_url_router():
+@pytest.mark.asyncio
+async def test_url_router():
     """
     Tests the URLRouter
     """
-    posarg_app = MagicMock(return_value=4)
-    kwarg_app = MagicMock(return_value=5)
-    defaultkwarg_app = MagicMock(return_value=6)
+    posarg_app = MockApplication(return_value=4)
+    kwarg_app = MockApplication(return_value=5)
+    defaultkwarg_app = MockApplication(return_value=6)
     router = URLRouter(
         [
-            path("", MagicMock(return_value=1)),
-            path("foo/", MagicMock(return_value=2)),
-            re_path(r"bar", MagicMock(return_value=3)),
+            path("", MockApplication(return_value=1)),
+            path("foo/", MockApplication(return_value=2)),
+            re_path(r"bar", MockApplication(return_value=3)),
             re_path(r"^posarg/(\d+)/$", posarg_app),
             path("kwarg/<str:name>/", kwarg_app),
             path("defaultkwargs/", defaultkwarg_app, kwargs={"default": 42}),
         ]
     )
     # Valid basic matches
-    assert router({"type": "http", "path": "/"}) == 1
-    assert router({"type": "http", "path": "/foo/"}) == 2
-    assert router({"type": "http", "path": "/bar/"}) == 3
-    assert router({"type": "http", "path": "/bar/baz/"}) == 3
+    assert await router({"type": "http", "path": "/"}, None, None) == 1
+    assert await router({"type": "http", "path": "/foo/"}, None, None) == 2
+    assert await router({"type": "http", "path": "/bar/"}, None, None) == 3
+    assert await router({"type": "http", "path": "/bar/baz/"}, None, None) == 3
     # Valid positional matches
-    assert router({"type": "http", "path": "/posarg/123/"}) == 4
+    assert await router({"type": "http", "path": "/posarg/123/"}, None, None) == 4
     assert posarg_app.call_args[0][0]["url_route"] == {"args": ("123",), "kwargs": {}}
-    assert router({"type": "http", "path": "/posarg/456/"}) == 4
+    assert await router({"type": "http", "path": "/posarg/456/"}, None, None) == 4
     assert posarg_app.call_args[0][0]["url_route"] == {"args": ("456",), "kwargs": {}}
     # Valid keyword argument matches
-    assert router({"type": "http", "path": "/kwarg/hello/"}) == 5
+    assert await router({"type": "http", "path": "/kwarg/hello/"}, None, None) == 5
     assert kwarg_app.call_args[0][0]["url_route"] == {
         "args": tuple(),
         "kwargs": {"name": "hello"},
     }
-    assert router({"type": "http", "path": "/kwarg/hellothere/"}) == 5
+    assert await router({"type": "http", "path": "/kwarg/hellothere/"}, None, None) == 5
     assert kwarg_app.call_args[0][0]["url_route"] == {
         "args": tuple(),
         "kwargs": {"name": "hellothere"},
     }
     # Valid default keyword arguments
-    assert router({"type": "http", "path": "/defaultkwargs/"}) == 6
+    assert await router({"type": "http", "path": "/defaultkwargs/"}, None, None) == 6
     assert defaultkwarg_app.call_args[0][0]["url_route"] == {
         "args": tuple(),
         "kwargs": {"default": 42},
@@ -97,14 +114,15 @@ def test_url_router():
 
     # Invalid matches
     with pytest.raises(ValueError):
-        router({"type": "http", "path": "/nonexistent/"})
+        await router({"type": "http", "path": "/nonexistent/"}, None, None)
 
 
-def test_url_router_nesting():
+@pytest.mark.asyncio
+async def test_url_router_nesting():
     """
     Tests that nested URLRouters add their keyword captures together.
     """
-    test_app = MagicMock(return_value=1)
+    test_app = MockApplication(return_value=1)
     inner_router = URLRouter(
         [
             re_path(r"^book/(?P<book>[\w\-]+)/page/(?P<page>\d+)/$", test_app),
@@ -120,11 +138,13 @@ def test_url_router_nesting():
         ]
     )
     assert (
-        outer_router(
+        await outer_router(
             {
                 "type": "http",
                 "path": "/universe/42/author/andrewgodwin/book/channels-guide/page/10/",
-            }
+            },
+            None,
+            None,
         )
         == 1
     )
@@ -138,24 +158,30 @@ def test_url_router_nesting():
         },
     }
 
-    assert outer_router({"type": "http", "path": "/positional/foo/test/3/"}) == 1
+    assert (
+        await outer_router(
+            {"type": "http", "path": "/positional/foo/test/3/"}, None, None
+        )
+        == 1
+    )
     assert test_app.call_args[0][0]["url_route"] == {"args": ("foo", "3"), "kwargs": {}}
 
 
-def test_url_router_nesting_path():
+@pytest.mark.asyncio
+async def test_url_router_nesting_path():
     """
     Tests that nested URLRouters add their keyword captures together when used
     with path().
     """
     from django.urls import path
 
-    test_app = MagicMock(return_value=1)
+    test_app = MockApplication(return_value=1)
     inner_router = URLRouter([path("test/<int:page>/", test_app)])
 
     def asgi_middleware(inner):
         # Some middleware which hides the fact that we have an inner URLRouter
-        def app(scope):
-            return inner(scope)
+        async def app(scope, receive, send):
+            return await inner(scope, receive, send)
 
         app._path_routing = True
         return app
@@ -164,67 +190,80 @@ def test_url_router_nesting_path():
         [path("number/<int:number>/", asgi_middleware(inner_router))]
     )
 
-    assert inner_router({"type": "http", "path": "/test/3/"}) == 1
-    assert outer_router({"type": "http", "path": "/number/42/test/3/"}) == 1
+    assert await inner_router({"type": "http", "path": "/test/3/"}, None, None) == 1
+    assert (
+        await outer_router({"type": "http", "path": "/number/42/test/3/"}, None, None)
+        == 1
+    )
     assert test_app.call_args[0][0]["url_route"] == {
         "args": (),
         "kwargs": {"number": 42, "page": 3},
     }
     with pytest.raises(ValueError):
-        assert outer_router({"type": "http", "path": "/number/42/test/3/bla/"})
+        assert await outer_router(
+            {"type": "http", "path": "/number/42/test/3/bla/"}, None, None
+        )
     with pytest.raises(ValueError):
-        assert outer_router({"type": "http", "path": "/number/42/blub/"})
+        assert await outer_router(
+            {"type": "http", "path": "/number/42/blub/"}, None, None
+        )
 
 
-def test_url_router_path():
+@pytest.mark.asyncio
+async def test_url_router_path():
     """
     Tests that URLRouter also works with path()
     """
     from django.urls import path
 
-    kwarg_app = MagicMock(return_value=3)
+    kwarg_app = MockApplication(return_value=3)
     router = URLRouter(
         [
-            path("", MagicMock(return_value=1)),
-            path("foo/", MagicMock(return_value=2)),
+            path("", MockApplication(return_value=1)),
+            path("foo/", MockApplication(return_value=2)),
             path("author/<name>/", kwarg_app),
             path("year/<int:year>/", kwarg_app),
         ]
     )
     # Valid basic matches
-    assert router({"type": "http", "path": "/"}) == 1
-    assert router({"type": "http", "path": "/foo/"}) == 2
+    assert await router({"type": "http", "path": "/"}, None, None) == 1
+    assert await router({"type": "http", "path": "/foo/"}, None, None) == 2
     # Named without typecasting
-    assert router({"type": "http", "path": "/author/andrewgodwin/"}) == 3
+    assert (
+        await router({"type": "http", "path": "/author/andrewgodwin/"}, None, None) == 3
+    )
     assert kwarg_app.call_args[0][0]["url_route"] == {
         "args": tuple(),
         "kwargs": {"name": "andrewgodwin"},
     }
     # Named with typecasting
-    assert router({"type": "http", "path": "/year/2012/"}) == 3
+    assert await router({"type": "http", "path": "/year/2012/"}, None, None) == 3
     assert kwarg_app.call_args[0][0]["url_route"] == {
         "args": tuple(),
         "kwargs": {"year": 2012},
     }
     # Invalid matches
     with pytest.raises(ValueError):
-        router({"type": "http", "path": "/nonexistent/"})
+        await router({"type": "http", "path": "/nonexistent/"}, None, None)
 
 
-# @pytest.mark.xfail
-def test_path_remaining():
+@pytest.mark.asyncio
+async def test_path_remaining():
     """
     Resolving continues in outer router if an inner router has no matching
     routes
     """
-    inner_router = URLRouter([path("no-match/", MagicMock(return_value=1))])
-    test_app = MagicMock(return_value=2)
+    inner_router = URLRouter([path("no-match/", MockApplication(return_value=1))])
+    test_app = MockApplication(return_value=2)
     outer_router = URLRouter(
         [path("prefix/", inner_router), path("prefix/stuff/", test_app)]
     )
     outermost_router = URLRouter([path("", outer_router)])
 
-    assert outermost_router({"type": "http", "path": "/prefix/stuff/"}) == 2
+    assert (
+        await outermost_router({"type": "http", "path": "/prefix/stuff/"}, None, None)
+        == 2
+    )
 
 
 def test_invalid_routes():

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -35,7 +35,7 @@ async def test_protocol_type_router():
     assert await router({"type": "http"}, None, None) == "http"
     # Test defaulting to AsgiHandler
     router = ProtocolTypeRouter({"websocket": MockApplication(return_value="ws")})
-    assert router.application_mapping["http"] == AsgiHandler
+    assert isinstance(router.application_mapping["http"], AsgiHandler)
     # Test an unmatched type
     with pytest.raises(ValueError):
         await router({"type": "aprs"}, None, None)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -28,7 +28,7 @@ async def test_http_communicator():
     """
     Tests that the HTTP communicator class works at a basic level.
     """
-    communicator = HttpCommunicator(SimpleHttpApp, "GET", "/test/?foo=bar")
+    communicator = HttpCommunicator(SimpleHttpApp(), "GET", "/test/?foo=bar")
     response = await communicator.get_response()
     assert response["body"] == b"test response"
     assert response["status"] == 200
@@ -72,7 +72,7 @@ async def test_websocket_communicator():
     """
     Tests that the WebSocket communicator class works at a basic level.
     """
-    communicator = WebsocketCommunicator(SimpleWebsocketApp, "/testws/")
+    communicator = WebsocketCommunicator(SimpleWebsocketApp(), "/testws/")
     # Test connection
     connected, subprotocol = await communicator.connect()
     assert connected
@@ -100,7 +100,7 @@ async def test_websocket_application():
     Tests that the WebSocket communicator class works with the
     URLRoute application.
     """
-    application = URLRouter([path("testws/<str:message>/", KwargsWebSocketApp)])
+    application = URLRouter([path("testws/<str:message>/", KwargsWebSocketApp())])
     communicator = WebsocketCommunicator(application, "/testws/test/")
     connected, subprotocol = await communicator.connect()
     # Test connection
@@ -117,7 +117,7 @@ async def test_timeout_disconnect():
     """
     Tests that disconnect() still works after a timeout.
     """
-    communicator = WebsocketCommunicator(ErrorWebsocketApp, "/testws/")
+    communicator = WebsocketCommunicator(ErrorWebsocketApp(), "/testws/")
     # Test connection
     connected, subprotocol = await communicator.connect()
     assert connected
@@ -163,7 +163,7 @@ async def test_connection_scope(path):
     """
     Tests ASGI specification for the the connection scope.
     """
-    communicator = WebsocketCommunicator(ConnectionScopeValidator, path)
+    communicator = WebsocketCommunicator(ConnectionScopeValidator(), path)
     connected, _ = await communicator.connect()
     assert connected
     await communicator.disconnect()


### PR DESCRIPTION
Closes #1420, #1319.

Not something we can really do bit-by-bit, so preparing here, for a major version bump. 

- [x] Update Middleware (Thanks to @jaydenwindle #1412) 
- [x] Update Routers (Thanks to @jaydenwindle #1479)
- [x] Update consumers (#1483)
- [x] ASGIHandler (#1484)
- [ ] Document changes and upgrade steps. 
- [ ] Maybe simplify BaseMiddleware: is there value in all of:
    - `__call__`
    - `populate_scope`
    - `resolve_scope`
    - `coroutine_call`
    

Then note for version release: 

- [x] Adapt ProtocolTypeRouter to use single callable. #1523
- [ ] Make ProtocolTypeRouter detect Django's own ASGI application for 3.0+ (by default)
- [x] Adapt runserver to use ASGI v3.  #1523
- [ ] Document usage with Django 2.2. vs 3.0+


Anything else? 