### PR TITLE
doc: fix some misspellings

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -27,7 +27,7 @@ Turtles All The Way Down
 ------------------------
 
 Channels operates on the principle of "`turtles all the way down
-<https://en.wikipedia.org/wiki/Turtles_all_the_way_down>`_ " - we have
+<https://en.wikipedia.org/wiki/Turtles_all_the_way_down>`_" - we have
 a single idea of what a channels "application" is, and even the simplest of
 *consumers* (the equivalent of Django views) are an entirely valid
 :doc:`/asgi` application you can run by themselves.

--- a/docs/releases/4.2.0.rst
+++ b/docs/releases/4.2.0.rst
@@ -2,7 +2,7 @@
 ===================
 
 Channels 4.2 introduces a couple of major but backwards-compatible
-changes, including most notably enhanced async suppport and fixing
+changes, including most notably enhanced async support and fixing
 a long-standing bug where tests would try and close db connections
 and erroneously fail.
 
@@ -18,7 +18,7 @@ function has been added to easily close old database connections
 in async consumers.
 
 Warning: Channels now automatically closes connections in async
-consumers before a new connection, after recieving message (but
+consumers before a new connection, after receiving message (but
 before dispatching to consumer code), and after disconnecting.
 
 This change has been made to more closely align with Django's

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -62,7 +62,7 @@ General support request
 
 .. code-block:: text
 
-    Sorry, but we can't help out with general support requests here - the issue tracker is for reproduceable bugs and
+    Sorry, but we can't help out with general support requests here - the issue tracker is for reproducible bugs and
     concrete feature requests only! Please see our support documentation (https://channels.readthedocs.io/en/latest/support.html)
     for more information about where you can get general help.
 


### PR DESCRIPTION
I figured I left a blank space in the link url in the previous PR, so I fixed some other misspellings to have a reason to make another useful PR.