### PR TITLE
Update Daphne docs, removing references to WhiteNoise

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,11 +62,9 @@ take control of the ``runserver`` command. See :doc:`introduction` for more.
 
     Please be wary of any other third-party apps that require an overloaded or
     replacement ``runserver`` command. Daphne provides a separate
-    ``runserver`` command and may conflict with it. An example
-    of such a conflict is with `whitenoise.runserver_nostatic <https://github.com/evansd/whitenoise/issues/77>`_
-    from `whitenoise <https://github.com/evansd/whitenoise>`_. In order to
-    solve such issues, make sure ``daphne`` is at the top of your ``INSTALLED_APPS``
-    or remove the offending app altogether.
+    ``runserver`` command and may conflict with it. In order to solve such
+    issues, make sure ``daphne`` is at the top of your ``INSTALLED_APPS`` or
+    remove the offending app altogether.
 
 
 Type checking support


### PR DESCRIPTION
As of [WhiteNoise 4.0](https://whitenoise.readthedocs.io/en/latest/changelog.html#id27) (released 2018-08-10), WhiteNoise supports running with Daphne. See [the fix in WhiteNoise](https://github.com/evansd/whitenoise/commit/ce74438f4de7e35aa922bf76e2159768708c6667) and [the original issue](https://github.com/evansd/whitenoise/issues/77).