### PR TITLE
Remove leading whitespace in cookie middleware

### DIFF
--- a/channels/sessions.py
+++ b/channels/sessions.py
@@ -111,7 +111,7 @@ class CookieMiddleware:
         # Write out the cookies to the response
         for c in cookies.values():
             message.setdefault("headers", []).append(
-                (b"Set-Cookie", bytes(c.output(header=""), encoding="utf-8"))
+                (b"Set-Cookie", bytes(c.output(header="").strip(), encoding="utf-8"))
             )
 
     @classmethod

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -4,7 +4,7 @@ import pytest
 
 from channels.consumer import AsyncConsumer
 from channels.db import database_sync_to_async
-from channels.sessions import SessionMiddlewareStack
+from channels.sessions import CookieMiddleware, SessionMiddlewareStack
 from channels.testing import HttpCommunicator
 
 
@@ -19,6 +19,15 @@ class SimpleHttpApp(AsyncConsumer):
         assert self.scope["method"] == "GET"
         await self.send({"type": "http.response.start", "status": 200, "headers": []})
         await self.send({"type": "http.response.body", "body": b"test response"})
+
+
+@pytest.mark.asyncio
+async def test_set_cookie():
+    message = {}
+    CookieMiddleware.set_cookie(message, "Testing-Key", "testing-value")
+    assert message == {
+        "headers": [(b"Set-Cookie", b"Testing-Key=testing-value; Path=/; SameSite=lax")]
+    }
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
Looks like the same issue as this PR https://github.com/django/channels/pull/1130 fixed.

h11 does not allow header values with leading or trailing whitespace.