### PR TITLE
Prevent HttpConsumer from hiding exceptions

### DIFF
--- a/channels/generic/http.py
+++ b/channels/generic/http.py
@@ -81,7 +81,7 @@ class AsyncHttpConsumer(AsyncConsumer):
                 await self.handle(b"".join(self.body))
             finally:
                 await self.disconnect()
-                raise StopConsumer()
+            raise StopConsumer()
 
     async def http_disconnect(self, message):
         """

--- a/tests/test_generic_http.py
+++ b/tests/test_generic_http.py
@@ -39,6 +39,19 @@ async def test_async_http_consumer():
 
 
 @pytest.mark.asyncio
+async def test_error():
+    class TestConsumer(AsyncHttpConsumer):
+        async def handle(self, body):
+            raise AssertionError("Error correctly raised")
+
+    communicator = HttpCommunicator(TestConsumer(), "GET", "/")
+    with pytest.raises(AssertionError) as excinfo:
+        await communicator.get_response(timeout=0.05)
+
+    assert str(excinfo.value) == "Error correctly raised"
+
+
+@pytest.mark.asyncio
 async def test_per_scope_consumers():
     """
     Tests that a distinct consumer is used per scope, with AsyncHttpConsumer as


### PR DESCRIPTION
Fixes #1950.

The issue didn’t only affect tests—exceptions were always swallowed by converting them into `StopConsumer()`. So there may be failing HTTP consumers in production apps where the exceptions aren’t being logged.