### PR TITLE
Added MQTTAsgi project to community projects.

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -12,6 +12,7 @@ These projects from the community are developed on top of Channels:
 * DjangoChannelsJsonRpc_, a wrapper for the JSON-RPC protocol.
 * channels-demultiplexer_, a (de)multiplexer for ``AsyncJsonWebsocketConsumer`` consumers.
 * channels_postgres_, a Django Channels channel layer that uses PostgreSQL as its backing store.
+* mqttasgi_, a complete MQTT protocol server for Django Channels.
 
 Community Tutorials
 ===================
@@ -32,3 +33,4 @@ If you'd like to add your project, please submit a PR with a link and brief desc
 .. _channels-demultiplexer: https://github.com/csdenboer/channels-demultiplexer
 .. _kafka-integration: https://gist.github.com/aryan340/da071d027050cfe0a03df3b500f2f44b
 .. _channels_postgres: https://github.com/danidee10/channels_postgres
+.. _mqttasgi: https://github.com/sivulich/mqttasgi


### PR DESCRIPTION
mqttasgi is an ASGI protocol server that implements a complete interface for MQTT for the Django development framework. 
Built following daphne protocol server as a guide.