### PR TITLE
Prevent /run/daphne/ directory from disappearing on reboot

### DIFF
--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -205,7 +205,7 @@ share the same bound port:
 
     # Each process needs to have a separate socket file, so we use process_num
     # Make sure to update "mysite.asgi" to match your project name
-    command=daphne -u /run/daphne/daphne%(process_num)d.sock --fd 0 --access-log - --proxy-headers mysite.asgi:application
+    command=/my/app/path/venv/bin/daphne -u /my/app/path/run/daphne/daphne%(process_num)d.sock --fd 0 --access-log - --proxy-headers mysite.asgi:application
 
     # Number of processes to startup, roughly the number of CPUs you have
     numprocs=4
@@ -225,7 +225,7 @@ Create the run directory for the sockets referenced in the supervisor configurat
 
 .. code-block:: sh
 
-    $ sudo mkdir /run/daphne/
+    $ sudo mkdir -p /my/app/path/run/daphne/
 
 When running the supervisor fcgi-program under a different user, change the owner settings of the run directory.
 


### PR DESCRIPTION
I saw another PR from @ronnievdc dealing with the exact same issue #1499.
But I have a different approach to address the issue.

As a newbie, I couldn't figure out how to auto remake `/run/daphne/` directory on reboot for a while.
Eventually, I got around the issue by changing the directory path to something that won't be deleted on reboot in the supervisor config file i.e.`-u /run/daphne/daphne%(process_num)d.sock` -> `-u /home/username/project/run/daphne/daphne%(process_num)d.sock`
This way, `/run/daphne/` is inside the project directory and doesn't get deleted on reboot.

This solution doesn't involve extra steps and appears to be beginner friendly.

Also this PR has `command=daphne -u ...` changed to `command=/my/app/path/venv/bin/daphne -u ...` provided most of us are using virtual environment and without this specific path, beginners would have to search why it's not working again.


