### PR TITLE
Fix for urlparse with OriginValidator

### DIFF
--- a/channels/security/websocket.py
+++ b/channels/security/websocket.py
@@ -94,10 +94,10 @@ class OriginValidator:
             return False
 
         # Get ResultParse object
-        parsed_pattern = urlparse(pattern.lower(), scheme=None)
+        parsed_pattern = urlparse(pattern.lower())
         if parsed_origin.hostname is None:
             return False
-        if parsed_pattern.scheme is None:
+        if not parsed_pattern.scheme:
             pattern_hostname = urlparse("//" + pattern).hostname or pattern
             return is_same_domain(parsed_origin.hostname, pattern_hostname)
         # Get origin.port or default ports for origin or None


### PR DESCRIPTION
 - Python >3.6.13 broke OriginValidator in channels 2.x. This fix makes it backwards
   compatible

   Example stack trace:
   ERROR    [Failure instance: Traceback: <class 'AttributeError'>: 'NoneType' object has no attribute 'replace'
   /usr/local/lib/python3.8/site-packages/autobahn/websocket/protocol.py:2841:processHandshake
   /usr/local/lib/python3.8/site-packages/txaio/tx.py:366:as_future
   /usr/local/lib/python3.8/site-packages/twisted/internet/defer.py:167:maybeDeferred
   /usr/local/lib/python3.8/site-packages/daphne/ws_protocol.py:72:onConnect
   --- <exception caught here> ---
   /usr/local/lib/python3.8/site-packages/twisted/internet/defer.py:167:maybeDeferred
   /usr/local/lib/python3.8/site-packages/daphne/server.py:200:create_application
   /usr/local/lib/python3.8/site-packages/channels/routing.py:58:__call__
   /usr/local/lib/python3.8/site-packages/channels/security/websocket.py:35:__call__
   /usr/local/lib/python3.8/site-packages/channels/security/websocket.py:53:valid_origin
   /usr/local/lib/python3.8/site-packages/channels/security/websocket.py:72:validate_origin
   /usr/local/lib/python3.8/site-packages/channels/security/websocket.py:73:<genexpr>
   /usr/local/lib/python3.8/site-packages/channels/security/websocket.py:97:match_allowed_origin
   /usr/local/lib/python3.8/urllib/parse.py:376:urlparse
   /usr/local/lib/python3.8/urllib/parse.py:433:urlsplit
   /usr/local/lib/python3.8/urllib/parse.py:422:_remove_unsafe_bytes_from_url

   https://github.com/django/channels/issues/1716
   https://github.com/django/channels/pull/1769