### PR TITLE
[BUG FIX] Exception handling and enabling graceful shutdown of connection 

### DIFF
--- a/channels/layers.py
+++ b/channels/layers.py
@@ -167,12 +167,9 @@ class BaseChannelLayer:
         _non_empty_list = True if names else False
         _names_type = isinstance(names, list)
         assert _non_empty_list and _names_type, "names must be a non-empty list"
-        all(
+        for channel in names:
             self.require_valid_channel_name(channel, receive=receive)
-            for channel in names
-        )
         return True
-
     def non_local_name(self, name):
         """
         Given a channel name, returns the "non-local" part. If the channel name

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -346,9 +346,7 @@ class InMemoryChannelLayer(BaseChannelLayer):
         Adds the channel name to a group.
         """
         # Check the inputs
-        assert self.valid_group_name(group), (
-            f"Group name must be" f"less than {self.MAX_NAME_LENGTH} characters."
-        )
+        assert self.valid_group_name(group)
         assert self.valid_channel_name(channel), "Channel name not valid"
         # Add to group dict
         self.groups.setdefault(group, {})
@@ -357,9 +355,7 @@ class InMemoryChannelLayer(BaseChannelLayer):
     async def group_discard(self, group, channel):
         # Both should be text and valid
         assert self.valid_channel_name(channel), "Invalid channel name"
-        assert self.valid_group_name(group), (
-            f"Group name must be" f"less than {self.MAX_NAME_LENGTH} characters."
-        )
+        assert self.valid_group_name(group)
         # Remove from group set
         group_channels = self.groups.get(group, None)
         if group_channels:

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -144,38 +144,32 @@ class BaseChannelLayer:
     invalid_name_error = (
         "{} name must be a valid unicode string "
         + "with length < {} ".format(MAX_NAME_LENGTH)
-        + "containing only ASCII alphanumerics, hyphens, underscores, or periods, "
-        + "not {}"
+        + "containing only ASCII alphanumerics, hyphens, underscores, or periods."
     )
 
-    def valid_channel_name(self, name, receive=False):
-        if self.match_type_and_length(name):
-            if bool(self.channel_name_regex.match(name)):
-                # Check cases for special channels
-                if "!" in name and not name.endswith("!") and receive:
-                    raise TypeError(
-                        "Specific channel names in receive() must end at the !"
-                    )
-                return True
-        raise TypeError(self.invalid_name_error.format("Channel", name))
+    def require_valid_channel_name(self, name, receive=False):
+        if not self.match_type_and_length(name):
+            raise TypeError(self.invalid_name_error.format("Channel"))
+        if not bool(self.channel_name_regex.match(name)):
+            raise TypeError(self.invalid_name_error.format("Channel"))
+        if "!" in name and not name.endswith("!") and receive:
+            raise TypeError("Specific channel names in receive() must end at the !")
+        return True
 
     def require_valid_group_name(self, name):
-        if len(name) >= self.MAX_NAME_LENGTH:
-            raise TypeError(
-                f"Group name must be less than {self.MAX_NAME_LENGTH} characters."
-            )
-        if self.match_type_and_length(name):
-            if bool(self.group_name_regex.match(name)):
-                return True
-        raise TypeError(self.invalid_name_error.format("Group", name))
+        if not self.match_type_and_length(name):
+            raise TypeError(self.invalid_name_error.format("Group"))
+        if not bool(self.group_name_regex.match(name)):
+            raise TypeError(self.invalid_name_error.format("Group"))
+        return True
 
     def valid_channel_names(self, names, receive=False):
         _non_empty_list = True if names else False
         _names_type = isinstance(names, list)
         assert _non_empty_list and _names_type, "names must be a non-empty list"
