### PR TITLE
documentation: update selenium call to switch window

### DIFF
--- a/docs/tutorial/part_4.rst
+++ b/docs/tutorial/part_4.rst
@@ -124,17 +124,17 @@ Put the following code in ``chat/tests.py``:
 
         def _open_new_window(self):
             self.driver.execute_script('window.open("about:blank", "_blank");')
-            self.driver.switch_to_window(self.driver.window_handles[-1])
+            self.driver.switch_to.window(self.driver.window_handles[-1])
 
         def _close_all_new_windows(self):
             while len(self.driver.window_handles) > 1:
-                self.driver.switch_to_window(self.driver.window_handles[-1])
+                self.driver.switch_to.window(self.driver.window_handles[-1])
                 self.driver.execute_script('window.close();')
             if len(self.driver.window_handles) == 1:
-                self.driver.switch_to_window(self.driver.window_handles[0])
+                self.driver.switch_to.window(self.driver.window_handles[0])
 
         def _switch_to_window(self, window_index):
-            self.driver.switch_to_window(self.driver.window_handles[window_index])
+            self.driver.switch_to.window(self.driver.window_handles[window_index])
 
         def _post_message(self, message):
             ActionChains(self.driver).send_keys(message + '\n').perform()


### PR DESCRIPTION
When following the tutorial at https://channels.readthedocs.io/en/latest/tutorial/part_4.html 

I would get this error when running: 
`python3 manage.py test chat.tests`

`AttributeError: 'WebDriver' object has no attribute 'switch_to_window'`



Maybe the syntax for that call changed since this tutorial was made?

I see the following changelog at  https://github.com/SeleniumHQ/selenium/blob/trunk/py/CHANGES

> Selenium 2.41
> * Support for Firefox 28
> * deprecating switch_to_* in favour of driver.switch_to.*

Maybe they finally removed the backward compatibility?