### PR TITLE
Adds router resolver 404 exception

### DIFF
--- a/channels/exceptions.py
+++ b/channels/exceptions.py
@@ -1,3 +1,6 @@
+from django.urls import Resolver404
+
+
 class RequestAborted(Exception):
     """
     Raised when the incoming request tells us it's aborted partway through
@@ -60,6 +63,15 @@ class MessageTooLarge(Exception):
 class StopConsumer(Exception):
     """
     Raised when a consumer wants to stop and close down its application instance.
+    """
+
+    pass
+
+
+class RouterResolver404(Resolver404, ValueError):
+    """
+    Raised when a router cannot resolve a path.
+    Backwards compatible, in future ValueError will be deprecated in favor of Resolver404
     """
 
     pass

--- a/channels/routing.py
+++ b/channels/routing.py
@@ -5,6 +5,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.urls.exceptions import Resolver404
 from django.urls.resolvers import RegexPattern, RoutePattern, URLResolver
 
+from channels.exceptions import RouterResolver404
+
 """
 All Routing instances inside this file are also valid ASGI applications - with
 new Channels routing, whatever you end up with as the top level object is just
@@ -99,7 +101,7 @@ class URLRouter:
             root_path = scope.get("root_path", "")
             if root_path and not path.startswith(root_path):
                 # If root_path is present, path must start with it.
-                raise ValueError("No route found for path %r." % path)
+                raise RouterResolver404("No route found for path %r." % path)
             path = path[len(root_path) :]
 
         # Remove leading / to match Django's handling
@@ -127,13 +129,13 @@ class URLRouter:
                         receive,
                         send,
                     )
-            except Resolver404:
+            except RouterResolver404:
                 pass
         else:
             if "path_remaining" in scope:
-                raise Resolver404("No route found for path %r." % path)
+                raise RouterResolver404("No route found for path %r." % path)
             # We are the outermost URLRouter
-            raise ValueError("No route found for path %r." % path)
+            raise RouterResolver404("No route found for path %r." % path)
 
 
 class ChannelNameRouter:


### PR DESCRIPTION
Motivation:
- Hard breaking in channels on non existent routes (because of bots/scanners) makes a lot of noise in logs analytics.

Contents:
- Add Django Resolver404 to unmatched routes
- ValueErrors will remain for misconfigurations and route not found exceptions become explicit
- Adds `RouterResolver404` as an abstraction over Django's `Resolver404`
- Keeps old `ValueError` exceptions handlers working for backwards compatibility

https://github.com/django/channels/issues/2147

