### PR TITLE
support URLRouter with include

### DIFF
--- a/channels/routing.py
+++ b/channels/routing.py
@@ -81,7 +81,21 @@ class URLRouter:
     _path_routing = True
 
     def __init__(self, routes):
-        self.routes = routes
+	new_routes = []
+        for route in routes:
+            if not route.callback and isinstance(route, URLResolver):
+                for url_pattern in route.url_patterns:
+                    url_pattern: URLPattern
+                    # concatenate parent's url and child's url
+                    regex = ''.join(x.pattern for x in [route.pattern.regex, url_pattern.pattern.regex])
+                    regex = re.sub(r'(/)\1+', r'\1', regex)
+                    name = f"{route.app_name}:{url_pattern.name}" if url_pattern.name else None
+                    pattern = RegexPattern(regex, name=name, is_endpoint=True)
+                    new_routes.append(URLPattern(pattern, url_pattern.callback, route.default_kwargs, name))
+            else:
+                new_routes.append(route)
+
+        self.routes = new_routes
 
         for route in self.routes:
             # The inner ASGI app wants to do additional routing, route

--- a/channels/routing.py
+++ b/channels/routing.py
@@ -1,9 +1,10 @@
 import importlib
+import re
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.urls.exceptions import Resolver404
-from django.urls.resolvers import RegexPattern, RoutePattern, URLResolver
+from django.urls.resolvers import RegexPattern, RoutePattern, URLResolver, URLPattern
 
 """
 All Routing instances inside this file are also valid ASGI applications - with
@@ -81,7 +82,7 @@ class URLRouter:
     _path_routing = True
 
     def __init__(self, routes):
-	new_routes = []
+        new_routes = []
         for route in routes:
             if not route.callback and isinstance(route, URLResolver):
                 for url_pattern in route.url_patterns:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -301,14 +301,3 @@ async def test_path_remaining():
             None,
         )
 
-
-def test_invalid_routes():
-    """
-    Test URLRouter route validation
-    """
-    from django.urls import include
-
-    with pytest.raises(ImproperlyConfigured) as exc:
-        URLRouter([path("", include([]))])
-
-    assert "include() is not supported in URLRouter." in str(exc)


### PR DESCRIPTION
I tried to implement to support `URLRouter` with `include`
Usage:

In parent's `routings.py`;

```python
urlpatterns = [
    path('chats/', include('pj.chats.routings'), name='chats'),
]
```

In child's `routings.py`;

```python
app_name = 'chats'

urlpatterns = [
    re_path(r"/(?P<room_name>\w+)/chat/$", ChatConsumer.as_asgi()),
]
```