### PR TITLE
Updated docs year to 2022

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Channels'
-copyright = u'2018, Django Software Foundation'
+copyright = u'2022, Django Software Foundation'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Leaving it at 2018 gives the impression that it hasn't been updated since then, which is bad especially if it's a user's first impression of the project.