### PR TITLE
Make live test case use pickleable DaphneProcess

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,10 +47,12 @@ Serving of Django HTTPS applications (whether using sync or async views) under A
 
         pip install 'channels[daphne]'
 
-  … to install.
+  … to install. Note use of ``ChannelsLiveServerTestCase`` still requires Daphne.
 
 * Removed the ``consumer_started`` and consumer_finished`` signals, unused since the 2.0 rewrite.
 
+* Fixed ``ChannelsLiveServerTestCase`` when running on systems using the ``spawn`` multiprocessing start method, such as
+  macOS and Windows.
 
 3.0.5 (2022-06-24)
 ------------------


### PR DESCRIPTION
Fixes #921, along with https://github.com/django/daphne/pull/440. Fixes #1207.

With a pickleable `DaphneProcess` class, we can be compatible with spawn and fork multiprocessing start modes. Thus there would be no need for the override added in #1906.

In order to remain pickleable, the `get_application` function passed to the process is turned into a `partial()` wrapping a module-level function.

I tested this by following the channels tutorial using the new beta versions. The tests there now pass on macOS, where the default multiprocessing start method is "spawn".