### PR TITLE
Relax consumer_callable requirements with a test

### DIFF
--- a/channels/utils.py
+++ b/channels/utils.py
@@ -34,10 +34,9 @@ async def await_many_dispatch(consumer_callables, dispatch):
     Given a set of consumer callables, awaits on them all and passes results
     from them to the dispatch awaitable as they come in.
     """
-    # Start them all off as tasks
-    loop = asyncio.get_event_loop()
+    # Call all callables, and ensure all return types are Futures
     tasks = [
-        loop.create_task(consumer_callable())
+        asyncio.ensure_future(consumer_callable())
         for consumer_callable in consumer_callables
     ]
     try:


### PR DESCRIPTION
See #1577 - I just added and formatted the suggested test as the first of two commits.

> According to [ASGI specification](https://asgi.readthedocs.io/en/latest/specs/main.html#applications), both receive and send should be an awaitable callable, where as [create_task()](https://docs.python.org/3/library/asyncio-eventloop.html#creating-futures-and-tasks), accept only coroutine.
> 
> [NGINX Unit](http://unit.nginx.org/) ASGI server implementation, provides receive and send callable which returns Future, which in turns is awaitable and can be used just as a Task.
> 
> Using ensure_future() instead of create_task() is a simple way to create Task for coroutines and use Future if it is already provided.