### PR TITLE
Removed async_generator dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
             "pytest",
             "pytest-django",
             "pytest-asyncio==0.14.0",
-            "async_generator",
             "async-timeout",
             "coverage~=4.5",
         ],

--- a/tests/test_inmemorychannel.py
+++ b/tests/test_inmemorychannel.py
@@ -2,20 +2,18 @@ import asyncio
 
 import async_timeout
 import pytest
-from async_generator import async_generator, yield_
 
 from channels.exceptions import ChannelFull
 from channels.layers import InMemoryChannelLayer
 
 
 @pytest.fixture()
-@async_generator
 async def channel_layer():
     """
     Channel layer fixture that flushes automatically.
     """
     channel_layer = InMemoryChannelLayer(capacity=3)
-    await yield_(channel_layer)
+    yield channel_layer
     await channel_layer.flush()
     await channel_layer.close()
 


### PR DESCRIPTION
I think we can remove this dependency now that only Python 3.6+ is supported?