### PR TITLE
Test installation update

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -42,3 +42,6 @@ Make sure your code conforms to the coding style:
     isort --check-only --diff --recursive ./channels ./tests
 
 Push to your fork and `submit a pull request <https://github.com/django/channels/compare/>`_.
+
+Note:
+For those using zsh, you might encounter the error ``zsh: no matches found: .[tests]``. In this case, try wrapping quotations around the ``[tests]]`` section like so ``'.[tests]'``

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -80,6 +80,8 @@ Note the ``[tests]`` section there; that tells ``pip`` that you want to install
 the ``tests`` extra, which will bring in testing dependencies like
 ``pytest-django``.
 
+For those using zsh, you might encounter encounter the error ``zsh: no matches found: .[tests]``. In this case, try wrapping quotations around the ``[tests]`` section like so ``'.[tests]'``.
+
 Then, you can run the tests:
 
 .. code-block:: sh


### PR DESCRIPTION
As per issue #2012, I have added a note under the test installation portion of the contribution documents. 

I've suggested to wrap quotations around tests (`'.[tests]'`) in case running installations on zsh produces an error. 

Kindly let me know if the team would prefer these to be written somewhere else.