### PR TITLE
Add Chanx to Community Projects

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -6,6 +6,9 @@ These projects from the community are developed on top of Channels:
 * Beatserver_, a periodic task scheduler for Django Channels.
 * EventStream_, a library to push data using the Server-Sent Events (SSE) protocol.
 * DjangoChannelsRestFramework_, a framework that provides DRF-like consumers for Channels.
+* Chanx_, a batteries-included WebSocket framework providing automatic message routing, Pydantic validation,
+  type safety, AsyncAPI documentation generation, and comprehensive testing utilities for Django Channels,
+  FastAPI, and ASGI applications.
 * ChannelsMultiplexer_, a JsonConsumer Multiplexer for Channels.
 * DjangoChannelsIRC_, an interface server and matching generic consumers for IRC.
 * Apollo_, a real-time polling application for corporate and academic environments.
@@ -24,6 +27,7 @@ If you'd like to add your project, please submit a PR with a link and brief desc
 .. _Beatserver: https://github.com/rajasimon/beatserver
 .. _EventStream: https://github.com/fanout/django-eventstream
 .. _DjangoChannelsRestFramework: https://github.com/hishnash/djangochannelsrestframework
+.. _Chanx: https://github.com/huynguyengl99/chanx
 .. _ChannelsMultiplexer: https://github.com/hishnash/channelsmultiplexer
 .. _DjangoChannelsIRC: https://github.com/AdvocatesInc/django-channels-irc
 .. _Apollo: https://github.com/maliesa96/apollo
@@ -32,7 +36,7 @@ If you'd like to add your project, please submit a PR with a link and brief desc
 .. _kafka-integration: https://gist.github.com/aryan340/da071d027050cfe0a03df3b500f2f44b
 .. _channels_postgres: https://github.com/danidee10/channels_postgres
 .. _channels-auth-token-middlewares: https://github.com/YegorDB/django-channels-auth-token-middlewares
-.. _channels-valkey: https://github.com/amirreza8002/channels_valkey   
+.. _channels-valkey: https://github.com/amirreza8002/channels_valkey
 .. _SimpleJWT: https://github.com/jazzband/djangorestframework-simplejwt
 .. _QueryStringSimpleJWTAuthTokenMiddleware: https://github.com/YegorDB/django-channels-auth-token-middlewares/tree/master/tutorial/drf#querystringsimplejwtauthtokenmiddleware
 .. _types-channels: https://pypi.org/project/types-channels/


### PR DESCRIPTION
Close #2205.

Hi django-channels team!

I'd like to add **Chanx** to the Community Projects list.

### What is Chanx?

Chanx is a batteries-included WebSocket framework built on top of Django Channels that eliminates common pain points in WebSocket development:

**Key Features:**
- **Decorator-based routing** - No more manual if-else chains for message routing
- **Automatic validation** - Pydantic models with full type safety (mypy/pyright support)
- **Auto-generated AsyncAPI 3.0 docs** - Interactive documentation from code
- **Enhanced testing utilities** - Completion signals and simplified WebSocket testing
- **Multi-framework support** - Works with Django Channels, FastAPI, and any ASGI framework

### What It Extends

Chanx builds on Django Channels' foundation by providing:
1. **Automatic message routing** using Pydantic discriminated unions
2. **Type-safe message handling** with static type checking support
3. **Comprehensive testing tools** with enhanced WebsocketCommunicator
4. **AsyncAPI documentation generation** for better API contracts
5. **Event broadcasting utilities** to trigger WebSocket messages from anywhere (views, tasks, scripts)

### Links
- **Repository**: https://github.com/huynguyengl99/chanx
- **Documentation**: https://chanx.readthedocs.io/
- **PyPI**: https://pypi.org/project/chanx/

The project has comprehensive documentation, test coverage, and is actively maintained.

Thank you for considering this addition!
