### PR TITLE
Don't treat synchronous Django views as thread-sensitive

### DIFF
--- a/channels/http.py
+++ b/channels/http.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import traceback
 import warnings
+from functools import partial
 
 from asgiref.sync import async_to_sync, sync_to_async
 from django import http
@@ -219,7 +220,7 @@ class AsgiHandler(base.BaseHandler):
         body_file.seek(0)
         return body_file
 
-    @sync_to_async
+    @partial(sync_to_async, thread_sensitive=False)
     def handle(self, body):
         """
         Synchronous message processing.


### PR DESCRIPTION
See https://github.com/django/asgiref/issues/218 for background.

This seems like a big deal to me - serving sync Django views with Channels is now unavoidably single-threaded, but in an even worse way than using regular sync workers without any threading because it messes up app-server level queuing.

I've made a simple Django project to demonstrate the problem at https://github.com/AlexHill/django_channels_test. This has a single view that calls `time.sleep()` with a parametrised delay before returning. There's a test script which hits that view requesting delays of `random.random()**2` seconds. The RNG is seeded so that successive runs are comparable.

Clone that, then `make env` to create the venv and `make asgi-threads` to start the application server with 4 workers and `ASGI_THREADS=4`. Then run `env/bin/python load_test.py 20 500` to hit it with 500 requests with 20 in-flight at a time.

Gunicorn/uvicorn/channels with `thread_sensitive=False`:
```
Elapsed:  17.17314076423645
Mean:     0.645045076
Median:   0.5966104999999999
Stddev:   0.4770741149910055
Variance: 0.22759971119445113
```

Gunicorn/uvicorn/channels with `thread_sensitive=True`:
```
Elapsed:  69.84854912757874
Mean:     2.691243674
Median:   1.9076985
Stddev:   2.3167855889750446
Variance: 5.3674954652824445
```

Gunicorn/wsgi with threads=1:
```
Elapsed:  44.140148639678955
Mean:     1.724540176
Median:   1.7028249999999998
Stddev:   0.47959156485083554
Variance: 0.23000806907607318
```

Channels underperforms single-threaded sync workers because gunicorn can't do any useful load balancing between its workers, since the async server in each process `accepts` connections as fast as it can. That's a separate issue, but makes this issue worse in practise. This test has a maximum request time of 1s; the slower your outliers, the worse this problem gets.

So my question is - are synchronous Django views actually any more thread-sensitive under Channels than they are under a normal sync threaded application server? My instinct is that given that the default `thread_sensitive` in `asgiref` is now `True`, any code explicitly decorated with `@sync_to_async` within the request-response cycle will run on the same thread as the request as intended, but that between two requests there should be nothing that causes additional problems beyond the ones already well-understood when running threaded Django servers - but I don't know much about Channels internals so I'm looking for advice here.