### PR TITLE
Micro-optimizations

### DIFF
--- a/channels/layers.py
+++ b/channels/layers.py
@@ -166,7 +166,7 @@ class BaseChannelLayer:
         raise TypeError(self.invalid_name_error.format("Group", name))
 
     def valid_channel_names(self, names, receive=False):
-        _non_empty_list = True if names else False
+        _non_empty_list = bool(names)
         _names_type = isinstance(names, list)
         assert _non_empty_list and _names_type, "names must be a non-empty list"
 

--- a/channels/security/websocket.py
+++ b/channels/security/websocket.py
@@ -123,10 +123,10 @@ class OriginValidator:
             # Return origin.port
             return origin.port
         # if origin.port doesn`t exists
-        if origin.scheme == "http" or origin.scheme == "ws":
+        if origin.scheme in {"http", "ws"}:
             # Default port return for http, ws
             return 80
-        elif origin.scheme == "https" or origin.scheme == "wss":
+        elif origin.scheme in {"https", "wss"}:
             # Default port return for https, wss
             return 443
         else:

--- a/channels/testing/live.py
+++ b/channels/testing/live.py
@@ -74,3 +74,4 @@ class ChannelsLiveServerTestCase(TransactionTestCase):
         """
         if connection.vendor == "sqlite":
             return connection.is_in_memory_db()
+        return None

--- a/channels/worker.py
+++ b/channels/worker.py
@@ -21,9 +21,9 @@ class Worker(StatelessServer):
         Listens on all the provided channels and handles the messages.
         """
         # For each channel, launch its own listening coroutine
-        listeners = []
-        for channel in self.channels:
-            listeners.append(asyncio.ensure_future(self.listener(channel)))
+        listeners = [
+            asyncio.ensure_future(self.listener(channel)) for channel in self.channels
+        ]
         # Wait for them all to exit
         await asyncio.wait(listeners)
         # See if any of the listeners had an error (e.g. channel layer error)

--- a/tests/test_generic_websocket.py
+++ b/tests/test_generic_websocket.py
@@ -280,7 +280,7 @@ async def test_async_websocket_consumer_specific_channel_layer():
         # Test that the specific channel layer is retrieved
         assert channel_layer is not None
 
-        channel_name = list(channel_layer.channels.keys())[0]
+        channel_name = next(iter(channel_layer.channels))
         message = {"type": "websocket.receive", "text": "hello"}
         await channel_layer.send(channel_name, message)
         response = await communicator.receive_from()
@@ -380,7 +380,7 @@ async def test_block_underscored_type_function_call():
         # Test that the specific channel layer is retrieved
         assert channel_layer is not None
 
-        channel_name = list(channel_layer.channels.keys())[0]
+        channel_name = next(iter(channel_layer.channels))
         # Should block call to private functions handler and raise ValueError
         message = {"type": "_my_private_handler", "text": "hello"}
         await channel_layer.send(channel_name, message)
@@ -415,7 +415,7 @@ async def test_block_leading_dot_type_function_call():
         # Test that the specific channel layer is retrieved
         assert channel_layer is not None
 
-        channel_name = list(channel_layer.channels.keys())[0]
+        channel_name = next(iter(channel_layer.channels))
         # Should not replace dot by underscore and call private function (see
         # issue: #1430)
         message = {"type": ".my_private_handler", "text": "hello"}

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -93,18 +93,18 @@ async def test_url_router():
     # Valid keyword argument matches
     assert await router({"type": "http", "path": "/kwarg/hello/"}, None, None) == 5
     assert kwarg_app.call_args[0][0]["url_route"] == {
-        "args": tuple(),
+        "args": (),
         "kwargs": {"name": "hello"},
     }
     assert await router({"type": "http", "path": "/kwarg/hellothere/"}, None, None) == 5
     assert kwarg_app.call_args[0][0]["url_route"] == {
-        "args": tuple(),
+        "args": (),
         "kwargs": {"name": "hellothere"},
     }
     # Valid default keyword arguments
     assert await router({"type": "http", "path": "/defaultkwargs/"}, None, None) == 6
     assert defaultkwarg_app.call_args[0][0]["url_route"] == {
-        "args": tuple(),
+        "args": (),
         "kwargs": {"default": 42},
     }
     # Valid root_path in scope
@@ -246,13 +246,13 @@ async def test_url_router_path():
         await router({"type": "http", "path": "/author/andrewgodwin/"}, None, None) == 3
     )
     assert kwarg_app.call_args[0][0]["url_route"] == {
-        "args": tuple(),
+        "args": (),
         "kwargs": {"name": "andrewgodwin"},
     }
     # Named with typecasting
     assert await router({"type": "http", "path": "/year/2012/"}, None, None) == 3
     assert kwarg_app.call_args[0][0]["url_route"] == {
-        "args": tuple(),
+        "args": (),
         "kwargs": {"year": 2012},
     }
     # Invalid matches


### PR DESCRIPTION
[Ruff rules](https://docs.astral.sh/ruff/rules):
* C408 Unnecessary `tuple` call (rewrite as a literal)
* PERF401 Use a list comprehension to create a transformed list
* PLR1714 Consider merging multiple comparisons. Use a `set` if the elements are hashable.
* RET503 Missing explicit `return` at the end of function able to return non-`None` value
* RUF015 Prefer `next(iter(channel_layer.channels))` over single element slice
* SIM210 Use `bool(...)` instead of `True if ... else False`

% `ruff rule PERF401`
# manual-list-comprehension (PERF401)

Derived from the **Perflint** linter.

## What it does
Checks for `for` loops that can be replaced by a list comprehension.

## Why is this bad?
When creating a transformed list from an existing list using a for-loop,
prefer a list comprehension. List comprehensions are more readable and
more performant.

Using the below as an example, the list comprehension is ~10% faster on
Python 3.11, and ~25% faster on Python 3.10.

Note that, as with all `perflint` rules, this is only intended as a
micro-optimization, and will have a negligible impact on performance in
most cases.

## Example
```python
original = list(range(10000))
filtered = []
for i in original:
    if i % 2:
        filtered.append(i)
```

Use instead:
```python
original = list(range(10000))
filtered = [x for x in original if x % 2]
```

If you're appending to an existing list, use the `extend` method instead:
```python
original = list(range(10000))
filtered.extend(x for x in original if x % 2)
```
