### PR TITLE
Document Django's async ORM API

### DIFF
--- a/channels/consumer.py
+++ b/channels/consumer.py
@@ -3,7 +3,7 @@ import functools
 from asgiref.sync import async_to_sync
 
 from . import DEFAULT_CHANNEL_LAYER
-from .db import database_sync_to_async
+from .db import aclose_old_connections, database_sync_to_async
 from .exceptions import StopConsumer
 from .layers import get_channel_layer
 from .utils import await_many_dispatch
@@ -70,6 +70,7 @@ class AsyncConsumer:
         """
         handler = getattr(self, get_handler_name(message), None)
         if handler:
+            await aclose_old_connections()
             await handler(message)
         else:
             raise ValueError("No handler for message type %s" % message["type"])

--- a/channels/db.py
+++ b/channels/db.py
@@ -1,4 +1,4 @@
-from asgiref.sync import SyncToAsync
+from asgiref.sync import SyncToAsync, sync_to_async
 from django.db import close_old_connections
 
 
@@ -17,3 +17,7 @@ class DatabaseSyncToAsync(SyncToAsync):
 
 # The class is TitleCased, but we want to encourage use as a callable/decorator
 database_sync_to_async = DatabaseSyncToAsync
+
+
+async def aclose_old_connections():
+    return await sync_to_async(close_old_connections)()

--- a/channels/generic/http.py
+++ b/channels/generic/http.py
@@ -1,5 +1,6 @@
 from channels.consumer import AsyncConsumer
 
+from ..db import aclose_old_connections
 from ..exceptions import StopConsumer
 
 
@@ -88,4 +89,5 @@ class AsyncHttpConsumer(AsyncConsumer):
         Let the user do their cleanup and close the consumer.
         """
         await self.disconnect()
+        await aclose_old_connections()
         raise StopConsumer()

--- a/channels/generic/websocket.py
+++ b/channels/generic/websocket.py
@@ -3,6 +3,7 @@ import json
 from asgiref.sync import async_to_sync
 
 from ..consumer import AsyncConsumer, SyncConsumer
+from ..db import aclose_old_connections
 from ..exceptions import (
     AcceptConnection,
     DenyConnection,
@@ -247,6 +248,7 @@ class AsyncWebsocketConsumer(AsyncConsumer):
                 "BACKEND is unconfigured or doesn't support groups"
             )
         await self.disconnect(message["code"])
+        await aclose_old_connections()
         raise StopConsumer()
 
     async def disconnect(self, code):

--- a/docs/topics/consumers.rst
+++ b/docs/topics/consumers.rst
@@ -112,7 +112,8 @@ callable into an asynchronous coroutine.
 
     If you want to call the Django ORM from an ``AsyncConsumer`` (or any other
     asynchronous code), you should use the ``database_sync_to_async`` adapter
-    instead. See :doc:`/topics/databases` for more.
+    or use the async versions of the methods (prefixed with ``a``, like ``aget``).
+    See :doc:`/topics/databases` for more.
 
 
 Closing Consumers

--- a/docs/tutorial/part_3.rst
+++ b/docs/tutorial/part_3.rst
@@ -15,16 +15,20 @@ asynchronous consumers can provide a higher level of performance since they
 don't need to create additional threads when handling requests.
 
 ``ChatConsumer`` only uses async-native libraries (Channels and the channel layer)
-and in particular it does not access synchronous Django models. Therefore it can
+and in particular it does not access synchronous code. Therefore it can
 be rewritten to be asynchronous without complications.
 
 .. note::
-    Even if ``ChatConsumer`` *did* access Django models or other synchronous code it
+    Even if ``ChatConsumer`` *did* access Django models or synchronous code it
     would still be possible to rewrite it as asynchronous. Utilities like
     :ref:`asgiref.sync.sync_to_async <sync_to_async>` and
     :doc:`channels.db.database_sync_to_async </topics/databases>` can be
     used to call synchronous code from an asynchronous consumer. The performance
-    gains however would be less than if it only used async-native libraries.
+    gains however would be less than if it only used async-native libraries. Django
+    models include methods prefixed with ``a`` that can be used safely from async
+    contexts, provided that
+    :doc:`channels.db.aclose_old_connections </topics/databases>` is called
+    occasionally.
 
 Let's rewrite ``ChatConsumer`` to be asynchronous.
 Put the following code in ``chat/consumers.py``:

--- a/tests/security/test_websocket.py
+++ b/tests/security/test_websocket.py
@@ -5,6 +5,7 @@ from channels.security.websocket import OriginValidator
 from channels.testing import WebsocketCommunicator
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_origin_validator():
     """

--- a/tests/test_generic_http.py
+++ b/tests/test_generic_http.py
@@ -8,6 +8,7 @@ from channels.generic.http import AsyncHttpConsumer
 from channels.testing import HttpCommunicator
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_async_http_consumer():
     """
@@ -38,6 +39,7 @@ async def test_async_http_consumer():
     assert response["headers"] == [(b"Content-Type", b"application/json")]
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_error():
     class TestConsumer(AsyncHttpConsumer):
@@ -51,6 +53,7 @@ async def test_error():
     assert str(excinfo.value) == "Error correctly raised"
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_per_scope_consumers():
     """
@@ -87,6 +90,7 @@ async def test_per_scope_consumers():
     assert response["body"] != second_response["body"]
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_async_http_consumer_future():
     """

--- a/tests/test_generic_websocket.py
+++ b/tests/test_generic_websocket.py
@@ -154,6 +154,7 @@ async def test_websocket_consumer_groups():
         assert channel_layer.groups == {}
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_async_websocket_consumer():
     """
@@ -195,6 +196,7 @@ async def test_async_websocket_consumer():
     assert "disconnected" in results
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_async_websocket_consumer_subprotocol():
     """
@@ -217,6 +219,7 @@ async def test_async_websocket_consumer_subprotocol():
     assert subprotocol == "subprotocol2"
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_async_websocket_consumer_groups():
     """
@@ -253,6 +256,7 @@ async def test_async_websocket_consumer_groups():
         assert channel_layer.groups == {}
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_async_websocket_consumer_specific_channel_layer():
     """
@@ -323,6 +327,7 @@ async def test_json_websocket_consumer():
         await communicator.wait()
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_async_json_websocket_consumer():
     """
@@ -355,6 +360,7 @@ async def test_async_json_websocket_consumer():
         await communicator.wait()
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_block_underscored_type_function_call():
     """
@@ -390,6 +396,7 @@ async def test_block_underscored_type_function_call():
             await communicator.receive_from()
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_block_leading_dot_type_function_call():
     """

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -23,6 +23,7 @@ class SimpleHttpApp(AsyncConsumer):
         await self.send({"type": "http.response.body", "body": b"test response"})
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_http_communicator():
     """


### PR DESCRIPTION
The async ORM interface was [added in 4.1](https://docs.djangoproject.com/en/5.0/releases/4.1/#asynchronous-orm-interface)! Since channels supports >=4.2 we can document that new API.

Consider this a first pass, I just updated the spots I noticed that looked like they needed tweaking, happy to take feedback on wordsmithing or different ideas on how to document this.

Closes: #1999 