### PR TITLE
Remove no more used deprecation message

### DIFF
--- a/channels/routing.py
+++ b/channels/routing.py
@@ -33,20 +33,6 @@ def get_default_application():
     return value
 
 
-DEPRECATION_MSG = """
-Using ProtocolTypeRouter without an explicit "http" key is deprecated.
-Given that you have not passed the "http" you likely should use Django's
-get_asgi_application():
-
-    from django.core.asgi import get_asgi_application
-
-    application = ProtocolTypeRouter(
-        "http": get_asgi_application()
-        # Other protocols here.
-    )
-"""
-
-
 class ProtocolTypeRouter:
     """
     Takes a mapping of protocol type names to other Application instances,


### PR DESCRIPTION
This deprecation message usage was removed in 354284550204510ad02e5677a87605ccc4f228b7, thus there is no point in keeping it in the codebase.