### PR TITLE
Set cooldown in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
from [docs]( https://docs.zizmor.sh/audits/#dependabot-cooldown) :
> Detects missing or insufficient cooldown settings in Dependabot configuration files.
   By default, Dependabot does not perform any "cooldown" on dependency updates. In other words, a regularly scheduled Dependabot run may perform an update on a dependency that was just released moments before the run began. This presents both stability and supply-chain security risks

