### PR TITLE
Document support for Django 3.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Dependencies
 ------------
 
 All Channels projects currently support Python 3.6 and up. ``channels`` is
-compatible with Django 2.2, 3.0, and 3.1.
+compatible with Django 2.2, 3.0, 3.1 and 3.2.
 
 
 Contributing


### PR DESCRIPTION
Support for Django 3.2 is already included in tox.ini ( https://github.com/django/channels/blob/main/tox.ini )
The same change might probably need to be applied also to release 3.0.4(given: https://github.com/django/channels/blob/3.0.4/tox.ini )