### PR TITLE
Document Django 4.0 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Dependencies
 ------------
 
 All Channels projects currently support Python 3.6 and up. ``channels`` is
-compatible with Django 2.2 and 3.2.
+compatible with Django 2.2, 3.2, and 4.0.
 
 
 Contributing


### PR DESCRIPTION
#1782 added explicit support for Django 4.0. This PR updates the README to reflect that.