### PR TITLE
Channels Projects now use Python 3.7+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ and `tutorial <https://channels.readthedocs.io/en/latest/tutorial/index.html>`_ 
 Dependencies
 ------------
 
-All Channels projects currently support Python 3.6 and up. ``channels`` is
+All Channels projects currently support Python 3.7 and up. ``channels`` is
 compatible with Django 2.2, 3.2, and 4.0.
 
 


### PR DESCRIPTION
A small tweak to the readme. 

It seems to me, looking at the tox config that Channels now only supports Python 3.7+.