### PR TITLE
Cache dependencies (pip)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v2
+        name: Configure pip caching
+        with:
+          path: ~/.cache/pip
+          key:${{ env.pythonLocation}}-${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
+          restore-keys: |
+            ${{ env.pythonLocation}}-${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools tox
@@ -42,6 +49,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+      - uses: actions/cache@v2
+        name: Configure pip caching
+        with:
+          path: ~/.cache/pip
+          key: ${{ env.pythonLocation}}-${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
+          restore-keys: |
+            ${{ env.pythonLocation}}-${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         name: Configure pip caching
         with:
           path: ~/.cache/pip
-          key:${{ env.pythonLocation}}-${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
+          key: ${{ env.pythonLocation}}-${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
           restore-keys: |
             ${{ env.pythonLocation}}-${{ runner.os }}-pip-
       - name: Install dependencies


### PR DESCRIPTION
Added cache for pip. As we're using tox, I suspect this will only give a small benefit as the environments will still need to be re-created. 

I added `${{ env.pythonLocation}}-` to the hash. This is intended to get the python version, and so when a small release is issued the cache gets reset. 