### PR TITLE
Updated asgiref dependency to v3.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ packages = find:
 include_package_data = True
 install_requires =
     Django>=4.2
-    asgiref>=3.6.0,<4
+    asgiref>=3.9.0,<4
 python_requires = >=3.8
 
 [options.extras_require]

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -142,7 +142,8 @@ async def test_websocket_application():
 @pytest.mark.asyncio
 async def test_timeout_disconnect():
     """
-    Tests that disconnect() still works after a timeout.
+    Tests that communicator.disconnect() raises after a timeout. (Application
+    is finished.)
     """
     communicator = WebsocketCommunicator(ErrorWebsocketApp(), "/testws/")
     # Test connection
@@ -153,8 +154,9 @@ async def test_timeout_disconnect():
     await communicator.send_to(text_data="hello")
     with pytest.raises(asyncio.TimeoutError):
         await communicator.receive_from()
-    # Close out
-    await communicator.disconnect()
+
+    with pytest.raises(asyncio.exceptions.CancelledError):
+        await communicator.disconnect()
 
 
 class ConnectionScopeValidator(WebsocketConsumer):


### PR DESCRIPTION
ApplicationCommunicator testing utility will now return result if application is finished when sending input. Assert CancelledError rather than allowing timeout.