### PR TITLE
Improve Performance for manage.py Commands or Alternative (non-daphne) ASGI Servers

### DIFF
--- a/channels/apps.py
+++ b/channels/apps.py
@@ -1,10 +1,18 @@
-# We import this here to ensure the reactor is installed very early on
-# in case other packages accidentally import twisted.internet.reactor
-# (e.g. raven does this).
-import daphne.server
-from django.apps import AppConfig
+import sys
 
-assert daphne.server  # pyflakes doesn't support ignores
+if (
+    len(sys.argv) >= 2
+    and sys.argv[0].endswith("manage.py")
+    and sys.argv[1] == "runserver"
+) or sys.argv[0].endswith("daphne"):
+    # We import this here to ensure the reactor is installed very early on
+    # in case other packages accidentally import twisted.internet.reactor
+    # (e.g. raven does this).
+    import daphne.server
+
+    assert daphne.server  # pyflakes doesn't support ignores
+
+from django.apps import AppConfig
 
 
 class ChannelsConfig(AppConfig):

--- a/channels/hacks.py
+++ b/channels/hacks.py
@@ -1,13 +1,22 @@
+import sys
+
+
 def monkeypatch_django():
     """
     Monkeypatches support for us into parts of Django.
     """
-    # Ensure that the staticfiles version of runserver bows down to us
-    # This one is particularly horrible
-    from django.contrib.staticfiles.management.commands.runserver import (
-        Command as StaticRunserverCommand,
-    )
 
-    from .management.commands.runserver import Command as RunserverCommand
+    if (
+        len(sys.argv) >= 2
+        and sys.argv[0].endswith("manage.py")
+        and sys.argv[1] == "runserver"
+    ):
+        # Ensure that the staticfiles version of runserver bows down to us
+        # This one is particularly horrible
+        from django.contrib.staticfiles.management.commands.runserver import (
+            Command as StaticRunserverCommand,
+        )
 
-    StaticRunserverCommand.__bases__ = (RunserverCommand,)
+        from .management.commands.runserver import Command as RunserverCommand
+
+        StaticRunserverCommand.__bases__ = (RunserverCommand,)


### PR DESCRIPTION
This improves speed and memory usage of `manage.py` commands other than `runserver`. It also improves performance when using an alternative ASGI server like "uvicorn" in production. In these cases `daphne` is not needed at all, and we can avoid the import cost of `daphne`.

## Reproduction

Create a new Django project, install channels and memray, apply migrations.

    django-admin startproject mysite
    cd mysite
    pip install Django channels memray
    ./manage.py migrate

Run `manage.py showmigrations` using memray.

    python -m memray run manage.py showmigrations
    python -m memray flamegraph memray-manage.py.253077.bin

Open HTML report and view total memory usage and memory allocations. Run `time ./manage.py showmigrations` 10 times and calculate average execution time.

Apply the changes from this PR, and calculate the metrics again.

## Results:

| Metric                | Before   | After    | Change       |
| --------------------- | -------- | -------- | ------------ |
| Memray - Total Memory | 32.5 MB | 17.9 MB | -45% |
| Memray - Allocations  | 10991    | 3992    | -64%      |
| Execution Time         | 0.322s  | 0.189s  | -41%     |

As you see, this PR can reduce memory usage up to **45%** and execution time up to **41%**.

## Package Versions

```
Django==4.0.4
channels==3.0.4
daphne==3.0.2
asgiref==3.5.0
memray==1.0.3
```