### PR TITLE
Relax consumer_callable requirements

### DIFF
--- a/channels/utils.py
+++ b/channels/utils.py
@@ -35,9 +35,8 @@ async def await_many_dispatch(consumer_callables, dispatch):
     from them to the dispatch awaitable as they come in.
     """
     # Start them all off as tasks
-    loop = asyncio.get_event_loop()
     tasks = [
-        loop.create_task(consumer_callable())
+        asyncio.ensure_future(consumer_callable())
         for consumer_callable in consumer_callables
     ]
     try:


### PR DESCRIPTION
According to [ASGI specification](https://asgi.readthedocs.io/en/latest/specs/main.html#applications), both `receive` and `send` should be _an awaitable callable_, where as [`create_task()`](https://docs.python.org/3/library/asyncio-eventloop.html#creating-futures-and-tasks), accept only _coroutine_.

[NGINX Unit](http://unit.nginx.org/) ASGI server implementation, provides `receive` and `send` callable which returns `Future`, which in turns is _awaitable_ and can be used just as a `Task`.

Using `ensure_future()` instead of `create_task()` is a simple way to create `Task` for coroutines and use `Future` if it is already provided.