### PR TITLE
Add test support for Python 3.15

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
         - "3.12"
         - "3.13"
         - "3.14"
+        - "3.15"
 
     steps:
       - uses: actions/checkout@v6

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
     Programming Language :: Python :: 3.14
+    Programming Language :: Python :: 3.15
     Framework :: Django
     Framework :: Django :: 5.2
     Framework :: Django :: 6.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
+requires =
+    tox>=4.32
 envlist =
-    py{310,311,312,313,314}-dj52
-    py{312,313,314}-dj60
-    py{312,313,314}-dj61
-    py{312,313,314}-djmain
+    py{310-314}-dj52
+    py{312-314}-dj60
+    py{312-315}-dj61
+    py{312-315}-djmain
     qa
 
 [testenv]


### PR DESCRIPTION
Follow on from https://github.com/django/channels/pull/2225.

The Python 3.15 beta is out. 🚀 

The 3.15 release manager (👋 hi, that's me!) [said](https://discuss.python.org/t/python-3-15-0-beta-3-is-here/107866):


> We ***strongly encourage*** maintainers of third-party Python projects to ***test with 3.15*** during the beta phase and report issues found to [the Python bug tracker](https://github.com/python/cpython/issues) as soon as possible. While the release is planned to be feature-complete entering the beta phase, it is possible that features may be modified or, in rare cases, removed up until the start of the release candidate phase (2026-08-04). Our goal is to have ***no ABI changes*** after beta 4 and as few code changes as possible after the first release candidate. To achieve that, it will be ***extremely important*** to get as much exposure for 3.15 as possible during the beta phase.
> 
> This includes creating pre-release wheels for 3.15, as it helps other projects to do their own testing. However, we recommend that your regular production releases wait until 3.15.0rc1, to avoid the risk of ABI breaks.

---

btw this repo tests Python 3.10 as the minimum (tox + GHA) and as the min Trove classifier, but also still has `python_requires = >=3.9`. Intentional, or also bump this to 3.10?
