### PR TITLE
Use path() instead of re_path()

### DIFF
--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -233,15 +233,13 @@ Put the following code in ``chat/routing.py``:
 .. code-block:: python
 
     # chat/routing.py
-    from django.urls import re_path
+    from django.urls import path
 
     from . import consumers
 
     websocket_urlpatterns = [
-        re_path(r'ws/chat/(?P<room_name>\w+)/$', consumers.ChatConsumer),
+        path('ws/chat/<str:room_name>/', consumers.ChatConsumer),
     ]
-
-(Note we use ``re_path()`` due to limitations in :ref:`URLRouter <urlrouter>`.)
 
 The next step is to point the root routing configuration at the **chat.routing**
 module. In ``mysite/routing.py``, import ``AuthMiddlewareStack``, ``URLRouter``,


### PR DESCRIPTION
Change re_path() to path() with the appropriate arguments.
Remove the note recommending re_path() 'due to limitation in URLRouter.'

According to https://channels.readthedocs.io/en/latest/topics/routing.html#urlrouter there is nothing that says URLRouter cannot use path() and even recommends using path(). path() is preferable to re_path() due to readability. I have tested these changes and the app works the same.