### PR TITLE
Fix an error when using  OriginValidator with python 3.8.11

### DIFF
--- a/channels/security/websocket.py
+++ b/channels/security/websocket.py
@@ -95,10 +95,10 @@ class OriginValidator:
             return False
 
         # Get ResultParse object
-        parsed_pattern = urlparse(pattern.lower(), scheme=None)
+        parsed_pattern = urlparse(pattern.lower())
         if parsed_origin.hostname is None:
             return False
-        if parsed_pattern.scheme is None:
+        if not parsed_pattern.scheme:
             pattern_hostname = urlparse("//" + pattern).hostname or pattern
             return is_same_domain(parsed_origin.hostname, pattern_hostname)
         # Get origin.port or default ports for origin or None


### PR DESCRIPTION
Per documentation, scheme should have a str or bytes type
https://docs.python.org/3/library/urllib.parse.html?highlight=urlparse#urllib.parse.urlparse

I have just checked my fix with the provided testcase in the issue #1716.