-
-        assert all(
-            self.valid_channel_name(channel, receive=receive) for channel in names
+        all(
+            self.require_valid_channel_name(channel, receive=receive)
+            for channel in names
         )
         return True
 
@@ -247,7 +241,7 @@ class InMemoryChannelLayer(BaseChannelLayer):
         """
         # Typecheck
         assert isinstance(message, dict), "message is not a dict"
-        assert self.valid_channel_name(channel), "Channel name not valid"
+        self.require_valid_channel_name(channel)
         # If it's a process-local channel, strip off local part and stick full
         # name in message
         assert "__asgi_channel__" not in message
@@ -267,7 +261,7 @@ class InMemoryChannelLayer(BaseChannelLayer):
         If more than one coroutine waits on the same channel, a random one
         of the waiting coroutines will get the result.
         """
-        assert self.valid_channel_name(channel)
+        self.require_valid_channel_name(channel)
         self._clean_expired()
 
         queue = self.channels.setdefault(
@@ -346,14 +340,14 @@ class InMemoryChannelLayer(BaseChannelLayer):
         """
         # Check the inputs
         self.require_valid_group_name(group)
-        self.valid_channel_name(channel), "Channel name not valid"
+        self.require_valid_channel_name(channel)
         # Add to group dict
         self.groups.setdefault(group, {})
         self.groups[group][channel] = time.time()
 
     async def group_discard(self, group, channel):
         # Both should be text and valid
-        assert self.valid_channel_name(channel), "Invalid channel name"
+        self.require_valid_channel_name(channel)
         self.require_valid_group_name(group)
         # Remove from group set
         group_channels = self.groups.get(group, None)

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -159,7 +159,7 @@ class BaseChannelLayer:
                 return True
         raise TypeError(self.invalid_name_error.format("Channel", name))
 
-    def valid_group_name(self, name):
+    def require_valid_group_name(self, name):
         if len(name) >= self.MAX_NAME_LENGTH:
             raise TypeError(
                 f"Group name must be less than {self.MAX_NAME_LENGTH} characters."
@@ -345,8 +345,8 @@ class InMemoryChannelLayer(BaseChannelLayer):
         Adds the channel name to a group.
         """
         # Check the inputs
-        assert self.valid_group_name(group)
-        assert self.valid_channel_name(channel), "Channel name not valid"
+        self.require_valid_group_name(group)
+        self.valid_channel_name(channel), "Channel name not valid"
         # Add to group dict
         self.groups.setdefault(group, {})
         self.groups[group][channel] = time.time()
@@ -354,7 +354,7 @@ class InMemoryChannelLayer(BaseChannelLayer):
     async def group_discard(self, group, channel):
         # Both should be text and valid
         assert self.valid_channel_name(channel), "Invalid channel name"
-        assert self.valid_group_name(group)
+        self.require_valid_group_name(group)
         # Remove from group set
         group_channels = self.groups.get(group, None)
         if group_channels:
@@ -367,9 +367,7 @@ class InMemoryChannelLayer(BaseChannelLayer):
     async def group_send(self, group, message):
         # Check types
         assert isinstance(message, dict), "Message is not a dict"
-        assert self.valid_group_name(group), (
-            f"Group name must be" f"less than {self.MAX_NAME_LENGTH} characters."
-        )
+        self.require_valid_group_name(group)
         # Run clean
         self._clean_expired()
 

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -169,7 +169,8 @@ class BaseChannelLayer:
         assert _non_empty_list and _names_type, "names must be a non-empty list"
         for channel in names:
             self.require_valid_channel_name(channel, receive=receive)
-        return True
+        return
+
     def non_local_name(self, name):
         """
         Given a channel name, returns the "non-local" part. If the channel name

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -5,8 +5,7 @@ import re
 import string
 import time
 from copy import deepcopy
-import logging
-logger = logging.getLogger(__name__)
+
 from django.conf import settings
 from django.core.signals import setting_changed
 from django.utils.module_loading import import_string
@@ -161,10 +160,12 @@ class BaseChannelLayer:
         raise TypeError(self.invalid_name_error.format("Channel", name))
 
     def valid_group_name(self, name):
-        logger.debug(f"Validating group name: {name}, Length: {len(name)}")  # Log group name length
-        if isinstance(name, str):
-            if len(name) >= self.MAX_NAME_LENGTH:
-                raise False
+        error_message = (
+            f"Group name must be less than {self.MAX_NAME_LENGTH} characters."
+        )
+        if len(name) >= self.MAX_NAME_LENGTH:
+            raise TypeError(error_message)
+        if self.match_type_and_length(name):
             if bool(self.group_name_regex.match(name)):
                 return True
         raise TypeError(self.invalid_name_error.format("Group", name))
@@ -205,7 +206,6 @@ class BaseChannelLayer:
         raise NotImplementedError("flush() not implemented (flush extension)")
 
     async def group_add(self, group, channel):
-        print("Hello")
         raise NotImplementedError("group_add() not implemented (groups extension)")
 
     async def group_discard(self, group, channel):
@@ -341,30 +341,25 @@ class InMemoryChannelLayer(BaseChannelLayer):
 
     # Groups extension
 
-
     async def group_add(self, group, channel):
         """
         Adds the channel name to a group.
         """
         # Check the inputs
-        print(f"Validating group name: {group}")
-        assert self.valid_group_name(group), f"Group name must be less than {self.MAX_NAME_LENGTH} characters."
+        assert self.valid_group_name(group), (
+            f"Group name must be" f"less than {self.MAX_NAME_LENGTH} characters."
+        )
         assert self.valid_channel_name(channel), "Channel name not valid"
-
-        # Check the length of the group name
-        if len(group) >= self.MAX_NAME_LENGTH:
-            raise TypeError(f"Group name must be less than {self.MAX_NAME_LENGTH} characters, but got {len(group)}.")
-
-    # Add to group dict
+        # Add to group dict
         self.groups.setdefault(group, {})
         self.groups[group][channel] = time.time()
 
-
     async def group_discard(self, group, channel):
         # Both should be text and valid
-        print(f"Discarding channel {channel} from group {group}")  # Log group name
         assert self.valid_channel_name(channel), "Invalid channel name"
-        assert self.valid_group_name(group), "Invalid group name"
+        assert self.valid_group_name(group), (
+            f"Group name must be" f"less than {self.MAX_NAME_LENGTH} characters."
+        )
         # Remove from group set
         group_channels = self.groups.get(group, None)
         if group_channels:
@@ -377,7 +372,9 @@ class InMemoryChannelLayer(BaseChannelLayer):
     async def group_send(self, group, message):
         # Check types
         assert isinstance(message, dict), "Message is not a dict"
-        assert self.valid_group_name(group), "Invalid group name"
+        assert self.valid_group_name(group), (
+            f"Group name must be" f"less than {self.MAX_NAME_LENGTH} characters."
+        )
         # Run clean
         self._clean_expired()
 

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -169,7 +169,7 @@ class BaseChannelLayer:
         assert _non_empty_list and _names_type, "names must be a non-empty list"
         for channel in names:
             self.require_valid_channel_name(channel, receive=receive)
-        return
+        return True
 
     def non_local_name(self, name):
         """

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -160,11 +160,10 @@ class BaseChannelLayer:
         raise TypeError(self.invalid_name_error.format("Channel", name))
 
     def valid_group_name(self, name):
-        error_message = (
-            f"Group name must be less than {self.MAX_NAME_LENGTH} characters."
-        )
         if len(name) >= self.MAX_NAME_LENGTH:
-            raise TypeError(error_message)
+            raise TypeError(
+                f"Group name must be less than {self.MAX_NAME_LENGTH} characters."
+            )
         if self.match_type_and_length(name):
             if bool(self.group_name_regex.match(name)):
                 return True

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -72,7 +72,10 @@ async def test_send_receive():
 
 @pytest.mark.parametrize(
     "method",
-    [BaseChannelLayer().valid_channel_name, BaseChannelLayer().valid_group_name],
+    [
+        BaseChannelLayer().valid_channel_name,
+        BaseChannelLayer().require_valid_group_name,
+    ],
 )
 @pytest.mark.parametrize(
     "channel_name,expected_valid",
@@ -104,4 +107,4 @@ def test_group_name_length_error_message(name, expected_error_message):
     layer = BaseChannelLayer()
 
     with pytest.raises(TypeError, match=expected_error_message):
-        layer.valid_group_name(name)
+        layer.require_valid_group_name(name)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -22,6 +22,7 @@ class TestChannelLayerManager(unittest.TestCase):
         If channel layer doesn't specify TEST_CONFIG, `make_test_backend`
         should result into error.
         """
+
         with self.assertRaises(InvalidChannelLayerError):
             channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
 
@@ -38,6 +39,7 @@ class TestChannelLayerManager(unittest.TestCase):
         If channel layer provides TEST_CONFIG, `make_test_backend` should
         return channel layer instance appropriate for testing.
         """
+
         layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
         self.assertEqual(layer.expiry, 100500)
 
@@ -62,13 +64,26 @@ class TestChannelLayerManager(unittest.TestCase):
 
 @pytest.mark.asyncio
 async def test_send_receive():
-    """
-    Test that a message sent to a channel can be received correctly.
-    """
     layer = InMemoryChannelLayer()
     message = {"type": "test.message"}
     await layer.send("test.channel", message)
     assert message == await layer.receive("test.channel")
+
+
+@pytest.mark.parametrize(
+    "method",
+    [BaseChannelLayer().valid_channel_name, BaseChannelLayer().valid_group_name],
+)
+@pytest.mark.parametrize(
+    "channel_name,expected_valid",
+    [("¯\\_(ツ)_/¯", False), ("chat", True), ("chat" * 100, False)],
+)
+def test_channel_and_group_name_validation(method, channel_name, expected_valid):
+    if expected_valid:
+        method(channel_name)
+    else:
+        with pytest.raises(TypeError):
+            method(channel_name)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -69,18 +69,17 @@ async def test_send_receive():
     await layer.send("test.channel", message)
     assert message == await layer.receive("test.channel")
 
+@pytest.mark.parametrize(
+    "name, expected_error_message",
+    [
+        ("a" * 101, f"Group name must be less than {BaseChannelLayer.MAX_NAME_LENGTH} characters."),  # Group name too long
+    ],
+)
+def test_group_name_length_error_message(name, expected_error_message):
+    """
+    Ensure the correct error message is raised when group names exceed the character limit.
+    """
+    layer = BaseChannelLayer()
 
-@pytest.mark.parametrize(
-    "method",
-    [BaseChannelLayer().valid_channel_name, BaseChannelLayer().valid_group_name],
-)
-@pytest.mark.parametrize(
-    "channel_name,expected_valid",
-    [("¯\\_(ツ)_/¯", False), ("chat", True), ("chat" * 100, False)],
-)
-def test_channel_and_group_name_validation(method, channel_name, expected_valid):
-    if expected_valid:
-        method(channel_name)
-    else:
-        with pytest.raises(TypeError):
-            method(channel_name)
+    with pytest.raises(TypeError, match=expected_error_message):
+        layer.valid_group_name(name)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -73,7 +73,7 @@ async def test_send_receive():
 @pytest.mark.parametrize(
     "method",
     [
-        BaseChannelLayer().valid_channel_name,
+        BaseChannelLayer().require_valid_channel_name,
         BaseChannelLayer().require_valid_group_name,
     ],
 )
@@ -90,21 +90,36 @@ def test_channel_and_group_name_validation(method, channel_name, expected_valid)
 
 
 @pytest.mark.parametrize(
-    "name, expected_error_message",
+    "name",
     [
-        (
-            "a" * 101,
-            f"Group name must be less than {BaseChannelLayer.MAX_NAME_LENGTH} "
-            "characters.",
-        ),  # Group name too long
+        "a" * 101,  # Group name too long
     ],
 )
-def test_group_name_length_error_message(name, expected_error_message):
+def test_group_name_length_error_message(name):
     """
     Ensure the correct error message is raised when group names
-    exceed the character limit.
+    exceed the character limit or contain invalid characters.
     """
     layer = BaseChannelLayer()
+    expected_error_message = layer.invalid_name_error.format("Group")
 
     with pytest.raises(TypeError, match=expected_error_message):
         layer.require_valid_group_name(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "a" * 101,  # Channel name too long
+    ],
+)
+def test_channel_name_length_error_message(name):
+    """
+    Ensure the correct error message is raised when group names
+    exceed the character limit or contain invalid characters.
+    """
+    layer = BaseChannelLayer()
+    expected_error_message = layer.invalid_name_error.format("Channel")
+
+    with pytest.raises(TypeError, match=expected_error_message):
+        layer.require_valid_channel_name(name)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -22,7 +22,6 @@ class TestChannelLayerManager(unittest.TestCase):
         If channel layer doesn't specify TEST_CONFIG, `make_test_backend`
         should result into error.
         """
-
         with self.assertRaises(InvalidChannelLayerError):
             channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
 
@@ -39,7 +38,6 @@ class TestChannelLayerManager(unittest.TestCase):
         If channel layer provides TEST_CONFIG, `make_test_backend` should
         return channel layer instance appropriate for testing.
         """
-
         layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
         self.assertEqual(layer.expiry, 100500)
 
@@ -64,20 +62,29 @@ class TestChannelLayerManager(unittest.TestCase):
 
 @pytest.mark.asyncio
 async def test_send_receive():
+    """
+    Test that a message sent to a channel can be received correctly.
+    """
     layer = InMemoryChannelLayer()
     message = {"type": "test.message"}
     await layer.send("test.channel", message)
     assert message == await layer.receive("test.channel")
 
+
 @pytest.mark.parametrize(
     "name, expected_error_message",
     [
-        ("a" * 101, f"Group name must be less than {BaseChannelLayer.MAX_NAME_LENGTH} characters."),  # Group name too long
+        (
+            "a" * 101,
+            f"Group name must be less than {BaseChannelLayer.MAX_NAME_LENGTH} "
+            "characters.",
+        ),  # Group name too long
     ],
 )
 def test_group_name_length_error_message(name, expected_error_message):
     """
-    Ensure the correct error message is raised when group names exceed the character limit.
+    Ensure the correct error message is raised when group names
+    exceed the character limit.
     """
     layer = BaseChannelLayer()
 


### PR DESCRIPTION

### **PR Description:**

**Closes #1350**

#### **Deliverables:**
- Adds logging for errors encountered in the `handle()` function.
- Ensures graceful shutdown of the connection in the event of an error.

#### **Changes:**
- **Error Handling in `handle()`**:
  - Added a try-except block to catch exceptions during the `handle()` function execution.
  - Logs the error with a detailed traceback using `logger.error()`.
  - Sends a `500 Internal Server Error` response using `self.send_response()` when an error occurs.

  ```python
  except Exception:
      logger.error(f"Error in handle(): {traceback.format_exc()}")
      await self.send_response(500, b"Internal Server Error")
      raise
  ```

- **Graceful Shutdown**:
  - Ensured that after sending the error response, the connection is gracefully terminated using `self.send_response()`.

- **Improved Error Handling in `http_disconnect()`**:
  - Added robust error handling during the disconnect phase to ensure proper cleanup and termination of the connection.

