### PR TITLE
Document `channels-auth-token-middlewares` third party package

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -12,6 +12,9 @@ These projects from the community are developed on top of Channels:
 * DjangoChannelsJsonRpc_, a wrapper for the JSON-RPC protocol.
 * channels-demultiplexer_, a (de)multiplexer for ``AsyncJsonWebsocketConsumer`` consumers.
 * channels_postgres_, a Django Channels channel layer that uses PostgreSQL as its backing store.
+* channels-auth-token-middlewares_, Django REST framework token authentication middleware and
+  SimpleJWT_ middleware, such as QueryStringSimpleJWTAuthTokenMiddleware_ for WebSocket
+  authentication.
 
 If you'd like to add your project, please submit a PR with a link and brief description.
 
@@ -25,3 +28,6 @@ If you'd like to add your project, please submit a PR with a link and brief desc
 .. _channels-demultiplexer: https://github.com/csdenboer/channels-demultiplexer
 .. _kafka-integration: https://gist.github.com/aryan340/da071d027050cfe0a03df3b500f2f44b
 .. _channels_postgres: https://github.com/danidee10/channels_postgres
+.. _channels-auth-token-middlewares: https://github.com/YegorDB/django-channels-auth-token-middlewares
+.. _SimpleJWT: https://github.com/jazzband/djangorestframework-simplejwt
+.. _QueryStringSimpleJWTAuthTokenMiddleware: https://github.com/YegorDB/django-channels-auth-token-middlewares/tree/master/tutorial/drf#querystringsimplejwtauthtokenmiddleware


### PR DESCRIPTION
[`channels-auth-token-middlewares`](https://github.com/YegorDB/django-channels-auth-token-middlewares) fills an important role for providing authentication support out of the box for DRF applications using JWT authentication.

This question has been asked several times on SO:

- https://stackoverflow.com/questions/65297148
- https://stackoverflow.com/questions/43392889

Hopefully by promoting it in the community page, more users can discover it.