### PR TITLE
More informative assert errors for WebsocketCommunicator.

### DIFF
--- a/channels/testing/websocket.py
+++ b/channels/testing/websocket.py
@@ -78,19 +78,23 @@ class WebsocketCommunicator(ApplicationCommunicator):
         """
         response = await self.receive_output(timeout)
         # Make sure this is a send message
-        assert response["type"] == "websocket.send"
+        assert (
+            response["type"] == "websocket.send"
+        ), f"Expected type 'websocket.send', but was '{response['type']}'"
         # Make sure there's exactly one key in the response
         assert ("text" in response) != (
             "bytes" in response
         ), "The response needs exactly one of 'text' or 'bytes'"
         # Pull out the right key and typecheck it for our users
         if "text" in response:
-            assert isinstance(response["text"], str), "Text frame payload is not str"
+            assert isinstance(
+                response["text"], str
+            ), f"Text frame payload is not str, it is {type(response['text'])}"
             return response["text"]
         else:
             assert isinstance(
                 response["bytes"], bytes
-            ), "Binary frame payload is not bytes"
+            ), f"Binary frame payload is not bytes, it is {type(response['bytes'])}"
             return response["bytes"]
 
     async def receive_json_from(self, timeout=1):
@@ -98,7 +102,9 @@ class WebsocketCommunicator(ApplicationCommunicator):
         Receives a JSON text frame payload and decodes it
         """
         payload = await self.receive_from(timeout)
-        assert isinstance(payload, str), "JSON data is not a text frame"
+        assert isinstance(
+            payload, str
+        ), f"JSON data is not a text frame, it is {type(payload)}"
         return json.loads(payload)
 
     async def disconnect(self, code=1000, timeout=1):

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -47,6 +47,13 @@ class SimpleWebsocketApp(WebsocketConsumer):
         self.send(text_data=text_data, bytes_data=bytes_data)
 
 
+class AcceptCloseWebsocketApp(WebsocketConsumer):
+    def connect(self):
+        assert self.scope["path"] == "/testws/"
+        self.accept()
+        self.close()
+
+
 class ErrorWebsocketApp(WebsocketConsumer):
     """
     Barebones WebSocket ASGI app for error testing.
@@ -91,6 +98,24 @@ async def test_websocket_communicator():
     assert response == {"hello": "world"}
     # Close out
     await communicator.disconnect()
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_websocket_incorrect_read_json():
+    """
+    Tests that when using invalid communicator method, assertion error is gonna be raised with informative message.
+    In this test, server accepts and then immediately closes the connection so the server is not in valid state
+    to handle "receive_from".
+    """
+    communicator = WebsocketCommunicator(AcceptCloseWebsocketApp(), "/testws/")
+    await communicator.connect()
+    with pytest.raises(AssertionError) as exception_info:
+        await communicator.receive_from()
+    assert (
+        str(exception_info.value)
+        == "Expected type 'websocket.send', but was 'websocket.close'"
+    )
 
 
 @pytest.mark.django_db

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -104,9 +104,10 @@ async def test_websocket_communicator():
 @pytest.mark.asyncio
 async def test_websocket_incorrect_read_json():
     """
-    When using an invalid communicator method, as assertion error will be raised with informative message.
-    In this test, server accepts and then immediately closes the connection so the server is not in valid state
-    to handle "receive_from".
+    When using an invalid communicator method, an assertion error will be raised with
+    informative message.
+    In this test, the server accepts and then immediately closes the connection so
+    the server is not in a valid state to handle "receive_from".
     """
     communicator = WebsocketCommunicator(AcceptCloseWebsocketApp(), "/testws/")
     await communicator.connect()

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -104,7 +104,7 @@ async def test_websocket_communicator():
 @pytest.mark.asyncio
 async def test_websocket_incorrect_read_json():
     """
-    Tests that when using invalid communicator method, assertion error is gonna be raised with informative message.
+    When using an invalid communicator method, as assertion error will be raised with informative message.
     In this test, server accepts and then immediately closes the connection so the server is not in valid state
     to handle "receive_from".
     """


### PR DESCRIPTION
Already happened to me twice, that this AssertionError got me puzzled for a bit (being channels newbie and coming back after months), until I figured out, what was going on (socket closed unexpectedly while I wanted to read from it).

Having this kind of informative message would give me immediate hint and make my debugging much faster.