### PR TITLE
Updated tutorial documentation

### DIFF
--- a/docs/tutorial/part_1.rst
+++ b/docs/tutorial/part_1.rst
@@ -175,7 +175,7 @@ Put the following code in ``chat/templates/chat/index.html``:
         <script>
             document.querySelector('#room-name-input').focus();
             document.querySelector('#room-name-input').onkeyup = function(e) {
-                if (e.keyCode === 13) {  // enter, return
+                if (e.key === 'Enter') {  // enter, return
                     document.querySelector('#room-name-submit').click();
                 }
             };

--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -63,7 +63,7 @@ Create the view template for the room view in ``chat/templates/chat/room.html``:
 
             document.querySelector('#chat-message-input').focus();
             document.querySelector('#chat-message-input').onkeyup = function(e) {
-                if (e.keyCode === 13) {  // enter, return
+                if (e.key === 'Enter') {  // enter, return
                     document.querySelector('#chat-message-submit').click();
                 }
             };


### PR DESCRIPTION
As per issue #2010, I've replaced the `keyCode` property with `key` as recommended by MDN web docs (property has been deprecated).