### PR TITLE
Use isort's "black" profile

### DIFF
--- a/channels/apps.py
+++ b/channels/apps.py
@@ -1,9 +1,8 @@
-from django.apps import AppConfig
-
 # We import this here to ensure the reactor is installed very early on
 # in case other packages accidentally import twisted.internet.reactor
 # (e.g. raven does this).
 import daphne.server
+from django.apps import AppConfig
 
 assert daphne.server  # pyflakes doesn't support ignores
 

--- a/channels/db.py
+++ b/channels/db.py
@@ -1,6 +1,5 @@
-from django.db import close_old_connections
-
 from asgiref.sync import SyncToAsync
+from django.db import close_old_connections
 
 
 class DatabaseSyncToAsync(SyncToAsync):

--- a/channels/http.py
+++ b/channels/http.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import traceback
 
+from asgiref.sync import async_to_sync, sync_to_async
 from django import http
 from django.conf import settings
 from django.core import signals
@@ -14,7 +15,6 @@ from django.http import FileResponse, HttpResponse, HttpResponseServerError
 from django.urls import set_script_prefix
 from django.utils.functional import cached_property
 
-from asgiref.sync import async_to_sync, sync_to_async
 from channels.exceptions import RequestAborted, RequestTimeout
 
 logger = logging.getLogger("django.request")

--- a/channels/management/commands/runserver.py
+++ b/channels/management/commands/runserver.py
@@ -2,6 +2,8 @@ import datetime
 import logging
 import sys
 
+from daphne.endpoints import build_endpoint_description_strings
+from daphne.server import Server
 from django.apps import apps
 from django.conf import settings
 from django.core.management import CommandError
@@ -9,8 +11,6 @@ from django.core.management.commands.runserver import Command as RunserverComman
 
 from channels import __version__
 from channels.routing import get_default_application
-from daphne.endpoints import build_endpoint_description_strings
-from daphne.server import Server
 
 from ...staticfiles import StaticFilesWrapper
 

--- a/channels/testing/live.py
+++ b/channels/testing/live.py
@@ -1,3 +1,4 @@
+from daphne.testing import DaphneProcess
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connections
 from django.test.testcases import TransactionTestCase
@@ -5,7 +6,6 @@ from django.test.utils import modify_settings
 
 from channels.routing import get_default_application
 from channels.staticfiles import StaticFilesWrapper
-from daphne.testing import DaphneProcess
 
 
 class ChannelsLiveServerTestCase(TransactionTestCase):

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,13 +4,7 @@ max-line-length = 88
 extend-ignore = E203, W503
 
 [isort]
-include_trailing_comma = True
-known_third_party = django
-known_first_party = channels,daphne,asgiref
-multi_line_output = 3
-line_length = 88
-force_grid_wrap=0
-use_parentheses=True
+profile = black
 
 [tool:pytest]
 testpaths = tests

--- a/tests/security/test_auth.py
+++ b/tests/security/test_auth.py
@@ -2,6 +2,7 @@ from importlib import import_module
 from unittest import mock
 
 import pytest
+from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.contrib.auth import (
     BACKEND_SESSION_KEY,
@@ -13,7 +14,6 @@ from django.contrib.auth import (
 )
 from django.contrib.auth.models import AnonymousUser
 
-from asgiref.sync import sync_to_async
 from channels.auth import AuthMiddleware, get_user, login, logout
 from channels.db import database_sync_to_async
 from channels.generic.websocket import WebsocketConsumer

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -4,11 +4,11 @@ from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 import pytest
+from asgiref.testing import ApplicationCommunicator
 from django.core.exceptions import RequestDataTooBig
 from django.http import HttpResponse, RawPostDataException
 from django.test import override_settings
 
-from asgiref.testing import ApplicationCommunicator
 from channels.consumer import AsyncConsumer
 from channels.db import database_sync_to_async
 from channels.http import AsgiHandler, AsgiRequest


### PR DESCRIPTION
isort 5 added built-in configuration profiles: https://pycqa.github.io/isort/docs/configuration/profiles/ . The "black" format is compatible with the [black formatter](https://github.com/psf/black) and avoids customization.