### PR TITLE
Remove Redis docker container on exit and do not detach

### DIFF
--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -371,7 +371,7 @@ Redis server on port 6379, run the following command:
 
 .. code-block:: sh
 
-    $ docker run -p 6379:6379 -d redis:5
+    $ docker run --rm -p 6379:6379 redis:5
 
 We need to install channels_redis so that Channels knows how to interface with
 Redis. Run the following command:

--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -367,7 +367,8 @@ That will allow ChatConsumers to transmit messages to all other ChatConsumers in
 the same room.
 
 We will use a channel layer that uses Redis as its backing store. To start a
-Redis server on port 6379, run the following command:
+Redis server on port 6379, run the following command (press Control-C to stop
+it):
 
 .. code-block:: sh
 


### PR DESCRIPTION
This PR does two things in the tutorial's usage of Docker:

1. Automatically clean up the Redis container when it is complete to keep the developers machine tidy
    - https://docs.docker.com/engine/reference/run/#clean-up---rm
    - > By default a container’s file system persists even after the container exits. This makes debugging a lot easier (since you can inspect the final state) and you retain all your data by default. But if you are running short-term foreground processes, these container file systems can really pile up. If instead you’d like Docker to automatically clean up the container and remove the file system when the container exits, you can add the --rm flag:
2. Do no run in detached mode. For a tutorial, I think it's easier to understand if we match `python manage.py` usage where the user runs the command, sees output, and Ctrl-C's when needed to stop it (more explicit)
    - Without this, it's not as obvious to new developers when/that Redis is running. They would need to run `docker ps` or `docker stats` to see if it's running, and stop it manually by copying the container ID

Output the developer sees:

```
$ docker run --rm -p 6379:6379 redis:5
1:C 05 Apr 2023 17:24:25.618 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
1:C 05 Apr 2023 17:24:25.618 # Redis version=5.0.14, bits=64, commit=00000000, modified=0, pid=1, just started
1:C 05 Apr 2023 17:24:25.618 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
1:M 05 Apr 2023 17:24:25.619 * Running mode=standalone, port=6379.
1:M 05 Apr 2023 17:24:25.619 # Server initialized
1:M 05 Apr 2023 17:24:25.619 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
1:M 05 Apr 2023 17:24:25.619 * Ready to accept connections
```