### PR TITLE
postpone model import in `channels.auth` to avoid ImproperlyConfigured error

### DIFF
--- a/channels/auth.py
+++ b/channels/auth.py
@@ -9,7 +9,6 @@ from django.contrib.auth import (
     user_logged_in,
     user_logged_out,
 )
-from django.contrib.auth.models import AnonymousUser
 from django.utils.crypto import constant_time_compare
 from django.utils.functional import LazyObject
 
@@ -24,6 +23,9 @@ def get_user(scope):
     Return the user model instance associated with the given scope.
     If no user is retrieved, return an instance of `AnonymousUser`.
     """
+    # postpone model import to avoid ImproperlyConfigured error before Django setup is complete.
+    from django.contrib.auth.models import AnonymousUser
+
     if "session" not in scope:
         raise ValueError(
             "Cannot find session in scope. You should wrap your consumer in "
@@ -112,6 +114,9 @@ def logout(scope):
     """
     Remove the authenticated user's ID from the request and flush their session data.
     """
+    # postpone model import to avoid ImproperlyConfigured error before Django setup is complete.
+    from django.contrib.auth.models import AnonymousUser
+
     if "session" not in scope:
         raise ValueError(
             "Login cannot find session in scope. You should wrap your "

--- a/docs/asgi.rst
+++ b/docs/asgi.rst
@@ -48,7 +48,7 @@ Composability
 
 ASGI applications, like WSGI ones, are designed to be composable, and this
 includes Channels' routing and middleware components like ``ProtocolTypeRouter``
-and ``SessionMiddeware``. These are just ASGI applications that take other
+and ``SessionMiddleware``. These are just ASGI applications that take other
 ASGI applications as arguments, so you can pass around just one top-level
 application for a whole Django project and dispatch down to the right consumer
 based on what sort of connection you're handling.

--- a/docs/channel_layer_spec.rst
+++ b/docs/channel_layer_spec.rst
@@ -301,7 +301,7 @@ limitation that they only use the following characters:
 * Hyphen ``-``
 * Underscore ``_``
 * Period ``.``
-* Question mark ``?`` (only to delineiate single-reader channel names,
+* Question mark ``?`` (only to delineate single-reader channel names,
   and only one per name)
 * Exclamation mark ``!`` (only to delineate process-specific channel names,
   and only one per name)

--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -22,17 +22,15 @@ Here's an example of what that ``asgi.py`` might look like:
 
     import os
 
+    from channels.auth import AuthMiddlewareStack
+    from channels.routing import ProtocolTypeRouter, URLRouter
     from django.conf.urls import url
     from django.core.asgi import get_asgi_application
 
-    # Fetch Django ASGI application early to ensure Django settings are 
-    # configured and the AppRegistry is populated before importing consumers
-    # and AuthMiddlewareStack that may use ORM models or the settings.
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mysite.settings")
+    # Initialize Django ASGI application early to ensure the AppRegistry
+    # is populated before importing code that may import ORM models.
     django_asgi_app = get_asgi_application()
-    
-    from channels.auth import AuthMiddlewareStack
-    from channels.routing import ProtocolTypeRouter, URLRouter
 
     from chat.consumers import AdminChatConsumer, PublicChatConsumer
 

--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -18,34 +18,8 @@ is almost certainly going to be your top-level (Protocol Type) router.
 
 Here's an example of what that ``asgi.py`` might look like:
 
-.. code-block:: python
+.. include:: ./includes/asgi_example.rst
 
-    import os
-
-    from channels.auth import AuthMiddlewareStack
-    from channels.routing import ProtocolTypeRouter, URLRouter
-    from django.conf.urls import url
-    from django.core.asgi import get_asgi_application
-
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mysite.settings")
-    # Initialize Django ASGI application early to ensure the AppRegistry
-    # is populated before importing code that may import ORM models.
-    django_asgi_app = get_asgi_application()
-
-    from chat.consumers import AdminChatConsumer, PublicChatConsumer
-
-    application = ProtocolTypeRouter({
-        # Django's ASGI application to handle traditional HTTP requests
-        "http": django_asgi_app,
-
-        # WebSocket chat handler
-        "websocket": AuthMiddlewareStack(
-            URLRouter([
-                url(r"^chat/admin/$", AdminChatConsumer.as_asgi()),
-                url(r"^chat/$", PublicChatConsumer.as_asgi()),
-            ])
-        ),
-    })
 
 Setting up a channel backend
 ----------------------------

--- a/docs/includes/asgi_example.rst
+++ b/docs/includes/asgi_example.rst
@@ -1,0 +1,28 @@
+.. code-block:: python
+
+    import os
+
+    from channels.auth import AuthMiddlewareStack
+    from channels.routing import ProtocolTypeRouter, URLRouter
+    from django.conf.urls import url
+    from django.core.asgi import get_asgi_application
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mysite.settings")
+    # Initialize Django ASGI application early to ensure the AppRegistry
+    # is populated before importing code that may import ORM models.
+    django_asgi_app = get_asgi_application()
+
+    from chat.consumers import AdminChatConsumer, PublicChatConsumer
+
+    application = ProtocolTypeRouter({
+        # Django's ASGI application to handle traditional HTTP requests
+        "http": django_asgi_app,
+
+        # WebSocket chat handler
+        "websocket": AuthMiddlewareStack(
+            URLRouter([
+                url(r"^chat/admin/$", AdminChatConsumer.as_asgi()),
+                url(r"^chat/$", PublicChatConsumer.as_asgi()),
+            ])
+        ),
+    })

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ Topics
    topics/testing
    topics/worker
    deploying
+   topics/troubleshooting
 
 
 Reference

--- a/docs/releases/2.3.0.rst
+++ b/docs/releases/2.3.0.rst
@@ -14,7 +14,7 @@ Backwards Incompatible Changes
 ------------------------------
 
 As a result of the reworked body handling, ``AsgiRequest.__init__()`` is
-adjusted to expecte a file-like ``stream``, rather than the whole ``body`` as
+adjusted to expect a file-like ``stream``, rather than the whole ``body`` as
 bytes.
 
 Test cases instantiating requests directly will likely need to be updated to

--- a/docs/topics/routing.rst
+++ b/docs/topics/routing.rst
@@ -30,34 +30,8 @@ Channels projects and settings in :doc:`/deploying`.
 
 Here's an example of what that ``asgi.py`` might look like:
 
-.. code-block:: python
+.. include:: ../includes/asgi_example.rst
 
-    import os
-
-    from channels.auth import AuthMiddlewareStack
-    from channels.routing import ProtocolTypeRouter, URLRouter
-    from django.conf.urls import url
-    from django.core.asgi import get_asgi_application
-
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mysite.settings")
-    # Initialize Django ASGI application early to ensure the AppRegistry
-    # is populated before importing code that may import ORM models.
-    django_asgi_app = get_asgi_application()
-
-    from chat.consumers import AdminChatConsumer, PublicChatConsumer
-
-    application = ProtocolTypeRouter({
-        # Django's ASGI application to handle traditional HTTP requests
-        "http": django_asgi_app,
-
-        # WebSocket chat handler
-        "websocket": AuthMiddlewareStack(
-            URLRouter([
-                url(r"^chat/admin/$", AdminChatConsumer.as_asgi()),
-                url(r"^chat/$", PublicChatConsumer.as_asgi()),
-            ])
-        ),
-    })
 
 .. note::
   We call the ``as_asgi()`` classmethod when routing our consumers. This

--- a/docs/topics/routing.rst
+++ b/docs/topics/routing.rst
@@ -39,13 +39,16 @@ Here's an example of what that ``asgi.py`` might look like:
     from django.conf.urls import url
     from django.core.asgi import get_asgi_application
 
-    from chat.consumers import AdminChatConsumer, PublicChatConsumer
-
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mysite.settings")
+    # Initialize Django ASGI application early to ensure the AppRegistry
+    # is populated before importing code that may import ORM models.
+    django_asgi_app = get_asgi_application()
+
+    from chat.consumers import AdminChatConsumer, PublicChatConsumer
 
     application = ProtocolTypeRouter({
         # Django's ASGI application to handle traditional HTTP requests
-        "http": get_asgi_application(),
+        "http": django_asgi_app,
 
         # WebSocket chat handler
         "websocket": AuthMiddlewareStack(

--- a/docs/topics/troubleshooting.rst
+++ b/docs/topics/troubleshooting.rst
@@ -24,20 +24,4 @@ which means it needs to be called before any ORM models are imported.
 
 The working code order would look like this:
 
-.. code-block:: python
-
-    from channels.routing import ProtocolTypeRouter, URLRouter
-    from django.core.asgi import get_asgi_application
-    # Initialize Django ASGI application early to ensure the AppRegistry
-    # is populated before importing code that may import ORM models.
-    django_asgi_app = get_asgi_application()
-
-    # custom code may cause ORM models import
-    from myapp.routing import websocket_urlpatterns
-
-    application = ProtocolTypeRouter(
-        {
-            "http": django_asgi_app,
-            "websocket": AuthMiddlewareStack(URLRouter(websocket_urlpatterns)),
-        }
-    )
+.. include:: ../includes/asgi_example.rst

--- a/docs/topics/troubleshooting.rst
+++ b/docs/topics/troubleshooting.rst
@@ -1,0 +1,43 @@
+Troubleshooting
+===============
+
+
+
+ImproperlyConfigured exception
+------------------------------
+
+
+.. code-block:: text
+
+    django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured.
+    You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
+
+
+This exception occurs when your application tries to import any models before Django finishes
+`its initialization process <https://docs.djangoproject.com/en/3.2/ref/applications/#initialization-process>`_ aka ``django.setup()``.
+
+
+``django.setup()`` `should be called only once <https://docs.djangoproject.com/en/3.2/topics/settings/#calling-django-setup-is-required-for-standalone-django-usage>`_,
+and should be called manually only in case of standalone apps.
+In context of Channels usage, ``django.setup()`` is called automatically in ``get_asgi_application()``,
+which means it needs to be called before any ORM models are imported.
+
+The working code order would look like this:
+
+.. code-block:: python
+
+    from channels.routing import ProtocolTypeRouter, URLRouter
+    from django.core.asgi import get_asgi_application
+    # Initialize Django ASGI application early to ensure the AppRegistry
+    # is populated before importing code that may import ORM models.
+    django_asgi_app = get_asgi_application()
+
+    # custom code may cause ORM models import
+    from myapp.routing import websocket_urlpatterns
+
+    application = ProtocolTypeRouter(
+        {
+            "http": django_asgi_app,
+            "websocket": AuthMiddlewareStack(URLRouter(websocket_urlpatterns)),
+        }
+    )

--- a/docs/tutorial/part_1.rst
+++ b/docs/tutorial/part_1.rst
@@ -1,6 +1,10 @@
 Tutorial Part 1: Basic Setup
 ============================
 
+.. note::
+    If you encounter any issue during your coding session, please see the :doc:`/topics/troubleshooting` section.
+
+
 In this tutorial we will build a simple chat server. It will have two pages:
 
 * An index view that lets you type the name of a chat room to join.


### PR DESCRIPTION
Hi,
the import of `channels.auth` is triggering import of `AnonymousUser` model, which should not happen before ASGI app is ready. Doing so raises `ImproperlyConfigured` exception which might be tricky for newcomers to solve (see numerous Issues and a few MR trying to pinpoint this in docs, eg. #1681, #1691)

To make it work, some code needs to be mixed among imports (`django.setup()` or `get_asgi_application()`), which does not look nice.

Postponing the model import can solve the most common culprit of this error.