### PR TITLE
Fix orphaned in-memory channel cleanup

### DIFF
--- a/channels/layers.py
+++ b/channels/layers.py
@@ -332,14 +332,20 @@ class InMemoryChannelLayer(BaseChannelLayer):
                     self.channels.pop(channel, None)
 
         # Group Expiration
+        expired_channels = set()
         timeout = int(time.time()) - self.group_expiry
-        for channels in self.groups.values():
+        for group, channels in list(self.groups.items()):
             for name, timestamp in list(channels.items()):
                 # If join time is older than group_expiry
                 # end the group membership
                 if timestamp and timestamp < timeout:
                     # Delete from group
                     channels.pop(name, None)
+                    expired_channels.add(name)
+            if not channels:
+                self.groups.pop(group, None)
+        for channel in expired_channels:
+            self._remove_empty_channel(channel)
 
     # Flush extension
 
@@ -357,6 +363,26 @@ class InMemoryChannelLayer(BaseChannelLayer):
         """
         for channels in self.groups.values():
             channels.pop(channel, None)
+
+    def _channel_is_in_group(self, channel):
+        """
+        Checks if a channel remains in any group.
+        """
+        return any(channel in channels for channels in self.groups.values())
+
+    def _remove_empty_channel(self, channel):
+        """
+        Removes an empty channel if it is no longer in any group and no receiver
+        is currently waiting on it.
+        """
+        queue = self.channels.get(channel)
+        if (
+            queue is not None
+            and queue.empty()
+            and not queue._getters
+            and not self._channel_is_in_group(channel)
+        ):
+            self.channels.pop(channel, None)
 
     # Groups extension
 
@@ -383,6 +409,7 @@ class InMemoryChannelLayer(BaseChannelLayer):
             # is group now empty? If yes remove it
             if not group_channels:
                 self.groups.pop(group, None)
+            self._remove_empty_channel(channel)
 
     async def group_send(self, group, message):
         # Check types

--- a/tests/test_inmemorychannel.py
+++ b/tests/test_inmemorychannel.py
@@ -118,6 +118,55 @@ async def test_groups_basic(channel_layer):
 
 
 @pytest.mark.asyncio
+async def test_group_discard_removes_empty_orphaned_channel(channel_layer):
+    """
+    Tests that group_discard cleans up empty channel queues that are no longer
+    reachable through any group.
+    """
+    await channel_layer.group_add("test-group", "test-gr-chan-1")
+    channel_layer.channels["test-gr-chan-1"] = asyncio.Queue()
+
+    await channel_layer.group_discard("test-group", "test-gr-chan-1")
+
+    assert "test-gr-chan-1" not in channel_layer.channels
+
+
+@pytest.mark.asyncio
+async def test_group_discard_preserves_waiting_receiver(channel_layer):
+    """
+    Tests that group_discard does not remove an empty channel queue that still
+    has a pending receiver.
+    """
+    receive_task = asyncio.create_task(channel_layer.receive("test-gr-chan-1"))
+    await asyncio.sleep(0)
+
+    await channel_layer.group_add("test-group", "test-gr-chan-1")
+    await channel_layer.group_discard("test-group", "test-gr-chan-1")
+
+    assert "test-gr-chan-1" in channel_layer.channels
+
+    await channel_layer.send("test-gr-chan-1", {"type": "message.1"})
+    assert (await receive_task)["type"] == "message.1"
+    assert "test-gr-chan-1" not in channel_layer.channels
+
+
+@pytest.mark.asyncio
+async def test_group_expiry_removes_empty_orphaned_channel(channel_layer):
+    """
+    Tests that group expiry cleans up empty channel queues that are no longer
+    reachable through any group.
+    """
+    await channel_layer.group_add("test-group", "test-gr-chan-1")
+    channel_layer.channels["test-gr-chan-1"] = asyncio.Queue()
+    channel_layer.groups["test-group"]["test-gr-chan-1"] = 1
+
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+
+    assert "test-group" not in channel_layer.groups
+    assert "test-gr-chan-1" not in channel_layer.channels
+
+
+@pytest.mark.asyncio
 async def test_groups_channel_full(channel_layer):
     """
     Tests that group_send ignores ChannelFull


### PR DESCRIPTION
Summary:
- remove empty in-memory channel queues after group discard once they are no longer reachable through any group
- clean up empty groups and their empty orphaned channel queues during group expiry
- preserve empty queues that still have a pending receiver

Fixes #933

Tests:
- .venv/bin/python -m pytest tests/test_inmemorychannel.py -q
- .venv/bin/python -m pytest -q --ignore=tests/sample_project/tests/test_selenium.py
- .venv/bin/python -m pytest tests/sample_project/tests/test_selenium.py -q
- .venv/bin/python -m black --check channels tests
- .venv/bin/python -m isort --check-only --diff channels tests
- .venv/bin/python -m flake8 channels tests
- git diff --check