### PR TITLE
Rewording of deployment instructions

### DIFF
--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -25,9 +25,9 @@ Here's an example of what that ``asgi.py`` might look like:
     from django.conf.urls import url
     from django.core.asgi import get_asgi_application
 
-    # Fetch Django ASGI application early to ensure AppRegistry is populated
-    # before importing consumers and AuthMiddlewareStack that may import ORM
-    # models. 
+    # Fetch Django ASGI application early to ensure Django settings are 
+    # configured and the AppRegistry is populated before importing consumers
+    # and AuthMiddlewareStack that may use ORM models or the settings.
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mysite.settings")
     django_asgi_app = get_asgi_application()
     

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'tests': [
             "pytest",
             "pytest-django",
-            "pytest-asyncio",
+            "pytest-asyncio==0.14.0",
             "async_generator",
             "async-timeout",
             "coverage~=4.5",


### PR DESCRIPTION
Without clear explanation, it may seem like you can call
`get_asgi_application()`
anywhere within this file, like you would with any other function,

It should be specifically pointed out that this must happen at the top of the page before any other imports.

A common example would be somebody who tries to do this:

```
application = ProtocolTypeRouter({
    # Django's ASGI application to handle traditional HTTP requests
    "http": get_asgi_application(),
})
```