### PR TITLE
Add daphne as optional requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,9 @@ setup(
     install_requires=[
         'Django>=2.2',
         'asgiref>=3.2.10,<4',
-        'daphne>=3.0,<4',
     ],
     extras_require={
+        'daphne': ['daphne>=3.0,<4'],
         'tests': [
             "pytest",
             "pytest-django",


### PR DESCRIPTION
Since Daphne is not really needed to run channels and other ASGI servers can be used.
We can reduce dependencies on projects that does not use daphne.