### PR TITLE
Dropped support for Python 3.6, Django 3.0 and Django 3.1.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.6"
         - "3.7"
         - "3.8"
         - "3.9"

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Dependencies
 ------------
 
 All Channels projects currently support Python 3.6 and up. ``channels`` is
-compatible with Django 2.2, 3.0, 3.1 and 3.2.
+compatible with Django 2.2 and 3.2.
 
 
 Contributing

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=[
         'Django>=2.2',
         'asgiref>=3.3.1,<4',
@@ -34,7 +34,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{36,37,38,39}-dj{22,30,31}
-    py{36,37,38,39,310}-dj32
+    py{37,38,39}-dj{22}
+    py{37,38,39,310}-dj32
     py{38,39,310}-djmain
     qa
 
@@ -12,8 +12,6 @@ commands =
     pytest -v {posargs}
 deps =
     dj22: Django~=2.2.8
-    dj30: Django==3.0.*
-    dj31: Django>=3.1,<3.2
     dj32: Django>=3.2.9,<4.0
     djmain: https://github.com/django/django/archive/main.tar.gz
 


### PR DESCRIPTION
Python 3.6, Django 3.0 and Django 3.1 have now all reached end of life. 

Closes #1795