### PR TITLE
WIP: docs: add troubleshooting section

### DIFF
--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -25,9 +25,9 @@ Here's an example of what that ``asgi.py`` might look like:
     from django.conf.urls import url
     from django.core.asgi import get_asgi_application
 
-    # Fetch Django ASGI application early to ensure Django settings are 
-    # configured and the AppRegistry is populated before importing consumers
-    # and AuthMiddlewareStack that may use ORM models or the settings.
+    # Initialize Django ASGI application early to ensure the AppRegistry
+    # is populated before importing consumers and AuthMiddlewareStack that
+    # may import ORM models.
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mysite.settings")
     django_asgi_app = get_asgi_application()
     

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ Topics
    topics/testing
    topics/worker
    deploying
+   topics/troubleshooting
 
 
 Reference

--- a/docs/topics/troubleshooting.rst
+++ b/docs/topics/troubleshooting.rst
@@ -1,0 +1,43 @@
+Troubleshooting
+===============
+
+
+
+ImproperlyConfigured exception
+------------------------------
+
+
+.. code-block:: text
+
+    django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured.
+    You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
+
+
+This exception occurs when your application tries to import any models before Django finishes
+`its initialization process <https://docs.djangoproject.com/en/3.2/ref/applications/#initialization-process>`_ aka ``django.setup()``.
+
+
+``django.setup()`` `should be called only once <https://docs.djangoproject.com/en/3.2/topics/settings/#calling-django-setup-is-required-for-standalone-django-usage>`_, and should be called manually only in case of standalone apps.
+In context of Channels usage, ``django.setup()`` is called automatically in ``get_asgi_application()``,
+which means it needs to be called before any models are imported.
+
+
+The most common culprit of models import is ``channels.auth`` (eg. ``AuthMiddlewareStack``, ``AuthMiddleware``) importing ``AnonymousUser``.
+The working code order would look like this:
+
+
+.. code-block:: python
+
+    from django.core.asgi import get_asgi_application
+    django_asgi_app = get_asgi_application() # needs to be called before models import
+
+    from channels.auth import AuthMiddlewareStack # triggers models import
+    from channels.routing import ProtocolTypeRouter, URLRouter
+    from myapp.routing import websocket_urlpatterns
+
+    application = ProtocolTypeRouter(
+        {
+            "http": django_asgi_app,
+            "websocket": AuthMiddlewareStack(URLRouter(websocket_urlpatterns)),
+        }
+    )

--- a/docs/tutorial/part_1.rst
+++ b/docs/tutorial/part_1.rst
@@ -1,6 +1,10 @@
 Tutorial Part 1: Basic Setup
 ============================
 
+.. note::
+    If you encounter any issue during your coding session, please see the :doc:`/topics/troubleshooting` section.
+
+
 In this tutorial we will build a simple chat server. It will have two pages:
 
 * An index view that lets you type the name of a chat room to join.


### PR DESCRIPTION
the `ImproperlyConfigured` exception seems like a quite common error nowadays, so having it mentioned explicitly somewhere in docs might be helpful.

Having the Troubleshooting section won't magically bring attention to it, so mentioning it somewhere explicitly might help too. Tutorial looks like a starting point for everyone, thus referring it right there could be the right place.

Wording might need to be changed in case #1692 will be accepted and merged.