### PR TITLE
Update authentication.rst

### DIFF
--- a/docs/topics/authentication.rst
+++ b/docs/topics/authentication.rst
@@ -17,15 +17,21 @@ to a user object in the ``scope``.
 ``AuthMiddleware`` requires ``SessionMiddleware`` to function, which itself
 requires ``CookieMiddleware``. For convenience, these are also provided
 as a combined callable called ``AuthMiddlewareStack`` that includes all three.
+You have to setup django before importing ``AuthMiddlewareStack`` or ``AuthMiddleware``.
 
 To use the middleware, wrap it around the appropriate level of consumer
 in your ``asgi.py``:
 
 .. code-block:: python
 
+    import django
     from django.urls import re_path
 
     from channels.routing import ProtocolTypeRouter, URLRouter
+
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mysite.settings')
+    django.setup()
+    
     from channels.auth import AuthMiddlewareStack
 
     from myapp import consumers


### PR DESCRIPTION
While running ASGI application with ``daphne`` on Django 3.x, I ran to this error:
```
ImproperlyConfigured(
django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
```
After that I figured out that we should setup django before importing session and authentication middlewares.
To solve this problem we can call ``django.setup()`` or ``get_asgi_application()`` before importing those middlewares.