### PR TITLE
Added fallbacks for old valid channel/group name checks.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,8 +1,8 @@
 Full release notes, with more details and upgrade information, are available at:
 https://channels.readthedocs.io/en/latest/releases
 
-UNRELEASED
-----------
+4.2.2 (2025-03-30)
+------------------
 
 * Added fallbacks for old valid channel/group name checks.
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,14 @@
 Full release notes, with more details and upgrade information, are available at:
 https://channels.readthedocs.io/en/latest/releases
 
+UNRELEASED
+----------
+
+* Added fallbacks for old valid channel/group name checks.
+
+  These were renamed in 4.2.1 but (as internal methods) without deprecation.
+  They are restored (and deprecated) here to allow updating channel layers
+  using them.
 
 4.2.1 (2025-03-29)
 ------------------

--- a/channels/__init__.py
+++ b/channels/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.2.1"
+__version__ = "4.2.2"
 
 
 DEFAULT_CHANNEL_LAYER = "default"

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -4,6 +4,7 @@ import random
 import re
 import string
 import time
+import warnings
 from copy import deepcopy
 
 from django.conf import settings
@@ -204,6 +205,29 @@ class BaseChannelLayer:
 
     async def group_send(self, group, message):
         raise NotImplementedError("group_send() not implemented (groups extension)")
+
+    # Deprecated methods.
+    def valid_channel_name(self, channel_name, receive=False):
+        """
+        Deprecated: Use require_valid_channel_name instead.
+        """
+        warnings.warn(
+            "valid_channel_name is deprecated, use require_valid_channel_name instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.require_valid_channel_name(channel_name)
+
+    def valid_group_name(self, group_name):
+        """
+        Deprecated: Use require_valid_group_name instead..
+        """
+        warnings.warn(
+            "valid_group_name is deprecated, use require_valid_group_name instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.require_valid_group_name(group_name)
 
 
 class InMemoryChannelLayer(BaseChannelLayer):

--- a/docs/releases/4.2.1.txt
+++ b/docs/releases/4.2.1.txt
@@ -1,7 +1,7 @@
 4.2.1 Release Notes
 ===================
 
-Channels 4.2.1 is a bugfix release in the 4.1 series.
+Channels 4.2.1 is a bugfix release in the 4.2 series.
 
 Bugfixes & Small Changes
 ------------------------

--- a/docs/releases/4.2.2.rst
+++ b/docs/releases/4.2.2.rst
@@ -1,0 +1,13 @@
+4.2.2 Release Notes
+===================
+
+Channels 4.2.2 is a bugfix release in the 4.2 series.
+
+Bugfixes & Small Changes
+------------------------
+
+* Added fallbacks for old valid channel/group name checks.
+
+  These (internal) methods were renamed in v4.2.1 without deprecation. This
+  release adds (deprecated) fallback aliases to allow time for channel layers
+  to update.

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -4,6 +4,7 @@ Release Notes
 .. toctree::
    :maxdepth: 1
 
+   4.2.2
    4.2.1
    4.2.0
    4.1.0

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -123,3 +123,37 @@ def test_channel_name_length_error_message(name):
 
     with pytest.raises(TypeError, match=expected_error_message):
         layer.require_valid_channel_name(name)
+
+
+def test_deprecated_valid_channel_name():
+    """
+    Test that the deprecated valid_channel_name method works
+    but raises a deprecation warning.
+    """
+    layer = BaseChannelLayer()
+
+    # Should work with valid name but raise warning
+    with pytest.warns(DeprecationWarning, match="valid_channel_name is deprecated"):
+        assert layer.valid_channel_name("valid-channel")
+
+    # Should raise TypeError for invalid names
+    with pytest.warns(DeprecationWarning):
+        with pytest.raises(TypeError):
+            layer.valid_channel_name("¯\\_(ツ)_/¯")
+
+
+def test_deprecated_valid_group_name():
+    """
+    Test that the deprecated valid_group_name method works
+    but raises a deprecation warning.
+    """
+    layer = BaseChannelLayer()
+
+    # Should work with valid name but raise warning
+    with pytest.warns(DeprecationWarning, match="valid_group_name is deprecated"):
+        assert layer.valid_group_name("valid-group")
+
+    # Should raise TypeError for invalid names
+    with pytest.warns(DeprecationWarning):
+        with pytest.raises(TypeError):
+            layer.valid_group_name("¯\\_(ツ)_/¯")


### PR DESCRIPTION
Internal methods are used by channel layers, so restore and deprecate in order to allow updating.

Refs #2144 