### PR TITLE
change 'type' property to match chat_message method

### DIFF
--- a/docs/topics/channel_layers.rst
+++ b/docs/topics/channel_layers.rst
@@ -112,7 +112,7 @@ layer:
     await self.channel_layer.group_send(
         room.group_name,
         {
-            "type": "chat.message",
+            "type": "chat_message",
             "room_id": room_id,
             "username": self.scope["user"].username,
             "message": message,


### PR DESCRIPTION
I noticed that the `channel_layer.group_send()` method was sending a message with property:

`
{
    "type": "chat.message"
}
`

In the tutorial, it is mentioned that consumers will match event types with their methods. Since the method was named `chat_message()`, I figured the event type should be the same. In fact, this pattern is shown elsewhere too.