### PR TITLE
Drop long deleted cookie_date

### DIFF
--- a/channels/sessions.py
+++ b/channels/sessions.py
@@ -10,13 +10,9 @@ from django.http.cookie import SimpleCookie
 from django.utils import timezone
 from django.utils.encoding import force_str
 from django.utils.functional import LazyObject
+from django.utils.http import http_date
 
 from channels.db import database_sync_to_async
-
-try:
-    from django.utils.http import http_date
-except ImportError:
-    from django.utils.http import cookie_date as http_date
 
 
 class CookieMiddleware:


### PR DESCRIPTION
This was originally added in: https://github.com/django/channels/pull/1237

This was removed in https://github.com/django/django/commit/958a7b4ca69434d0145fd569cf007e21841bb36c (part of the 3.0 release)

I think we can drop the fallback now 😄 