### PR TITLE
Websocket initial HTTP handshake could not be decoded inside AsgiHandler

### DIFF
--- a/channels/http.py
+++ b/channels/http.py
@@ -53,7 +53,11 @@ class AsgiRequest(http.HttpRequest):
             self.path = scope["path"]
 
         # HTTP basics
-        self.method = self.scope["method"].upper()
+        if self.scope.get("type") == "websocket":
+            self.method = "GET"
+        else:
+            self.method = self.scope["method"].upper()
+
         # fix https://github.com/django/channels/issues/622
         query_string = self.scope.get("query_string", "")
         if isinstance(query_string, bytes):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -159,15 +159,14 @@ class RequestTests(unittest.TestCase):
                 "headers": {
                     "sec-websocket-protocol": b"350",
                 },
-            }, BytesIO(b"")
+            },
+            BytesIO(b""),
         )
         self.assertEqual(request.path, "/test/")
         self.assertEqual(request.method, "GET")
         self.assertEqual(request.META["REQUEST_METHOD"], "GET")
         self.assertEqual(request.GET["django"], "great")
-        self.assertEqual(
-            request.META["HTTP_SEC_WEBSOCKET_PROTOCOL"], "350"
-        )
+        self.assertEqual(request.META["HTTP_SEC_WEBSOCKET_PROTOCOL"], "350")
 
     def test_stream(self):
         """

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -141,6 +141,34 @@ class RequestTests(unittest.TestCase):
         self.assertEqual(request.POST["title"], "My First Book")
         self.assertEqual(request.FILES["pdf"].read(), b"FAKEPDFBYTESGOHERE")
 
+    def test_websocket_handshake(self):
+        """
+        Tests handler can decode Websocket connection scope HTTP handshake.
+
+        As per the ASGI specs, a request method is not supplied in the
+        websocket connection scope (although the request method must have been
+        GET as of RFC6455).
+        """
+
+        request = AsgiRequest(
+            {
+                "type": "websocket",
+                "http_version": "1.1",
+                "query_string": "django=great",
+                "path": "/test/",
+                "headers": {
+                    "sec-websocket-protocol": b"350",
+                },
+            }, BytesIO(b"")
+        )
+        self.assertEqual(request.path, "/test/")
+        self.assertEqual(request.method, "GET")
+        self.assertEqual(request.META["REQUEST_METHOD"], "GET")
+        self.assertEqual(request.GET["django"], "great")
+        self.assertEqual(
+            request.META["HTTP_SEC_WEBSOCKET_PROTOCOL"], "350"
+        )
+
     def test_stream(self):
         """
         Tests the body stream is emulated correctly.


### PR DESCRIPTION
Motivation: https://github.com/django/daphne/issues/330

The request method of `GET` is not being supplied by Daphne in the Websocket connection scope for the initial HTTP handshake. This is actually as per the ASGI specification:

https://asgi.readthedocs.io/en/latest/specs/www.html#websocket-connection-scope

However as per RFC 6455 **4.1** it is specified that the Websocket's initial handshake must be a valid HTTP request with a method of GET.

https://tools.ietf.org/html/rfc6455

> 1.   The handshake MUST be a valid HTTP request as specified by
        [RFC2616].

>   2.   The method of the request MUST be GET, and the HTTP version MUST
        be at least 1.1.

Unfortunately using AsgiHandler against the websocket connection scope for the initial HTTP handshake is resulting in a KeyError as the method key does not exist in the scope. This pull allows an AsgiHandler instance to wrap the websocket scope of the initial HTTP handshake, by defaulting to GET for websocket connections.

This allows easier access to request headers, query parameters and more of the initial HTTP handshake (for instance, inside middlewares).  