### PR TITLE
Update asgiref dependency to >=3.3.1 (fixes #1613)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     python_requires='>=3.6',
     install_requires=[
         'Django>=2.2',
-        'asgiref>=3.2.10,<4',
+        'asgiref>=3.3.1,<4',
         'daphne>=3.0,<4',
     ],
     extras_require={


### PR DESCRIPTION
Update asgiref dependency to require at least version 3.3.1 which fixes crashing of background workers, as discussed in #1613.