### PR TITLE
Restructured exceptions so exceptions within the backend are not hidden

### DIFF
--- a/channels/layers.py
+++ b/channels/layers.py
@@ -63,14 +63,18 @@ class ChannelLayerManager:
             )
         # Load the backend class
         try:
-            backend_class = import_string(self.configs[name]["BACKEND"])
+            backend_module = self.configs[name]["BACKEND"]
         except KeyError:
             raise InvalidChannelLayerError("No BACKEND specified for %s" % name)
-        except ImportError:
-            raise InvalidChannelLayerError(
-                "Cannot import BACKEND %r specified for %s"
-                % (self.configs[name]["BACKEND"], name)
-            )
+        else:
+            try:
+                backend_class = import_string(backend_module)
+            except ImportError:
+                raise InvalidChannelLayerError(
+                    "Cannot import BACKEND %r specified for %s"
+                    % (self.configs[name]["BACKEND"], name)
+                )
+                
         # Initialise and pass config
         return backend_class(**config)
 

--- a/channels/layers.py
+++ b/channels/layers.py
@@ -74,7 +74,7 @@ class ChannelLayerManager:
                     "Cannot import BACKEND %r specified for %s"
                     % (self.configs[name]["BACKEND"], name)
                 )
-                
+
         # Initialise and pass config
         return backend_class(**config)
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -58,6 +58,30 @@ class TestChannelLayerManager(unittest.TestCase):
             self.assertNotEqual(channel_layers.backends, {})
         self.assertEqual(channel_layers.backends, {})
 
+    @override_settings(
+        CHANNEL_LAYERS={
+            "default": {
+                "BACKEND": "tests.test_layers.BrokenBackend",
+            }
+        }
+    )
+    def test_backend_import_error_not_hidden(self):
+        """
+        Test that KeyError exceptions within the backend import are not hidden.
+        This test ensures that the PR #2146 fix works correctly.
+        """
+        # This should raise a KeyError from the backend, not an InvalidChannelLayerError
+        with self.assertRaises(KeyError):
+            channel_layers.make_backend(DEFAULT_CHANNEL_LAYER)
+
+
+# Mock backend that raises KeyError during import
+class BrokenBackend:
+    def __init__(self, **kwargs):
+        # This will be called during backend initialization
+        # and should raise a KeyError that should not be caught
+        raise KeyError("This is a deliberate KeyError from the backend")
+
 
 # In-memory layer tests
 


### PR DESCRIPTION
The current release of channels hides all `KeyError`s that can occur in backends. We should only catch the specific `KeyError` from parsing the settings, not from the import as well.

This pull request fixes that :)