### PR TITLE
Fix Daphne typo on the 4.0.0 release notes

### DIFF
--- a/docs/releases/4.0.0.rst
+++ b/docs/releases/4.0.0.rst
@@ -12,7 +12,7 @@ the top of your ``INSTALLED_APPS`` setting.
 
 First ``pip``::
 
-    pip install -U 'channels[dapne]' channels-redis
+    pip install -U 'channels[daphne]' channels-redis
 
 Then in your Django settings file::
 


### PR DESCRIPTION
Fixing a little typo on the pip command of the 4.0.0 release notes