### PR TITLE
Added `SECRET_KEY` to settings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,5 +11,5 @@ def pytest_configure():
             "django.contrib.admin",
             "channels",
         ],
-        SECRET_KEY="Not_a_secret_key"
+        SECRET_KEY="Not_a_secret_key",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,4 +11,5 @@ def pytest_configure():
             "django.contrib.admin",
             "channels",
         ],
+        SECRET_KEY="Not_a_secret_key"
     )


### PR DESCRIPTION
Tests are currently failing against the Django main branch. A bit of `git bisect` helped here (first time I've used this, so excited)

This commit requires a `SECRET_KEY` in the settings file to avoid raising an `ImproperlyConfigured` error.
https://github.com/django/django/commit/948a874425e7d999950a8fa3b6598d9e34a4b861