### PR TITLE
Add missing space in introduction example code

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -265,7 +265,7 @@ point-to-point and broadcast messaging.
 
 .. code-block:: python
 
-    #In a consumer
+    # In a consumer
     self.channel_layer.send(
         'event', 
         {


### PR DESCRIPTION
This matches the comment in the code block directly after this one