### PR TITLE
Use decorator for declaring event handlers

### DIFF
--- a/channels/generic/http.py
+++ b/channels/generic/http.py
@@ -1,4 +1,4 @@
-from channels.consumer import AsyncConsumer
+from channels.consumer import AsyncConsumer, msg_handler
 
 from ..exceptions import StopConsumer
 
@@ -69,6 +69,7 @@ class AsyncHttpConsumer(AsyncConsumer):
         """
         pass
 
+    @msg_handler("http.request")
     async def http_request(self, message):
         """
         Async entrypoint - concatenates body fragments and hands off control
@@ -83,6 +84,7 @@ class AsyncHttpConsumer(AsyncConsumer):
                 await self.disconnect()
             raise StopConsumer()
 
+    @msg_handler("http.disconnect")
     async def http_disconnect(self, message):
         """
         Let the user do their cleanup and close the consumer.

--- a/channels/generic/websocket.py
+++ b/channels/generic/websocket.py
@@ -2,7 +2,7 @@ import json
 
 from asgiref.sync import async_to_sync
 
-from ..consumer import AsyncConsumer, SyncConsumer
+from ..consumer import AsyncConsumer, SyncConsumer, msg_handler
 from ..exceptions import (
     AcceptConnection,
     DenyConnection,
@@ -23,6 +23,7 @@ class WebsocketConsumer(SyncConsumer):
         if self.groups is None:
             self.groups = []
 
+    @msg_handler("websocket.connect")
     def websocket_connect(self, message):
         """
         Called when a WebSocket connection is opened.
@@ -50,6 +51,7 @@ class WebsocketConsumer(SyncConsumer):
         """
         super().send({"type": "websocket.accept", "subprotocol": subprotocol})
 
+    @msg_handler("websocket.receive")
     def websocket_receive(self, message):
         """
         Called when a WebSocket frame is received. Decodes it and passes it
@@ -88,6 +90,7 @@ class WebsocketConsumer(SyncConsumer):
         else:
             super().send({"type": "websocket.close"})
 
+    @msg_handler("websocket.disconnect")
     def websocket_disconnect(self, message):
         """
         Called when a WebSocket connection is closed. Base level so you don't
@@ -158,6 +161,7 @@ class AsyncWebsocketConsumer(AsyncConsumer):
         if self.groups is None:
             self.groups = []
 
+    @msg_handler("websocket.connect")
     async def websocket_connect(self, message):
         """
         Called when a WebSocket connection is opened.
@@ -185,6 +189,7 @@ class AsyncWebsocketConsumer(AsyncConsumer):
         """
         await super().send({"type": "websocket.accept", "subprotocol": subprotocol})
 
+    @msg_handler("websocket.receive")
     async def websocket_receive(self, message):
         """
         Called when a WebSocket frame is received. Decodes it and passes it
@@ -223,6 +228,7 @@ class AsyncWebsocketConsumer(AsyncConsumer):
         else:
             await super().send({"type": "websocket.close"})
 
+    @msg_handler("websocket.disconnect")
     async def websocket_disconnect(self, message):
         """
         Called when a WebSocket connection is closed. Base level so you don't

--- a/tests/test_generic_websocket.py
+++ b/tests/test_generic_websocket.py
@@ -355,6 +355,7 @@ async def test_async_json_websocket_consumer():
         await communicator.wait()
 
 
+@override_settings(CHANNELS_AUTO_HANDLER_BY_NAME=True)  # test not relevant when setting is disabled
 @pytest.mark.asyncio
 async def test_block_underscored_type_function_call():
     """
@@ -390,6 +391,7 @@ async def test_block_underscored_type_function_call():
             await communicator.receive_from()
 
 
+@override_settings(CHANNELS_AUTO_HANDLER_BY_NAME=True)  # test not relevant when setting is disabled
 @pytest.mark.asyncio
 async def test_block_leading_dot_type_function_call():
     """


### PR DESCRIPTION
This is related to the issue I posted yesterday: https://github.com/django/channels/issues/2075
The issue contains info about motivation and room for further discussion.

You can set the setting `CHANNELS_AUTO_HANDLER_BY_NAME` to disable the new behaviour. However I propose that the old behaviour should be deprecated as it could introduce vulnerabilities regarding leaking methods.

I made sure all tests are green with both the feature enabled and disabled. That means that with the setting enabled, the behaviour should be exactly the way it was before.

The new usage is as follows (example taken from the `AsyncWebsocketConsumer` class):
```python
    @msg_handler("websocket.connect")
    async def websocket_connect(self, message):
        """
        Called when a WebSocket connection is opened.
        """
        try:
            for group in self.groups:
                await self.channel_layer.group_add(group, self.channel_name)
        except AttributeError:
            raise InvalidChannelLayerError(
                "BACKEND is unconfigured or doesn't support groups"
            )
        try:
            await self.connect()
        except AcceptConnection:
            await self.accept()
        except DenyConnection:
            await self.close()
```

All the pros about this approach are listed in the issue linked above.