### PR TITLE
Update tutorial to use period style event types

### DIFF
--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -455,7 +455,7 @@ following code in ``chat/consumers.py``, replacing the old code:
 
             # Send message to room group
             async_to_sync(self.channel_layer.group_send)(
-                self.room_group_name, {"type": "chat_message", "message": message}
+                self.room_group_name, {"type": "chat.message", "message": message}
             )
 
         # Receive message from room group
@@ -514,7 +514,9 @@ Several parts of the new ``ChatConsumer`` code deserve further explanation:
 * ``async_to_sync(self.channel_layer.group_send)``
     * Sends an event to a group.
     * An event has a special ``'type'`` key corresponding to the name of the method
-      that should be invoked on consumers that receive the event.
+      that should be invoked on consumers that receive the event. This translation
+      is done by replacing ``.`` with ``_``, thus in this example, ``chat.message``
+      calls the ``chat_message`` method.
 
 Let's verify that the new consumer for the ``/ws/chat/ROOM_NAME/`` path works.
 To start the Channels development server, run the following command:

--- a/docs/tutorial/part_3.rst
+++ b/docs/tutorial/part_3.rst
@@ -58,7 +58,7 @@ Put the following code in ``chat/consumers.py``:
 
             # Send message to room group
             await self.channel_layer.group_send(
-                self.room_group_name, {"type": "chat_message", "message": message}
+                self.room_group_name, {"type": "chat.message", "message": message}
             )
 
         # Receive message from room group


### PR DESCRIPTION
Something that confused me when going through the tutorial the first time was how exactly `chat_message()` method was called. This PR attempts to make that more clear.

It also moves the `type` to use `.` notation, which is more in-align with both how the ASGI spec names types as well as the guidance later in the docs: 

- https://channels.readthedocs.io/en/stable/topics/channel_layers.html#what-to-send-over-the-channel-layer

> Any message sent to that channel name - or to a group the channel name was added to - will be received by the consumer much like an event from its connected client, and dispatched to a named method on the consumer. The name of the method will be the type of the event with periods replaced by underscores - so, for example, an event coming in over the channel layer with a type of chat.join will be handled by the method chat_join.

I think this change will help users more naturally flow from the tutorial into what is considered typical best practice for naming event types.