### PR TITLE
GitHub Actions: Test on Python 3.14 release candidate 2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,14 +19,16 @@ jobs:
         - "3.11"
         - "3.12"
         - "3.13"
+        - "3.14"
 
     steps:
       - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Set up Chrome
         uses: browser-actions/setup-chrome@v2
@@ -40,8 +42,7 @@ jobs:
           python -m pip install --upgrade tox
 
       - name: Run tox targets for ${{ matrix.python-version }}
-        run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d .)
-
+        run: tox run -e py
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -49,7 +50,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
Python v3.14 -- October 7th
* https://www.python.org/download/pre-releases
* https://www.python.org/downloads/release/python-3140rc2
* https://code.djangoproject.com/ticket/35844
> Django 5.2 will be the first version to support Python 3.14

GitHub Actions with tox:
* https://docs.github.com/en/actions/tutorials/build-and-test-code/python#running-tests-with-tox