### PR TITLE
Update from EOL Redis 5 to supported Redis 7 in tutorial

### DIFF
--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -372,7 +372,7 @@ it):
 
 .. code-block:: sh
 
-    $ docker run --rm -p 6379:6379 redis:5
+    $ docker run --rm -p 6379:6379 redis:7
 
 We need to install channels_redis so that Channels knows how to interface with
 Redis. Run the following command:


### PR DESCRIPTION
Redis 5 is no longer supported: https://endoflife.date/redis

Update from Redis 5 to the latest stable release, 7, which was released 11 months ago.

I tested the tutorial program using the latest Django/Channels, and it worked as expected with Redis 7.