### PR TITLE
Fix monospace formatting in Installation docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,7 @@ Channels is available on PyPI - to install it run:
     python -m pip install -U channels["daphne"]
 
 This will install Channels together with the Daphne ASGI application server. If
-you wish to use a different application server you can ``pip install channels`,
+you wish to use a different application server you can ``pip install channels``,
 without the optional ``daphe`` add-on.
 
 Once that's done, you should add ``daphne`` to the beginning of your


### PR DESCRIPTION
Prior to this fix:

<img width="742" alt="Screen Shot 2022-08-25 at 7 57 04 AM" src="https://user-images.githubusercontent.com/10340167/186658132-6e5e05dc-092f-4ec8-8467-5e75cf852af8.png">

