### PR TITLE
Remove universal wheels declaration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,5 @@ line_length = 88
 force_grid_wrap=0
 use_parentheses=True
 
-[bdist_wheel]
-universal=1
-
 [tool:pytest]
 testpaths = tests


### PR DESCRIPTION
Python 2 is no longer supported, so the wheels are no longer universal.