### PR TITLE
Use isort --check option to match black

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,4 @@ deps =
 commands =
     flake8 channels tests
     black --check channels tests
-    isort --check-only --diff channels tests
+    isort --check --diff channels tests


### PR DESCRIPTION
`isort` has a `--check` command alias that matches `black`: https://pycqa.github.io/isort/docs/configuration/options.html#check