### PR TITLE
Added function prototype for BaseChannelLayer

### DIFF
--- a/channels/layers.py
+++ b/channels/layers.py
@@ -198,7 +198,7 @@ class BaseChannelLayer:
     # flush extension
 
     async def flush(self):
-        raise NotImplementedError("flush() called but not implemented (flush extension)")
+        raise NotImplementedError("flush() not implemented (flush extension)")
 
     # groups extension
 

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -191,15 +191,15 @@ class BaseChannelLayer:
 
     async def receive(self, channel):
         raise NotImplementedError("receive() should be implemented in channels")
-    
+
     async def new_channel(self):
         raise NotImplementedError("new_channel() should be implemented in channels")
-    
+
     # flush extension
 
     async def flush(self):
         raise NotImplementedError("flush() called but not implemented (flush extension)")
-    
+
     # groups extension
 
     async def group_add(self, group, channel):

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -187,20 +187,18 @@ class BaseChannelLayer:
             return name
 
     async def send(self, channel, message):
-        raise NotImplementedError("send() should be implemented in channels")
+        raise NotImplementedError("send() should be implemented in a channel layer")
 
     async def receive(self, channel):
-        raise NotImplementedError("receive() should be implemented in channels")
+        raise NotImplementedError("receive() should be implemented in a channel layer")
 
     async def new_channel(self):
-        raise NotImplementedError("new_channel() should be implemented in channels")
-
-    # flush extension
+        raise NotImplementedError(
+            "new_channel() should be implemented in a channel layer"
+        )
 
     async def flush(self):
         raise NotImplementedError("flush() not implemented (flush extension)")
-
-    # groups extension
 
     async def group_add(self, group, channel):
         raise NotImplementedError("group_add() not implemented (groups extension)")

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -186,6 +186,31 @@ class BaseChannelLayer:
         else:
             return name
 
+    async def send(self, channel, message):
+        raise NotImplementedError("send() should be implemented in channels")
+
+    async def receive(self, channel):
+        raise NotImplementedError("receive() should be implemented in channels")
+    
+    async def new_channel(self):
+        raise NotImplementedError("new_channel() should be implemented in channels")
+    
+    # flush extension
+
+    async def flush(self):
+        raise NotImplementedError("flush() called but not implemented (flush extension)")
+    
+    # groups extension
+
+    async def group_add(self, group, channel):
+        raise NotImplementedError("group_add() not implemented (groups extension)")
+
+    async def group_discard(self, group, channel):
+        raise NotImplementedError("group_discard() not implemented (groups extension)")
+
+    async def group_send(self, group, message):
+        raise NotImplementedError("group_send() not implemented (groups extension)")
+
 
 class InMemoryChannelLayer(BaseChannelLayer):
     """


### PR DESCRIPTION
Added prototypes like `send()`, `receive()`, etc. to `BaseChannelLayer`, the base class of all channel layers. These are necessary functions for any channel layer, according to the [docs](https://channels.readthedocs.io/en/latest/channel_layer_spec.html).

This helps intellisense when type hints are present, and assists developers writing their own channel.