### PR TITLE
Add types extra and installation docs for type checking support.

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -16,6 +16,8 @@ These projects from the community are developed on top of Channels:
 * channels-valkey_, a Django Channels channel layer that uses valkey as it's backing store.
   SimpleJWT_ middleware, such as QueryStringSimpleJWTAuthTokenMiddleware_ for WebSocket
   authentication.
+* types-channels_, type stubs for Channels from the `Python typeshed project`_.
+  These stubs provide type checking support for mypy, PyCharm, and other type checkers.
 
 If you'd like to add your project, please submit a PR with a link and brief description.
 
@@ -33,3 +35,5 @@ If you'd like to add your project, please submit a PR with a link and brief desc
 .. _channels-valkey: https://github.com/amirreza8002/channels_valkey   
 .. _SimpleJWT: https://github.com/jazzband/djangorestframework-simplejwt
 .. _QueryStringSimpleJWTAuthTokenMiddleware: https://github.com/YegorDB/django-channels-auth-token-middlewares/tree/master/tutorial/drf#querystringsimplejwtauthtokenmiddleware
+.. _types-channels: https://pypi.org/project/types-channels/
+.. _Python typeshed project: https://github.com/python/typeshed

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -69,6 +69,22 @@ take control of the ``runserver`` command. See :doc:`introduction` for more.
     or remove the offending app altogether.
 
 
+Type checking support
+---------------------
+
+If you want type checking support, you can install the type stubs:
+
+.. code-block:: sh
+
+    python -m pip install types-channels
+
+Or install channels with type support using the ``types`` extra:
+
+.. code-block:: sh
+
+    python -m pip install 'channels[types]'
+
+
 Installing the latest development version
 -----------------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,8 @@ tests =
     pytest-asyncio
 daphne =
     daphne>=4.0.0
+types =
+    types-channels
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
  ## Summary
  - Add `types` extra to setup.cfg for installing types-channels package
  - Add "Type checking support" section to installation.rst with installation instructions
  - Add types-channels reference to community.rst as a typeshed community project

Fix #2171