### PR TITLE
Add missing newline in manage.py for black 26 compatibility

### DIFF
--- a/tests/sample_project/manage.py
+++ b/tests/sample_project/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 


### PR DESCRIPTION
I noticed the CI was red, and it was red because Black is unpined in tox settings, and since there has been a new year - 2026 -, Black updated its yearly syntax.
I just made this quick change, but:
1. Linters version should be pinned
2. I don't think code in `test/sample_projects` should turn CI red.

3 - bonus: The whole linting stuff, which goes through tox, it's very old-fashioned. I don't think the linting should go through tox anymore. If I get a core maintainer greenlight, I could just replicate here what django does in its main repo.