### PR TITLE
Updated config for pytest-asyncio 0.19

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,4 @@ profile = black
 
 [tool:pytest]
 testpaths = tests
+asyncio_mode = auto


### PR DESCRIPTION
Set `asyncio_mode = auto`, which is recommended for projects, like
Channels, that do not need to support multiple frameworks, such as
asyncio and trio.

pytest-asyncio 0.19 sets `asyncio_mode = strict` by default, which
would require explicitly marking tests and fixtures to be run with
asyncio.

See https://github.com/pytest-dev/pytest-asyncio/releases/tag/v0.19.0
for details.

Address breakage from pytest-asyncio release, as seen https://github.com/django/channels/actions/runs/2708052488