### PR TITLE
Add GitHub Code of Conduct and Security Policy files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+This project follows [Django's Code of Conduct](https://www.djangoproject.com/conduct/).

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,3 @@
+# Django Security Policies
+
+Please see https://www.djangoproject.com/security/.


### PR DESCRIPTION
These appear in the GitHub UI as per [their documentation](https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file).