### PR TITLE
Drop support for Django 4.2 and python 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.9"
         - "3.10"
         - "3.11"
         - "3.12"

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,14 +16,12 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
     Programming Language :: Python :: 3.14
     Framework :: Django
-    Framework :: Django :: 4.2
     Framework :: Django :: 5.1
     Framework :: Django :: 5.2
     Framework :: Django :: 6.0
@@ -33,7 +31,7 @@ classifiers =
 packages = find:
 include_package_data = True
 install_requires =
-    Django>=4.2
+    Django>=5.0
     asgiref>=3.9.0,<4
 python_requires = >=3.9
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py{39,310,311}-dj42
     py{310,311,312,313}-dj51
     py{310,311,312,313,314}-dj52
     py{312,313,314}-dj60
@@ -12,7 +11,6 @@ extras = tests, daphne
 commands =
     pytest -v {posargs}
 deps =
-    dj42: Django>=4.2,<5.0
     dj51: Django>=5.1,<5.2
     dj52: Django>=5.2,<6.0
     dj60: Django>=6.0rc1,<6.1


### PR DESCRIPTION
check [here](https://docs.djangoproject.com/en/6.0/faq/install/#what-python-version-can-i-use-with-django:~:text=For%20example%2C%20Python%203%2E9%20security%20support%20ends%20in%20October%202025%20and%20Django%204%2E2%20LTS%20security%20support%20ends%20in%20April%202026%2E%20Therefore%20Django%204%2E2%20is%20the%20last%20version%20to%20support%20Python%203%2E9)