### PR TITLE
Run tests against Python 3.11 and add trove classifier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
         - "3.8"
         - "3.9"
         - "3.10"
+        - "3.11"
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Framework :: Django",
         "Framework :: Django :: 3",
         "Framework :: Django :: 3.2",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     py{37,38,39,310}-dj32
-    py{38,39,310}-dj{40,41,main}
+    py{38,39,310}-dj40
+    py{38,39,310,311}-dj{41,main}
     qa
 
 [testenv]
@@ -12,7 +13,7 @@ commands =
 deps =
     dj32: Django>=3.2.9,<4.0
     dj40: Django>=4.0,<4.1
-    dj41: Django>=4.1b1,<4.2
+    dj41: Django>=4.1.2,<4.2
     djmain: https://github.com/django/django/archive/main.tar.gz
 
 [testenv:qa]


### PR DESCRIPTION
Django [4.1.3](https://docs.djangoproject.com/en/dev/releases/4.1.3/) (expected on 2022-11-01) adds compatibility with Python 3.11.  But the [commit history](https://github.com/django/django/compare/4.1.2...stable/4.1.x) suggests that this is only a formality and 4.1.2 should work as well.