### PR TITLE
remove unused `extensions` variable

### DIFF
--- a/channels/layers.py
+++ b/channels/layers.py
@@ -214,8 +214,6 @@ class InMemoryChannelLayer(BaseChannelLayer):
 
     # Channel layer API
 
-    extensions = ["groups", "flush"]
-
     async def send(self, channel, message):
         """
         Send a message onto a (general or specific) channel.


### PR DESCRIPTION
I can't find any usage of this. asgiref docs mentions something like [extensions](https://asgi.readthedocs.io/en/latest/extensions.html), but it seems just like a name coincidence.

if this has just a documentation purpose, it could be done as a comment instead?