### PR TITLE
skip_install on qa

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     djmaster: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:qa]
+skip_install=true
 deps =
     black
     flake8


### PR DESCRIPTION
Ok -- here is a slightly easier change. 

I don't think we need to install the package (and therefore all the dependencies) to run black et al? 

EDIT: 
Pre = [68 seconds](https://github.com/django/channels/runs/1282795278?check_suite_focus=true)
Post = [36 seconds](https://github.com/django/channels/runs/1283181213?check_suite_focus=true)