### PR TITLE
Use format string for `room_name` in tutorial

### DIFF
--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -432,7 +432,7 @@ following code in ``chat/consumers.py``, replacing the old code:
     class ChatConsumer(WebsocketConsumer):
         def connect(self):
             self.room_name = self.scope["url_route"]["kwargs"]["room_name"]
-            self.room_group_name = "chat_%s" % self.room_name
+            self.room_group_name = f"chat_{self.room_name}"
 
             # Join room group
             async_to_sync(self.channel_layer.group_add)(
@@ -480,7 +480,7 @@ Several parts of the new ``ChatConsumer`` code deserve further explanation:
       including in particular any positional or keyword arguments from the URL
       route and the currently authenticated user if any.
 
-* ``self.room_group_name = "chat_%s" % self.room_name``
+* ``self.room_group_name = f"chat_{self.room_name}"``
     * Constructs a Channels group name directly from the user-specified room
       name, without any quoting or escaping.
     * Group names may only contain alphanumerics, hyphens, underscores, or

--- a/docs/tutorial/part_3.rst
+++ b/docs/tutorial/part_3.rst
@@ -40,7 +40,7 @@ Put the following code in ``chat/consumers.py``:
     class ChatConsumer(AsyncWebsocketConsumer):
         async def connect(self):
             self.room_name = self.scope["url_route"]["kwargs"]["room_name"]
-            self.room_group_name = "chat_%s" % self.room_name
+            self.room_group_name = f"chat_{self.room_name}"
 
             # Join room group
             await self.channel_layer.group_add(self.room_group_name, self.channel_name)


### PR DESCRIPTION
Since channels supports Python 3.7+, can use format strings to simplify string construction within the tutorial (which is a Python 3.6+ feature).