### PR TITLE
Fix selenium test flakiness

### DIFF
--- a/tests/sample_project/sampleapp/static/sampleapp/js/scripts.js
+++ b/tests/sample_project/sampleapp/static/sampleapp/js/scripts.js
@@ -12,6 +12,7 @@
     const socket = new WebSocket(wsPath);
 
     window.websocketConnected = false;
+    window.messageHandled = false;
 
     socket.onopen = () => {
       window.websocketConnected = true;
@@ -27,6 +28,7 @@
   function handleMessage(e) {
     const data = JSON.parse(e.data);
     renderState(data.count, data.messages);
+    window.messageHandled = true;
   }
 
   function renderState(count, messages) {

--- a/tests/sample_project/tests/selenium_mixin.py
+++ b/tests/sample_project/tests/selenium_mixin.py
@@ -141,6 +141,21 @@ class SeleniumMixin:
                 f"Timed out waiting for window.websocketConnected after {timeout}s"
             )
 
+    def wait_for_websocket_message_handled(self, timeout=5):
+        """
+        Wait until window.messageHandled is true, or fail after timeout.
+        """
+        try:
+            WebDriverWait(self.web_driver, timeout).until(
+                lambda d: d.execute_script("return window.messageHandled === true")
+            )
+        except TimeoutException:
+            logs = self.get_browser_logs()
+            print("\n Browser logs on WS-flag timeout:")
+            for entry in logs:
+                print(f"[{entry['level']}] {entry['message']}")
+            self.fail(f"Timed out waiting for window.messageHandled after {timeout}s")
+
     def tearDown(self):
         logs = self.web_driver.get_log("browser")
         severe_logs = [entry for entry in logs if entry.get("level") == "SEVERE"]

--- a/tests/sample_project/tests/test_selenium.py
+++ b/tests/sample_project/tests/test_selenium.py
@@ -13,6 +13,9 @@ class TestSampleApp(SeleniumMixin, ChannelsLiveServerTestCase):
     def setUp(self):
         super().setUp()
         self.login()
+        self.open_admin_message_page()
+
+    def open_admin_message_page(self):
         self.open("/admin/sampleapp/message/")
         self.wait_for_websocket_connection()
 
@@ -29,7 +32,7 @@ class TestSampleApp(SeleniumMixin, ChannelsLiveServerTestCase):
         tabs = self.web_driver.window_handles
         self.web_driver.switch_to.window(tabs[1])
 
-        self.open("/admin/sampleapp/message/")
+        self.open_admin_message_page()
         titleInput = self.find_element(By.ID, "msgTitle")
         self.assertIsNotNone(titleInput, "Title input should be present")
         messageInput = self.find_element(By.ID, "msgTextArea")
@@ -52,6 +55,7 @@ class TestSampleApp(SeleniumMixin, ChannelsLiveServerTestCase):
     def test_real_time_delete_message(self):
         self._create_message()
         self.web_driver.refresh()
+        self.wait_for_websocket_message_handled()
 
         messageCount = self.find_element(By.ID, "messageCount")
         self.assertIsNotNone(messageCount, "Message count should be present")
@@ -61,7 +65,7 @@ class TestSampleApp(SeleniumMixin, ChannelsLiveServerTestCase):
         tabs = self.web_driver.window_handles
         self.web_driver.switch_to.window(tabs[1])
 
-        self.open("/admin/sampleapp/message/")
+        self.open_admin_message_page()
         deleteButton = self.find_element(By.ID, "deleteBtn")
         self.assertIsNotNone(deleteButton, "Delete button should be present")
         deleteButton.click()


### PR DESCRIPTION
Currently:
1. Django renders the `<strong>Total messages:</strong> <span id="messageCount">0</span>`
2. Test `test_real_time_delete_message` creates a new message and hits page refresh
3. Test refreshes the page but doesnt wait for message to be handled, so renderState is not able to update the counter
4. Test finds the existing count element and asserts that count 0 is not expected 1.

PR changes:
- explicitly wait on `window.messageHandled` in js to be sure that renderState has finished.

Removes flakiness on fast machine.