### PR TITLE
Use the async session.asave method if it exists

### DIFF
--- a/docs/topics/sessions.rst
+++ b/docs/topics/sessions.rst
@@ -73,7 +73,8 @@ whenever the session is modified.
 
 If you are in a WebSocket consumer, however, the session is populated
 **but will never be saved automatically** - you must call
-``scope["session"].save()`` yourself whenever you want to persist a session
+``scope["session"].save()`` (or the asynchronous version,
+``scope["session"].asave()``) yourself whenever you want to persist a session
 to your session store. If you don't save, the session will still work correctly
 inside the consumer (as it's stored as an instance variable), but other
 connections or HTTP views won't be able to see the changes.


### PR DESCRIPTION
Support was added in https://github.com/django/django/pull/17372 (slated for release in 5.1)

We can use this API if it exists, otherwise, we fallback to a `sync_to_async` bridge.

This does break backwards compatibility, which I'm not terribly happy about but I'm not sure how best to fix it.

If users overrode `save_session` in a subclass they would expect that to still work, so I thought the best way to do this was to make it async in the base class and then `await` it, so at least it will be obvious that it doesn't work (python will raise an exception about `await`ing a non-awaitable), but I'm open to other solutions.