### PR TITLE
Enforced `fork` multiprocessing start mode for live test case.

### DIFF
--- a/channels/testing/live.py
+++ b/channels/testing/live.py
@@ -1,3 +1,5 @@
+import multiprocessing
+
 from daphne.testing import DaphneProcess
 from django.contrib.staticfiles.handlers import ASGIStaticFilesHandler
 from django.core.exceptions import ImproperlyConfigured
@@ -6,6 +8,9 @@ from django.test.testcases import TransactionTestCase
 from django.test.utils import modify_settings
 
 from channels.routing import get_default_application
+
+# Enforce multiprocessing start method for macOS.
+multiprocessing.set_start_method("fork")
 
 
 class ChannelsLiveServerTestCase(TransactionTestCase):


### PR DESCRIPTION
Current test case is not compatible with the spawn start method,
hitting errors pickling inner functions and lambdas.

Refs #1485 and django/asgiref#313.

Enforcing fork allows tests to run at least on macOS. Fork is
deprecated there, so spawn compatibility is still needed. Likewise
for Windows, which requires spawn.