### PR TITLE
Add subdomains of localhost to the default DEBUG mode allowed_hosts

### DIFF
--- a/channels/security/websocket.py
+++ b/channels/security/websocket.py
@@ -140,7 +140,7 @@ def AllowedHostsOriginValidator(application):
     """
     allowed_hosts = settings.ALLOWED_HOSTS
     if settings.DEBUG and not allowed_hosts:
-        allowed_hosts = ["localhost", "127.0.0.1", "[::1]"]
+        allowed_hosts = [".localhost", "127.0.0.1", "[::1]"]
     return OriginValidator(application, allowed_hosts)
 
 


### PR DESCRIPTION
This will bring Channels in line with Django. See https://code.djangoproject.com/ticket/31010