### PR TITLE
InMemoryChannelLayer improvements, test fixes

### DIFF
--- a/channels/layers.py
+++ b/channels/layers.py
@@ -350,7 +350,11 @@ class InMemoryChannelLayer(BaseChannelLayer):
         if group in self.groups:
             for channel in self.groups[group].keys():
                 ops.append(asyncio.ensure_future(self.send(channel, message)))
-        await asyncio.wait(ops)
+        for send_result in asyncio.as_completed(ops):
+            try:
+                await send_result
+            except ChannelFull:
+                pass
 
 
 def get_channel_layer(alias=DEFAULT_CHANNEL_LAYER):

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -50,7 +50,9 @@ class ChannelLayerManager:
         try:
             config = self.configs[name]["TEST_CONFIG"]
         except KeyError:
-            raise InvalidChannelLayerError("No TEST_CONFIG specified for %s" % name)
+            raise InvalidChannelLayerError(
+                "No TEST_CONFIG specified for %s" % name
+            )
         return self._make_backend(name, config)
 
     def _make_backend(self, name, config):
@@ -64,7 +66,9 @@ class ChannelLayerManager:
         try:
             backend_class = import_string(self.configs[name]["BACKEND"])
         except KeyError:
-            raise InvalidChannelLayerError("No BACKEND specified for %s" % name)
+            raise InvalidChannelLayerError(
+                "No BACKEND specified for %s" % name
+            )
         except ImportError:
             raise InvalidChannelLayerError(
                 "Cannot import BACKEND %r specified for %s"
@@ -168,10 +172,13 @@ class BaseChannelLayer:
     def valid_channel_names(self, names, receive=False):
         _non_empty_list = True if names else False
         _names_type = isinstance(names, list)
-        assert _non_empty_list and _names_type, "names must be a non-empty list"
+        assert (
+            _non_empty_list and _names_type
+        ), "names must be a non-empty list"
 
         assert all(
-            self.valid_channel_name(channel, receive=receive) for channel in names
+            self.valid_channel_name(channel, receive=receive)
+            for channel in names
         )
         return True
 
@@ -225,13 +232,14 @@ class InMemoryChannelLayer(BaseChannelLayer):
         # name in message
         assert "__asgi_channel__" not in message
 
-        queue = self.channels.setdefault(channel, asyncio.Queue())
-        # Are we full
-        if queue.qsize() >= self.capacity:
-            raise ChannelFull(channel)
-
+        queue = self.channels.setdefault(
+            channel, asyncio.Queue(maxsize=self.get_capacity(channel))
+        )
         # Add message
-        await queue.put((time.time() + self.expiry, deepcopy(message)))
+        try:
+            queue.put_nowait((time.time() + self.expiry, deepcopy(message)))
+        except asyncio.queues.QueueFull:
+            raise ChannelFull(channel)
 
     async def receive(self, channel):
         """
@@ -242,14 +250,16 @@ class InMemoryChannelLayer(BaseChannelLayer):
         assert self.valid_channel_name(channel)
         self._clean_expired()
 
-        queue = self.channels.setdefault(channel, asyncio.Queue())
+        queue = self.channels.setdefault(
+            channel, asyncio.Queue(maxsize=self.get_capacity(channel))
+        )
 
         # Do a plain direct receive
         try:
-            _, message = await queue.get()
+            _, message = await asyncio.wait_for(queue.get(), self.expiry)
         finally:
             if queue.empty():
-                del self.channels[channel]
+                self.channels.pop(channel, None)
 
         return message
 
@@ -279,19 +289,18 @@ class InMemoryChannelLayer(BaseChannelLayer):
                 self._remove_from_groups(channel)
                 # Is the channel now empty and needs deleting?
                 if queue.empty():
-                    del self.channels[channel]
+                    self.channels.pop(channel, None)
 
         # Group Expiration
         timeout = int(time.time()) - self.group_expiry
-        for group in self.groups:
-            for channel in list(self.groups.get(group, set())):
-                # If join time is older than group_expiry end the group membership
-                if (
-                    self.groups[group][channel]
-                    and int(self.groups[group][channel]) < timeout
-                ):
+        for channels in self.groups.values():
+
+            for name, timestamp in list(channels.items()):
+                # If join time is older than group_expiry
+                # end the group membership
+                if timestamp and timestamp < timeout:
                     # Delete from group
-                    del self.groups[group][channel]
+                    channels.pop(name, None)
 
     # Flush extension
 
@@ -308,8 +317,7 @@ class InMemoryChannelLayer(BaseChannelLayer):
         Removes a channel from all groups. Used when a message on it expires.
         """
         for channels in self.groups.values():
-            if channel in channels:
-                del channels[channel]
+            channels.pop(channel, None)
 
     # Groups extension
 
@@ -329,11 +337,12 @@ class InMemoryChannelLayer(BaseChannelLayer):
         assert self.valid_channel_name(channel), "Invalid channel name"
         assert self.valid_group_name(group), "Invalid group name"
         # Remove from group set
-        if group in self.groups:
-            if channel in self.groups[group]:
-                del self.groups[group][channel]
-            if not self.groups[group]:
-                del self.groups[group]
+        group_channels = self.groups.get(group, None)
+        if group_channels:
+            group_channels.pop(channel, None)
+            # group is now empty
+            if not group_channels:
+                self.groups.pop(group, None)
 
     async def group_send(self, group, message):
         # Check types
@@ -341,12 +350,13 @@ class InMemoryChannelLayer(BaseChannelLayer):
         assert self.valid_group_name(group), "Invalid group name"
         # Run clean
         self._clean_expired()
+
         # Send to each channel
-        for channel in self.groups.get(group, set()):
-            try:
-                await self.send(channel, message)
-            except ChannelFull:
-                pass
+        ops = []
+        if group in self.groups:
+            for channel in self.groups[group].keys():
+                ops.append(asyncio.ensure_future(self.send(channel, message)))
+        await asyncio.wait(ops)
 
 
 def get_channel_layer(alias=DEFAULT_CHANNEL_LAYER):

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -50,9 +50,7 @@ class ChannelLayerManager:
         try:
             config = self.configs[name]["TEST_CONFIG"]
         except KeyError:
-            raise InvalidChannelLayerError(
-                "No TEST_CONFIG specified for %s" % name
-            )
+            raise InvalidChannelLayerError("No TEST_CONFIG specified for %s" % name)
         return self._make_backend(name, config)
 
     def _make_backend(self, name, config):
@@ -66,9 +64,7 @@ class ChannelLayerManager:
         try:
             backend_class = import_string(self.configs[name]["BACKEND"])
         except KeyError:
-            raise InvalidChannelLayerError(
-                "No BACKEND specified for %s" % name
-            )
+            raise InvalidChannelLayerError("No BACKEND specified for %s" % name)
         except ImportError:
             raise InvalidChannelLayerError(
                 "Cannot import BACKEND %r specified for %s"
@@ -172,13 +168,10 @@ class BaseChannelLayer:
     def valid_channel_names(self, names, receive=False):
         _non_empty_list = True if names else False
         _names_type = isinstance(names, list)
-        assert (
-            _non_empty_list and _names_type
-        ), "names must be a non-empty list"
+        assert _non_empty_list and _names_type, "names must be a non-empty list"
 
         assert all(
-            self.valid_channel_name(channel, receive=receive)
-            for channel in names
+            self.valid_channel_name(channel, receive=receive) for channel in names
         )
         return True
 

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -198,13 +198,13 @@ class InMemoryChannelLayer(BaseChannelLayer):
         group_expiry=86400,
         capacity=100,
         channel_capacity=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             expiry=expiry,
             capacity=capacity,
             channel_capacity=channel_capacity,
-            **kwargs
+            **kwargs,
         )
         self.channels = {}
         self.groups = {}
@@ -287,7 +287,6 @@ class InMemoryChannelLayer(BaseChannelLayer):
         # Group Expiration
         timeout = int(time.time()) - self.group_expiry
         for channels in self.groups.values():
-
             for name, timestamp in list(channels.items()):
                 # If join time is older than group_expiry
                 # end the group membership
@@ -349,7 +348,7 @@ class InMemoryChannelLayer(BaseChannelLayer):
         ops = []
         if group in self.groups:
             for channel in self.groups[group].keys():
-                ops.append(asyncio.ensure_future(self.send(channel, message)))
+                ops.append(asyncio.create_task(self.send(channel, message)))
         for send_result in asyncio.as_completed(ops):
             try:
                 await send_result

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -50,7 +50,9 @@ class ChannelLayerManager:
         try:
             config = self.configs[name]["TEST_CONFIG"]
         except KeyError:
-            raise InvalidChannelLayerError("No TEST_CONFIG specified for %s" % name)
+            raise InvalidChannelLayerError(
+                "No TEST_CONFIG specified for %s" % name
+            )
         return self._make_backend(name, config)
 
     def _make_backend(self, name, config):
@@ -64,7 +66,9 @@ class ChannelLayerManager:
         try:
             backend_class = import_string(self.configs[name]["BACKEND"])
         except KeyError:
-            raise InvalidChannelLayerError("No BACKEND specified for %s" % name)
+            raise InvalidChannelLayerError(
+                "No BACKEND specified for %s" % name
+            )
         except ImportError:
             raise InvalidChannelLayerError(
                 "Cannot import BACKEND %r specified for %s"
@@ -168,10 +172,13 @@ class BaseChannelLayer:
     def valid_channel_names(self, names, receive=False):
         _non_empty_list = True if names else False
         _names_type = isinstance(names, list)
-        assert _non_empty_list and _names_type, "names must be a non-empty list"
+        assert (
+            _non_empty_list and _names_type
+        ), "names must be a non-empty list"
 
         assert all(
-            self.valid_channel_name(channel, receive=receive) for channel in names
+            self.valid_channel_name(channel, receive=receive)
+            for channel in names
         )
         return True
 
@@ -332,8 +339,9 @@ class InMemoryChannelLayer(BaseChannelLayer):
         # Remove from group set
         group_channels = self.groups.get(group, None)
         if group_channels:
+            # remove channel if in group
             group_channels.pop(channel, None)
-            # group is now empty
+            # is group now empty? If yes remove it
             if not group_channels:
                 self.groups.pop(group, None)
 

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -249,7 +249,7 @@ class InMemoryChannelLayer(BaseChannelLayer):
 
         # Do a plain direct receive
         try:
-            _, message = await asyncio.wait_for(queue.get(), self.expiry)
+            _, message = await queue.get()
         finally:
             if queue.empty():
                 self.channels.pop(channel, None)

--- a/tests/test_inmemorychannel.py
+++ b/tests/test_inmemorychannel.py
@@ -62,7 +62,6 @@ async def test_multi_send_receive(channel_layer):
     """
     Tests overlapping sends and receives, and ordering.
     """
-    channel_layer = InMemoryChannelLayer()
     await channel_layer.send("test-channel-3", {"type": "message.1"})
     await channel_layer.send("test-channel-3", {"type": "message.2"})
     await channel_layer.send("test-channel-3", {"type": "message.3"})
@@ -76,7 +75,6 @@ async def test_groups_basic(channel_layer):
     """
     Tests basic group operation.
     """
-    channel_layer = InMemoryChannelLayer()
     await channel_layer.group_add("test-group", "test-gr-chan-1")
     await channel_layer.group_add("test-group", "test-gr-chan-2")
     await channel_layer.group_add("test-group", "test-gr-chan-3")
@@ -97,7 +95,6 @@ async def test_groups_channel_full(channel_layer):
     """
     Tests that group_send ignores ChannelFull
     """
-    channel_layer = InMemoryChannelLayer()
     await channel_layer.group_add("test-group", "test-gr-chan-1")
     await channel_layer.group_send("test-group", {"type": "message.1"})
     await channel_layer.group_send("test-group", {"type": "message.1"})

--- a/tests/test_inmemorychannel.py
+++ b/tests/test_inmemorychannel.py
@@ -46,7 +46,7 @@ async def test_race_empty(channel_layer):
     """
     Makes sure the race is handled gracefully.
     """
-    receive_task = asyncio.ensure_future(channel_layer.receive("test-channel-1"))
+    receive_task = asyncio.create_task(channel_layer.receive("test-channel-1"))
     await asyncio.sleep(0.1)
     await channel_layer.send(
         "test-channel-1", {"type": "test.message", "text": "Ahoy-hoy!"}


### PR DESCRIPTION
Improvements to InMemoryChannelLayer
- honor expiry / don't block for eternity
- honor per channel capacities
- threadsafer cleaning design with atomic operations
- parallel sending

Bugfixes tests
- channel_layer is sometimes overwritten and the tests become bogus