### PR TITLE
Adding Matrix and MQTT servers / consumers to Community Projects

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -12,6 +12,7 @@ These projects from the community are developed on top of Channels:
 * DjangoChannelsJsonRpc_, a wrapper for the JSON-RPC protocol.
 * channels-demultiplexer_, a (de)multiplexer for ``AsyncJsonWebsocketConsumer`` consumers.
 * channels_postgres_, a Django Channels channel layer that uses PostgreSQL as its backing store.
+* matrix-asgi_, an interface server and matching generic consumers for the Matrix protocol.
 
 Community Tutorials
 ===================
@@ -32,3 +33,4 @@ If you'd like to add your project, please submit a PR with a link and brief desc
 .. _channels-demultiplexer: https://github.com/csdenboer/channels-demultiplexer
 .. _kafka-integration: https://gist.github.com/aryan340/da071d027050cfe0a03df3b500f2f44b
 .. _channels_postgres: https://github.com/danidee10/channels_postgres
+.. _matrix-asgi: https://github.com/nim65s/matrix-asgi

--- a/docs/community.rst
+++ b/docs/community.rst
@@ -12,7 +12,8 @@ These projects from the community are developed on top of Channels:
 * DjangoChannelsJsonRpc_, a wrapper for the JSON-RPC protocol.
 * channels-demultiplexer_, a (de)multiplexer for ``AsyncJsonWebsocketConsumer`` consumers.
 * channels_postgres_, a Django Channels channel layer that uses PostgreSQL as its backing store.
-* matrix-asgi_, an interface server and matching generic consumers for the Matrix protocol.
+* matrix-asgi_, an interface server and matching generic consumer for the Matrix protocol.
+* mqttasgi_, an interface server and matching generic consumer for the MQTT protocol.
 
 Community Tutorials
 ===================
@@ -34,3 +35,4 @@ If you'd like to add your project, please submit a PR with a link and brief desc
 .. _kafka-integration: https://gist.github.com/aryan340/da071d027050cfe0a03df3b500f2f44b
 .. _channels_postgres: https://github.com/danidee10/channels_postgres
 .. _matrix-asgi: https://github.com/nim65s/matrix-asgi
+.. _mqttasgi: https://github.com/sivulich/mqttasgi


### PR DESCRIPTION
Hi,

I'm making a Django project requiring IoT and Instant Messaging interfaces. This works well with Channels, thanks !

For this, I found a nice MQTT ASGI server, and didn't find any Matrix ASGI server, so I made one. 
I guess both could be added in the community list :)