### PR TITLE
Updated CI Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Django Channels
 ===============
 
-.. image:: https://api.travis-ci.org/django/channels.svg
-    :target: https://travis-ci.org/django/channels
+.. image:: https://github.com/django/channels/workflows/Tests/badge.svg
+    :target: https://github.com/django/channels/actions
 
 .. image:: https://readthedocs.org/projects/channels/badge/?version=latest
     :target: https://channels.readthedocs.io/en/latest/?badge=latest

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Django Channels
 ===============
 
-.. image:: https://github.com/django/channels/workflows/Tests/badge.svg
+.. image:: https://github.com/django/channels/workflows/Tests/badge.svg?branch=master
     :target: https://github.com/django/channels/actions
 
 .. image:: https://readthedocs.org/projects/channels/badge/?version=latest


### PR DESCRIPTION
Closes #1529 

This PR updates the tests "badge" to refer to GHActions rather than Travis CI. 

Relevant docs are here -- I've tried to pin it on the 'master' branch only. So if a PR is opened and fails, it doesn't reflect on the badge on the readme.

https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/adding-a-workflow-status-badge