### PR TITLE
Make Django 4.2 the minimum supported version.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Dependencies
 ------------
 
 All Channels projects currently support Python 3.8 and up. ``channels`` is
-compatible with Django 3.2, 4.0, 4.1, 4.2 and 5.0.
+compatible with Django 4.2 and 5.0.
 
 
 Contributing

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,11 +22,6 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Framework :: Django
-    Framework :: Django :: 3
-    Framework :: Django :: 3.2
-    Framework :: Django :: 4
-    Framework :: Django :: 4.0
-    Framework :: Django :: 4.1
     Framework :: Django :: 4.2
     Framework :: Django :: 5.0
     Topic :: Internet :: WWW/HTTP
@@ -35,8 +30,8 @@ classifiers =
 packages = find:
 include_package_data = True
 install_requires =
-    Django>=3.2
-    asgiref>=3.5.0,<4
+    Django>=4.2
+    asgiref>=3.6.0,<4
 python_requires = >=3.8
 
 [options.extras_require]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,5 @@
 [tox]
 envlist =
-    py{38,39,310}-dj32
-    py{38,39,310}-dj40
-    py{38,39,310,311}-dj41
     py{38,39,310,311}-dj42
     py{310,311,312}-dj50
     py{310,311,312}-djmain
@@ -13,9 +10,6 @@ extras = tests, daphne
 commands =
     pytest -v {posargs}
 deps =
-    dj32: Django>=3.2.9,<4.0
-    dj40: Django>=4.0,<4.1
-    dj41: Django>=4.1.2,<4.2
     dj42: Django>=4.2,<5.0
     dj50: Django>=5.0rc1,<5.1
     djmain: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
Bump asgiref dependency to match Django stable/4.2.x