### PR TITLE
Remove the `providing_args` argument from `django.dispatch.Signal` to…

### DIFF
--- a/channels/signals.py
+++ b/channels/signals.py
@@ -1,7 +1,7 @@
 from django.db import close_old_connections
 from django.dispatch import Signal
 
-consumer_started = Signal(providing_args=["environ"])
+consumer_started = Signal()
 consumer_finished = Signal()
 
 # Connect connection closer to consumer finished as well


### PR DESCRIPTION
Remove the `providing_args` argument from `django.dispatch.Signal` to be compatible with Django 4.0.

Quoting the Django doc: _The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring._