### PR TITLE
Corrected urlparse usage in OriginValidator

### DIFF
--- a/channels/security/websocket.py
+++ b/channels/security/websocket.py
@@ -94,10 +94,10 @@ class OriginValidator:
             return False
 
         # Get ResultParse object
-        parsed_pattern = urlparse(pattern.lower(), scheme=None)
+        parsed_pattern = urlparse(pattern.lower())
         if parsed_origin.hostname is None:
             return False
-        if parsed_pattern.scheme is None:
+        if not parsed_pattern.scheme:
             pattern_hostname = urlparse("//" + pattern).hostname or pattern
             return is_same_domain(parsed_origin.hostname, pattern_hostname)
         # Get origin.port or default ports for origin or None


### PR DESCRIPTION
backport of https://github.com/django/channels/pull/1719 to channels 2