### PR TITLE
Adjusted tox config for Django 3.2 beta.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    py{36,37,38,39}-dj{22,30,31,master}
+    py{36,37,38,39}-dj{22,30,31,32}
+    py{38,39}-djmaster
     qa
 
 [testenv]
@@ -12,6 +13,7 @@ deps =
     dj22: Django~=2.2.8
     dj30: Django==3.0.*
     dj31: Django>=3.1,<3.2
+    dj32: Django>=3.2b1,<4.0
     djmaster: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:qa]


### PR DESCRIPTION
* Added 3.2 beta (and greater). 
* Dropped PY36 and PY37 against Django main development branch.