### PR TITLE
Fix install command

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,7 @@ Channels is available on PyPI - to install it run:
 
 .. code-block:: sh
 
-    python -m pip install -U channels["daphne"]
+    python -m pip install -U 'channels[daphne]'
 
 This will install Channels together with the Daphne ASGI application server. If
 you wish to use a different application server you can ``pip install channels``,


### PR DESCRIPTION
Using quotes within the square brackets fails with:

```
$ python -m pip install -U 'channels["daphne"]'
ERROR: Exception:
   ...
pip._vendor.packaging.requirements.InvalidRequirement: Parse error at "'["daphne'": Expected string_end
```

The quotes need only be around the whole reference, `channels[daphne]`, for shell escaping.