### PR TITLE
Cache tox

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v2
+        name: Configure pip caching
+        with:
+          path: ~/.cache/pip
+          key:${{ env.pythonLocation}}-${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
+          restore-keys: |
+            ${{ env.pythonLocation}}-${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools tox
@@ -42,6 +49,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+      - uses: actions/cache@v2
+        name: Configure pip caching
+        with:
+          path: ~/.cache/pip
+          key: ${{ env.pythonLocation}}-${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
+          restore-keys: |
+            ${{ env.pythonLocation}}-${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,9 @@ jobs:
       - uses: actions/cache@v2
         name: Configure pip caching
         with:
-          path: ~/.cache/pip
+          path: |
+            ~/.cache/pip
+            .tox
           key: ${{ env.pythonLocation}}-${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
           restore-keys: |
             ${{ env.pythonLocation}}-${{ runner.os }}-pip-
@@ -52,7 +54,9 @@ jobs:
       - uses: actions/cache@v2
         name: Configure pip caching
         with:
-          path: ~/.cache/pip
+          path: |
+            ~/.cache/pip
+            .tox
           key: ${{ env.pythonLocation}}-${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
           restore-keys: |
             ${{ env.pythonLocation}}-${{ runner.os }}-pip-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
           path: |
             ~/.cache/pip
             .tox
-          key: ${{ env.pythonLocation}}-${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
+          key: ${{ env.pythonLocation}}-${{ runner.os }}-pip-${{ hashFiles('**setup.py', '**/tox.ini') }}
           restore-keys: |
             ${{ env.pythonLocation}}-${{ runner.os }}-pip-
       - name: Install dependencies
@@ -56,7 +56,6 @@ jobs:
         with:
           path: |
             ~/.cache/pip
-            .tox
           key: ${{ env.pythonLocation}}-${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
           restore-keys: |
             ${{ env.pythonLocation}}-${{ runner.os }}-pip-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         name: Configure pip caching
         with:
           path: ~/.cache/pip
-          key:${{ env.pythonLocation}}-${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
+          key: ${{ env.pythonLocation}}-${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
           restore-keys: |
             ${{ env.pythonLocation}}-${{ runner.os }}-pip-
       - name: Install dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
 usedevelop = true
 extras = tests
 commands =
+    pip install --upgrade --upgrade-strategy eager -e .[tests] --use-feature=2020-resolver
     pytest -v {posargs}
 deps =
     dj22: Django~=2.2.8


### PR DESCRIPTION
If the cache of pip is merged then this could also be considered but needs a much closer look 🔍 .

This idea here is to cache the tox environments as well, and I'd therefore expect a much more significant speedup of the tests. 

This bit I'm not certain about is what happens when a new version gets released, but is a general tox question. If tox.ini doesn't change, but there is a new release of dependency, does this get updated? I think the answer to this is "yes" as it's not any different to running against "djmaster" where you'd want an update each time...

Anyway, let's see what the github action logs have got to say about it. 
