### PR TITLE
Added as_asgi() consumer classmethod.

### DIFF
--- a/channels/consumer.py
+++ b/channels/consumer.py
@@ -80,6 +80,26 @@ class AsyncConsumer:
         """
         await self.base_send(message)
 
+    @classmethod
+    def as_asgi(cls, **initkwargs):
+        """
+        Return an ASGI v3 single callable that instantiates a consumer instance
+        per scope. Similar in purpose to Django's as_view().
+
+        initkwargs will be used to instantiate the consumer instance.
+        """
+
+        async def app(scope, receive, send):
+            consumer = cls(**initkwargs)
+            return await consumer(scope, receive, send)
+
+        app.consumer_class = cls
+        app.consumer_initkwargs = initkwargs
+
+        # take name and docstring from class
+        functools.update_wrapper(app, cls, updated=())
+        return app
+
 
 class SyncConsumer(AsyncConsumer):
     """

--- a/docs/releases/3.0.0.rst
+++ b/docs/releases/3.0.0.rst
@@ -1,27 +1,35 @@
 3.0.0 Release Notes
 ===================
 
-TODO
+Update to ASGI 3
+----------------
 
-* Update to ASGI v3: update init and call **if you implemented** these yourself.
+* Consumers are *single-callables*, taking the scope at the beginning of the
+  request. You'll need to update init and call **if you implemented** these yourself.
   (Otherwise you should be good.)
 
-  * Means you need to instantiate your consumers when setting up your routing::
+* Consumers now have an ``as_asgi()`` class method you need to call when
+  setting up your routing::
 
-      websocket_urlpatterns = [
-        re_path(r'ws/chat/(?P<room_name>\w+)/$', consumers.ChatConsumer()),
-      ]
+    websocket_urlpatterns = [
+      re_path(r'ws/chat/(?P<room_name>\w+)/$', consumers.ChatConsumer.as_asgi()),
+    ]
 
-    Consumers are *single-callables*, taking the scope at the beginning of the
-    request.
+  This returns an ASGI application that will instantiate the consumer per-request.
+
+  It's similar to Django's ``as_view()``, which serves the same purpose. You
+  can pass ``initkwargs`` if your consumer requires them.
+
+* Middleware will also need to be updated to ASGI v3 signature.
+
+Other Bits
+----------
 
 * Built-in `AsgiHandler` is deprecated. Update to Django 3.0+ and use its version.
 
 * Explicitly specify `"http"` in ProtocolTypeRouter. (Deprecate auto usage.)
 
 * Update your `routing.py` to an `asgi.py`
-
-* What else breaks? Anything?
 
 * Dropped Python 3.5
 

--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -238,14 +238,19 @@ Put the following code in ``chat/routing.py``:
     from . import consumers
 
     websocket_urlpatterns = [
-        re_path(r'ws/chat/(?P<room_name>\w+)/$', consumers.ChatConsumer()),
+        re_path(r'ws/chat/(?P<room_name>\w+)/$', consumers.ChatConsumer.as_asgi()),
     ]
+
+We call the ``as_asgi()`` classmethod in order to get an ASGI application that
+will instantiate an instance of our consumer for each user-connection. This is
+similar to Django's ``as_view()``, which plays the same role for per-request
+Django view instances.
 
 (Note we use ``re_path()`` due to limitations in :ref:`URLRouter <urlrouter>`.)
 
-The next step is to point the root routing configuration at the **chat.routing**
-module. In ``mysite/asgi.py``, import ``AuthMiddlewareStack``, ``URLRouter``,
-and ``chat.routing``; and insert a ``'websocket'`` key in the
+The next step is to point the root routing configuration at the
+**chat.routing** module. In ``mysite/asgi.py``, import ``AuthMiddlewareStack``,
+``URLRouter``, and ``chat.routing``; and insert a ``'websocket'`` key in the
 ``ProtocolTypeRouter`` list in the following format:
 
 .. code-block:: python

--- a/tests/test_generic_http.py
+++ b/tests/test_generic_http.py
@@ -34,3 +34,33 @@ async def test_async_http_consumer():
     assert response["body"] == b'{"value": 42}'
     assert response["status"] == 200
     assert response["headers"] == [(b"Content-Type", b"application/json")]
+
+
+@pytest.mark.asyncio
+async def test_per_scope_consumers():
+    """
+    Tests that a distinct consumer is used per scope, with AsyncHttpConsumer as
+    the example consumer class.
+    """
+
+    class TestConsumer(AsyncHttpConsumer):
+        async def handle(self, body):
+            await self.send_response(
+                200,
+                repr(self).encode("utf-8"),
+                headers={b"Content-Type": b"text/plain"},
+            )
+
+    app = TestConsumer.as_asgi()
+
+    # Open a connection
+    communicator = HttpCommunicator(app, method="GET", path="/test/")
+    response = await communicator.get_response()
+    assert response["status"] == 200
+
+    # And another one.
+    communicator = HttpCommunicator(app, method="GET", path="/test2/")
+    second_response = await communicator.get_response()
+    assert second_response["status"] == 200
+
+    assert response["body"] != second_response["body"]


### PR DESCRIPTION
To be used when routing a consumer.
Returns an ASGI v3 single callable that will instantiate the consumer per-scope.
Closes #1531.

Docs for this to follow. 