### PR TITLE
chore: Update tutorial. Use path over repath .

### DIFF
--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -238,7 +238,7 @@ Put the following code in ``chat/routing.py``:
     from . import consumers
 
     websocket_urlpatterns = [
-        path(r"ws/chat/<str:room_name>/", consumers.ChatConsumer.as_asgi()),
+        path("ws/chat/<str:room_name>/", consumers.ChatConsumer.as_asgi()),
     ]
 
 We call the ``as_asgi()`` classmethod in order to get an ASGI application that

--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -233,12 +233,12 @@ Put the following code in ``chat/routing.py``:
 .. code-block:: python
 
     # chat/routing.py
-    from django.urls import re_path
+    from django.urls import path
 
     from . import consumers
 
     websocket_urlpatterns = [
-        re_path(r"ws/chat/(?P<room_name>\w+)/$", consumers.ChatConsumer.as_asgi()),
+        path(r"ws/chat/<str:room_name>/", consumers.ChatConsumer.as_asgi()),
     ]
 
 We call the ``as_asgi()`` classmethod in order to get an ASGI application that


### PR DESCRIPTION
path is more intuitive to use than repath as an example.