### PR TITLE
Fixed test_staticfiles_handler_can_generate_file_path on Windows.

### DIFF
--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from channels.staticfiles import StaticFilesHandler, StaticFilesWrapper
@@ -121,5 +123,5 @@ async def test_staticfiles_handler_can_generate_file_path():
     scope = request_for_path("/static/image.png")
     scope["method"] = "GET"
     assert (
-        await wrapper(scope, None, None) == "/image.png"
+        await wrapper(scope, None, None) == os.path.normpath("/image.png")
     ), "StaticFilesWrapper should serve paths under the STATIC_URL path"

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -122,6 +122,6 @@ async def test_staticfiles_handler_can_generate_file_path():
     )
     scope = request_for_path("/static/image.png")
     scope["method"] = "GET"
-    assert (
-        await wrapper(scope, None, None) == os.path.normpath("/image.png")
+    assert await wrapper(scope, None, None) == os.path.normpath(
+        "/image.png"
     ), "StaticFilesWrapper should serve paths under the STATIC_URL path"


### PR DESCRIPTION
Currently this test fails on Windows due to back slashes being used for file paths on Windows. 

I think we can normalise the expected path to make this work cross platform? This now passes locally, on Windows, atleast. 
```
assert '\\image.png' == '/image.png'
E         - /image.png
E         ? ^
E         + \image.png
E         ? ^
```