### PR TITLE
Require `asgiref` version equal or higher than `3.5.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     python_requires='>=3.7',
     install_requires=[
         'Django>=2.2',
-        'asgiref>=3.3.1,<4',
+        'asgiref>=3.5.0,<4',
         'daphne>=3.0,<4',
     ],
     extras_require={


### PR DESCRIPTION
Given the issue found in #1713, 
updating related requirements, 
to help users who already have the library installed to not face the same problems.