### PR TITLE
Unpin pytest-asyncio.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'tests': [
             "pytest",
             "pytest-django",
-            "pytest-asyncio==0.14.0",
+            "pytest-asyncio",
             "async-timeout",
             "coverage~=4.5",
         ],


### PR DESCRIPTION
Reverts 1945a9fc286fc0afda1e1371562a743fbe97ccb5.
Issue in 0.15.0 resolved in 0.15.1.
Refs #1682
Refs https://github.com/pytest-dev/pytest-asyncio/issues/209