### PR TITLE
Fixed unsecure/broken links and typos.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ https://channels.readthedocs.io
 
 Channels is an official Django Project and as such has a deprecation policy.
 Details about what's deprecated or pending deprecation for each release is in
-the `release notes <http://channels.readthedocs.io/en/latest/releases/index.html>`_.
+the `release notes <https://channels.readthedocs.io/en/latest/releases/index.html>`_.
 
 Support can be obtained through several locations - see our
 `support docs <https://channels.readthedocs.io/en/latest/support.html>`_ for more.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = _build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from https://www.sphinx-doc.org/)
 endif
 
 # Internal variables.

--- a/docs/asgi.rst
+++ b/docs/asgi.rst
@@ -1,7 +1,7 @@
 ASGI
 ====
 
-`ASGI <http://asgi.readthedocs.io>`_, or the
+`ASGI <https://asgi.readthedocs.io>`_, or the
 Asynchronous Server Gateway Interface, is the specification which
 Channels and Daphne are built upon, designed to untie Channels apps from a
 specific application server and provide a common way to write application
@@ -10,7 +10,7 @@ and middleware code.
 It's a spiritual successor to WSGI, designed not only run in an asynchronous
 fashion via ``asyncio``, but also supporting multiple protocols.
 
-The full ASGI spec can be found at http://asgi.readthedocs.io
+The full ASGI spec can be found at https://asgi.readthedocs.io
 
 
 Summary

--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -125,7 +125,7 @@ You can see more about Daphne and its options
 Alternative Web Servers
 -----------------------
 
-There are also alternative `ASGI <http://asgi.readthedocs.io>`_ servers
+There are also alternative `ASGI <https://asgi.readthedocs.io>`_ servers
 that you can use for serving Channels.
 
 To some degree ASGI web servers should be interchangeable, they should all have
@@ -221,13 +221,13 @@ Have supervisor reread and update its jobs:
     $ sudo supervisorctl update
 
 .. note::
-    Running the daphe command with ``--fd 0`` in the commandline will fail and
+    Running the daphne command with ``--fd 0`` in the commandline will fail and
     result in *[Errno 88] Socket operation on non-socket*.
 
     Supervisor will automatically create the socket, bind, and listen before
     forking the first child in a group. The socket will be passed to each child
     on file descriptor number 0 (zero). See
-    http://supervisord.org/configuration.html#fcgi-program-x-section-settings
+    https://supervisord.org/configuration.html#fcgi-program-x-section-settings
 
 Next, Nginx has to be told to proxy traffic to the running Daphne instances.
 Setup your nginx upstream conf file for your project:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ Django Channels
 
 Channels is a project that takes Django and extends its abilities beyond
 HTTP - to handle WebSockets, chat protocols, IoT protocols, and more. It's
-built on a Python specification called `ASGI <http://asgi.readthedocs.io>`_.
+built on a Python specification called `ASGI <https://asgi.readthedocs.io>`_.
 
 Channels builds upon the native ASGI support available in Django since v3.0,
 and provides an implementation itself for Django v2.2. Django still handles

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -35,7 +35,7 @@ a single idea of what a channels "application" is, and even the simplest of
     ASGI is the name for the asynchronous server specification that Channels
     is built on. Like WSGI, it is designed to let you choose between different
     servers and frameworks rather than being locked into Channels and our server
-    Daphne. You can learn more at http://asgi.readthedocs.io
+    Daphne. You can learn more at https://asgi.readthedocs.io
 
 Channels gives you the tools to write these basic *consumers* - individual
 pieces that might handle chat messaging, or notifications - and tie them

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -56,7 +56,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://www.sphinx-doc.org/
 	exit /b 1
 )
 

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -63,7 +63,7 @@ General support request
 .. code-block:: text
 
     Sorry, but we can't help out with general support requests here - the issue tracker is for reproduceable bugs and
-    concrete feature requests only! Please see our support documentation (http://channels.readthedocs.io/en/latest/support.html)
+    concrete feature requests only! Please see our support documentation (https://channels.readthedocs.io/en/latest/support.html)
     for more information about where you can get general help.
 
 Non-specific bug/"It doesn't work!"
@@ -73,7 +73,7 @@ Non-specific bug/"It doesn't work!"
 
     I'm afraid we can't address issues without either direct steps to reproduce, or that only happen in a production
     environment, as they may not be problems in the project itself. Our support documentation
-    (http://channels.readthedocs.io/en/latest/support.html) has details about how to take this sort of problem, diagnose it,
+    (https://channels.readthedocs.io/en/latest/support.html) has details about how to take this sort of problem, diagnose it,
     and either fix it yourself, get help from the community, or make it into an actionable issue that we can handle.
 
     Sorry we have to direct you away like this, but we get a lot of support requests every week. If you can reduce the problem
@@ -87,4 +87,4 @@ Problem in application code
 
     It looks like a problem in your application code rather than in Channels itself, so I'm going to close the ticket.
     If you can trace it down to a problem in Channels itself (with exact steps to reproduce on a fresh or small example
-    project - see http://channels.readthedocs.io/en/latest/support.html) please re-open the ticket! Thanks.
+    project - see https://channels.readthedocs.io/en/latest/support.html) please re-open the ticket! Thanks.


### PR DESCRIPTION
Fixed insecure links:
 - *.readthedocs.io
 - supervisord.org
 
 Broken links:
 - http://sphinx-doc.org/ -> https://www.sphinx-doc.org/
 
 Typos:
 - daphe -> daphne