### PR TITLE
Fix Fixture Loading by Configuring Settings of django in child process that gets spawn

### DIFF
--- a/channels/testing/live.py
+++ b/channels/testing/live.py
@@ -8,7 +8,6 @@ from django.test.testcases import TransactionTestCase
 from django.test.utils import modify_settings
 
 from channels.routing import get_default_application
-from django.core.management import call_command
 
 
 def make_application(*, static_wrapper):

--- a/channels/testing/live.py
+++ b/channels/testing/live.py
@@ -71,7 +71,6 @@ class ChannelsLiveServerTestCase(TransactionTestCase):
         self._port = self._server_process.port.value
 
     def _post_teardown(self):
-        
         self._server_process.terminate()
         self._server_process.join()
         self._live_server_modified_settings.disable()


### PR DESCRIPTION
This fix refers to [here]( https://github.com/django/channels/issues/2030#issue-1801941335)

Currently, when a test class inherits from ChannelsLiveServerTestCase, all database changes that happen will be written to the default main database, not the test database that is created by the parent class--TransactionTestCase. This is the reason that fixtures are not currently referenced 

When ChannelsLiveServerTestCase initiates a DaphneProcess, by calling this following line 
`self._server_process = self.ProtocolServerProcess(self.host, get_application)`
This instantiates a multiprocessing.Process object which takes care of creating a new process. This uses the spawn method. 


Here is what is said about spawn.
`The parent process starts a fresh python interpreter process. The child process will only inherit those resources necessary` `to run the process objects run() method. In particular, unnecessary file descriptors and handles from the parent process` `will not be inherited. Starting a process using this method is rather slow compared to using fork or forkserver. [Available on` `Unix and Windows. The default on Windows and macOS.]`

This means that django setup() is called and the settings file it reloaded. This means that `setting.DATABASES['default'] will point to the default database. This is incorrect. 

Because ChannelsLiveServerTestCase inherits from TransactionTestCase, it it necessary that all functionality is retained. Therefore, we must point the django module at the test database in the the new process that is running Daphne so that we can correctly use the fixtures, and have the test database removed after testing is finished. Also, so that changes do not leak into the default database. 

This is why, we reassign the default main database NAME to the NAME of the TEST attribute(see the codes difference.

